### PR TITLE
Adding import/export support for single-file CSV

### DIFF
--- a/app/src/main/java/com/coincollection/CollectionListInfo.java
+++ b/app/src/main/java/com/coincollection/CollectionListInfo.java
@@ -20,6 +20,9 @@
 
 package com.coincollection;
 
+import static com.coincollection.CollectionPage.SIMPLE_DISPLAY;
+import static com.coincollection.ExportImportHelper.JSON_COIN_LIST;
+
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.util.JsonReader;
@@ -53,9 +56,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-
-import static com.coincollection.CollectionPage.SIMPLE_DISPLAY;
-import static com.coincollection.ExportImportHelper.JSON_COIN_LIST;
 
 /**
  * Object used to represent each collection in the various list of collections
@@ -435,7 +435,7 @@ public class CollectionListInfo implements Parcelable {
      * @param dbAdapter database adapter
      * @return string array with collection data
      */
-    public String[] getLegacyCsvExportProperties(DatabaseAdapter dbAdapter) {
+    public String[] getCsvExportProperties(DatabaseAdapter dbAdapter) {
 
         // NOTE For display, don't use item.getDisplayType bc I don't
         // think we populate that value except when importing...
@@ -515,6 +515,7 @@ public class CollectionListInfo implements Parcelable {
     /**
      * Create a collection list info from imported JSON file
      * @param reader JsonReader to read from
+     * @param coinList List of coins with collection populated
      * @throws IOException if an error occurred
      */
     public CollectionListInfo(JsonReader reader, ArrayList<CoinSlot> coinList) throws IOException {

--- a/app/src/main/java/com/coincollection/MainActivity.java
+++ b/app/src/main/java/com/coincollection/MainActivity.java
@@ -88,6 +88,7 @@ public class MainActivity extends BaseActivity {
     // Used for the Update Database functionality
     private boolean mIsImportingCollection = false;
     private boolean mImportExportLegacyCsv = false;
+    private boolean mExportSingleFileCsv = false;
     private Uri mImportExportFileUri = null;
 
     // App permission requests
@@ -243,7 +244,7 @@ public class MainActivity extends BaseActivity {
                             promptCsvOrJsonImport();
                             break;
                         case EXPORT_COLLECTIONS:
-                            launchExportTask();
+                            promptCsvOrJsonExport();
                             break;
                         case REORDER_COLLECTIONS:
                             launchReorderFragment();
@@ -377,20 +378,17 @@ public class MainActivity extends BaseActivity {
                 if (mImportExportLegacyCsv) {
                     return helper.importCollectionsFromLegacyCSV(getLegacyExportFolderName());
                 } else {
-                    InputStream inputStream = null;
-                    try {
-                        inputStream = getContentResolver().openInputStream(mImportExportFileUri);
-                        return helper.importCollectionsFromJson(inputStream);
+                    try (InputStream inputStream = getContentResolver().openInputStream(mImportExportFileUri)) {
+                        String fileName = getFileNameFromUri(mImportExportFileUri);
+                        if (fileName.endsWith(".csv")) {
+                            return helper.importCollectionsFromSingleCSV(inputStream);
+                        } else {
+                            return helper.importCollectionsFromJson(inputStream);
+                        }
                     } catch (FileNotFoundException e) {
                         return mRes.getString(R.string.error_importing, e.getMessage());
-                    } finally {
-                        if (inputStream != null) {
-                            try {
-                                inputStream.close();
-                            } catch (IOException ignored) {
-                                // Can't close the stream for some reason (shouldn't happen - ignore)
-                            }
-                        }
+                    } catch (IOException e) {
+                        return mRes.getString(R.string.error_importing, e.getMessage());
                     }
                 }
             }
@@ -399,21 +397,17 @@ public class MainActivity extends BaseActivity {
                 if (mImportExportLegacyCsv) {
                     return helper.exportCollectionsToLegacyCSV(getLegacyExportFolderName());
                 } else {
-                    OutputStream outputStream = null;
-                    try {
-                        outputStream = getContentResolver().openOutputStream(mImportExportFileUri);
-                        return helper.exportCollectionsToJson(outputStream,
-                                getFileNameFromUri(mImportExportFileUri));
-                    } catch (FileNotFoundException e) {
-                        return mRes.getString(R.string.error_importing, e.getMessage());
-                    } finally {
-                        if (outputStream != null) {
-                            try {
-                                outputStream.close();
-                            } catch (IOException ignored) {
-                                // Can't close the stream for some reason (shouldn't happen - ignore)
-                            }
+                    try (OutputStream outputStream = getContentResolver().openOutputStream(mImportExportFileUri)) {
+                        String fileName = getFileNameFromUri(mImportExportFileUri);
+                        if (fileName.endsWith(".csv")) {
+                            return helper.exportCollectionsToSingleCSV(outputStream, fileName);
+                        } else {
+                            return helper.exportCollectionsToJson(outputStream, fileName);
                         }
+                    } catch (FileNotFoundException e) {
+                        return mRes.getString(R.string.error_exporting, e.getMessage());
+                    } catch (IOException e) {
+                        return mRes.getString(R.string.error_exporting, e.getMessage());
                     }
                 }
             }
@@ -509,7 +503,9 @@ public class MainActivity extends BaseActivity {
                 android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
             Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
             intent.addCategory(Intent.CATEGORY_OPENABLE);
-            intent.setType("application/json");
+            intent.setType("*/*");
+            String[] mimeTypes = {"text/comma-separated-values", "text/csv", "application/json"};
+            intent.putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes);
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 // The files should preferably be placed in the downloads folder
                 Uri pickerInitialUri = Uri.parse(Environment.DIRECTORY_DOWNLOADS);
@@ -544,13 +540,18 @@ public class MainActivity extends BaseActivity {
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            // Indicate that we're using the legacy CSV
+            // Indicate that we're not using the legacy CSV
             mImportExportLegacyCsv = false;
 
             Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
             intent.addCategory(Intent.CATEGORY_OPENABLE);
-            intent.setType("application/json");
-            intent.putExtra(Intent.EXTRA_TITLE, "coin-collection-" + getTodayDateString() + ".json");
+            if (mExportSingleFileCsv) {
+                intent.setType("text/csv");
+                intent.putExtra(Intent.EXTRA_TITLE, "coin-collection-" + getTodayDateString() + ".csv");
+            } else {
+                intent.setType("application/json");
+                intent.putExtra(Intent.EXTRA_TITLE, "coin-collection-" + getTodayDateString() + ".json");
+            }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 // The files should preferably be placed in the downloads folder
                 Uri pickerInitialUri = Uri.parse(Environment.DIRECTORY_DOWNLOADS);
@@ -1089,6 +1090,46 @@ public class MainActivity extends BaseActivity {
                                 dialog.dismiss();
                                 mImportExportLegacyCsv = false;
                                 launchImportTask();
+                                break;
+                            }
+                        }
+                    }
+                }));
+    }
+
+    /**
+     * Allow users to pick between an export file format
+     */
+    private void promptCsvOrJsonExport() {
+
+        if(mNumberOfCollections == 0){
+            Toast.makeText(mContext, mRes.getString(R.string.no_collections), Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        // Populate a menu of actions for export
+        CharSequence[] actionsList = new CharSequence[2];
+        actionsList[0] = mRes.getString(R.string.json_file);
+        actionsList[1] = mRes.getString(R.string.csv_file);
+        showAlert(newBuilder()
+                .setTitle(mRes.getString(R.string.export_format_message))
+                .setItems(actionsList, new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int item) {
+                        switch (item) {
+                            case 0: {
+                                // JSON file
+                                dialog.dismiss();
+                                mImportExportLegacyCsv = false;
+                                mExportSingleFileCsv = false;
+                                launchExportTask();
+                                break;
+                            }
+                            case 1: {
+                                // CSV file (single-file)
+                                dialog.dismiss();
+                                mImportExportLegacyCsv = false;
+                                mExportSingleFileCsv = true;
+                                launchExportTask();
                                 break;
                             }
                         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,6 +134,9 @@
     <string name="importing_collections">Importing Collections…</string>
     <string name="exporting_collections">Exporting Collections…</string>
     <string name="import_place_message">Where would you like to import from?</string>
+    <string name="export_format_message">Select an export file format:</string>
+    <string name="json_file">JSON file</string>
+    <string name="csv_file">CSV file (table format)</string>
     <string name="legacy_storage">Legacy Storage (going away)</string>
     <string name="pick_backup_file">Pick Back-Up File</string>
 


### PR DESCRIPTION
Adding import/export support for single-file CSV. Now that the app import/exports from the downloads directory, it's better to have all contents in a single file instead of multiple files.  JSON is already a single file but some users reported that they like CSV better to be able to edit in Excel or similar programs.