### PR TITLE
Initial support for coin edit menu and copying

### DIFF
--- a/app/src/main/java/com/coincollection/BaseActivity.java
+++ b/app/src/main/java/com/coincollection/BaseActivity.java
@@ -291,8 +291,9 @@ public class BaseActivity extends AppCompatActivity implements AsyncProgressInte
      * Create a help dialog to show the user how to do something
      * @param helpStrKey key uniquely identifying this boolean key
      * @param helpStrId Help message to display
+     * @return true if the help dialog was displayed, otherwise false
      */
-    public void createAndShowHelpDialog (final String helpStrKey, int helpStrId){
+    public boolean createAndShowHelpDialog (final String helpStrKey, int helpStrId){
         final SharedPreferences mainPreferences = this.getSharedPreferences(MainApplication.PREFS, MODE_PRIVATE);
         final Resources res = this.getResources();
         if(mainPreferences.getBoolean(helpStrKey, true)){
@@ -305,34 +306,9 @@ public class BaseActivity extends AppCompatActivity implements AsyncProgressInte
                         editor.putBoolean(helpStrKey, false);
                         editor.apply();
                     }));
+            return true;
         }
-    }
-
-    /**
-     * Show an alert that changes aren't saved before changing views
-     */
-    public void showUnsavedChangesAlertViewChange(Resources res) {
-        showAlert(newBuilder()
-                .setMessage(res.getString(R.string.dialog_unsaved_changes_change_views))
-                .setCancelable(false)
-                .setPositiveButton(res.getString(R.string.okay), (dialog, id) -> {
-                    // Nothing to do, just a warning
-                    dialog.dismiss();
-                }));
-    }
-
-    /**
-     * Show an alert that changes aren't saved before exiting activity
-     */
-    public void showUnsavedChangesAlertAndExitActivity(){
-        showAlert(newBuilder()
-                .setMessage(mRes.getString(R.string.dialog_unsaved_changes_exit))
-                .setCancelable(false)
-                .setPositiveButton(mRes.getString(R.string.okay), (dialog, id) -> {
-                    dialog.dismiss();
-                    finish();
-                })
-                .setNegativeButton(mRes.getString(R.string.cancel), (dialog, id) -> dialog.cancel()));
+        return false;
     }
 
     /**

--- a/app/src/main/java/com/coincollection/CoinPageCreator.java
+++ b/app/src/main/java/com/coincollection/CoinPageCreator.java
@@ -314,7 +314,7 @@ public class CoinPageCreator extends BaseActivity {
         final EditText nameEditText = findViewById(R.id.edit_enter_collection_name);
         nameEditText.setOnKeyListener(hideKeyboardListener);
         // Make a filter to block out bad characters
-        InputFilter nameFilter = getCollectionNameFilter();
+        InputFilter nameFilter = getCollectionOrCoinNameFilter();
         nameEditText.setFilters(new InputFilter[]{nameFilter});
         // Set the name if editing an existing collection
         if (mExistingCollection != null && savedInstanceState == null) {
@@ -631,7 +631,7 @@ public class CoinPageCreator extends BaseActivity {
     /** Returns an input filter for sanitizing collection names
      * @return The input filter
      */
-    static InputFilter getCollectionNameFilter() {
+    static InputFilter getCollectionOrCoinNameFilter() {
         return (source, start, end, dest, dstart, dend) -> {
             for (int i = start; i < end; i++) {
                 if (source.charAt(i) == '[' || source.charAt(i) == ']') {

--- a/app/src/main/java/com/coincollection/CoinPageCreator.java
+++ b/app/src/main/java/com/coincollection/CoinPageCreator.java
@@ -874,15 +874,30 @@ public class CoinPageCreator extends BaseActivity {
             boolean hasMintMarks = (getMintMarkFlagsFromParameters(mParameters) & CollectionListInfo.SHOW_MINT_MARKS) != 0;
             ArrayList<CoinSlot> existingCoinList = mDbAdapter.getCoinList(
                     mExistingCollection.getName(), true);
+            ArrayList<CoinSlot> mergedCoinList = new ArrayList<>();
+
+            // Add any custom coins at the beginning of the list
+            while ((existingCoinList.size() != 0) && existingCoinList.get(0).isCustomCoin()) {
+                mergedCoinList.add(existingCoinList.remove(0));
+            }
+
             for (int i = 0; i < mCoinList.size(); i++) {
+                CoinSlot newCoin = mCoinList.get(i);
+                boolean foundExistingCoinMatch = false;
                 for (int j = 0; j < existingCoinList.size(); j++) {
-                    CoinSlot newCoin = mCoinList.get(i);
                     CoinSlot existingCoin = existingCoinList.get(j);
+
+                    // Skip custom coins added by the user, as those may spuriously match
+                    if (existingCoin.isCustomCoin()) {
+                        continue;
+                    }
+
                     if (!mExistingCollection.hasMintMarks() && hasMintMarks) {
                         // If going from no mint marks to having mint marks, copy the coin progress
                         // for the existing identifier into each of the coin mints selected.
                         if (newCoin.getIdentifier().equals(existingCoin.getIdentifier())) {
-                            mCoinList.set(i, existingCoin.copy(newCoin.getIdentifier(), newCoin.getMint()));
+                            foundExistingCoinMatch = true;
+                            newCoin = existingCoin.copy(newCoin.getIdentifier(), newCoin.getMint(), false);
                             break;
                         }
                     } else if (mExistingCollection.hasMintMarks() && !hasMintMarks) {
@@ -890,19 +905,45 @@ public class CoinPageCreator extends BaseActivity {
                         // coin's advanced info and merge the inCollection attribute
                         if (newCoin.getIdentifier().equals(existingCoin.getIdentifier())) {
                             existingCoin.setInCollection(existingCoin.isInCollection() || newCoin.isInCollection());
-                            mCoinList.set(i, existingCoin);
+                            existingCoin.setMint(newCoin.getMint());
+                            foundExistingCoinMatch = true;
+                            newCoin = existingCoin;
                             // No break here to allow merging across all mints
                         }
                     } else {
                         // In all other cases, copy any coins that match identifier and mint
                         if (newCoin.equals(existingCoin)) {
-                            mCoinList.set(i, existingCoin);
+                            foundExistingCoinMatch = true;
+                            newCoin = existingCoin;
                             existingCoinList.remove(j);
                             break;
                         }
                     }
                 }
+
+                if (foundExistingCoinMatch) {
+                    // When a match is found, insert any custom coins with a lower display order ahead
+                    // of the match and remove from the list
+                    for (int j = 0; j < existingCoinList.size(); j++) {
+                        CoinSlot existingCoin = existingCoinList.get(j);
+                        if (existingCoin.isCustomCoin() && existingCoin.getSortOrder() < newCoin.getSortOrder()) {
+                            mergedCoinList.add(existingCoinList.remove(j--));
+                        }
+                    }
+                }
+                mergedCoinList.add(newCoin);
             }
+
+            // Add any remaining custom coins to the end of the list
+            for (int j = 0; j < existingCoinList.size(); j++) {
+                CoinSlot existingCoin = existingCoinList.get(j);
+                if (existingCoin.isCustomCoin()) {
+                    mergedCoinList.add(existingCoin);
+                }
+            }
+
+            // Replace the coin list with the merged coin list
+            mCoinList = mergedCoinList;
         }
     }
 

--- a/app/src/main/java/com/coincollection/CoinSlot.java
+++ b/app/src/main/java/com/coincollection/CoinSlot.java
@@ -34,23 +34,20 @@ import java.io.IOException;
  */
 public class CoinSlot implements Parcelable {
 
-    // Database id
+    /** id of the row for this coin in the database **/
     private long mDatabaseId = 0;
 
-    /** mIdentifierList Contains a list of the main coin identifiers (Ex: "2009", or "Kentucky") */
+    /** Name of the coin (Ex: "2009", or "Kentucky") **/
     private String mIdentifier;
 
-    /** mMintList Contains a list of the mint marks associated with each coin, if any */
+    /** Mint mark of the coin, if any **/
     private String mMint;
 
-    // These are public so that we can reach in and grab these values to save them off
-    // We will keep track of which items need to be pushed back
-
-    // List holding whether each coin is in the collection
+    /** Whether the coin is collected or not **/
     private boolean mInCollection = false;
 
-    // Lists needed to support the advanced view
-    private boolean mIndexHasChanged = false;
+    /** Whether the advanced info has changed, and has not yet been written to the database **/
+    private boolean mAdvInfoHasChanged = false;
 
     // In the database, we store the index into the grade and quantity arrays
     // so we can use these values efficiently.  For notes, we have to store the
@@ -59,7 +56,7 @@ public class CoinSlot implements Parcelable {
     private Integer mAdvancedQuantities = 0;
     private String mAdvancedNotes = "";
 
-    // Sort order
+    /** Sort order **/
     private int mSortOrder;
 
     // Database keys
@@ -142,8 +139,8 @@ public class CoinSlot implements Parcelable {
         return mMint;
     }
 
-    void setIndexChanged(boolean changed) {
-        this.mIndexHasChanged = changed;
+    void setAdvInfoChanged(boolean changed) {
+        this.mAdvInfoHasChanged = changed;
     }
 
     public boolean isInCollection() {
@@ -158,8 +155,8 @@ public class CoinSlot implements Parcelable {
         return this.isInCollection() ? R.string.collected : R.string.missing;
     }
 
-    boolean hasIndexChanged() {
-        return mIndexHasChanged;
+    boolean hasAdvInfoChanged() {
+        return mAdvInfoHasChanged;
     }
 
     public Integer getAdvancedGrades() {
@@ -339,7 +336,7 @@ public class CoinSlot implements Parcelable {
         mIdentifier = in.readString();
         mMint = in.readString();
         mInCollection = in.readByte() != 0;
-        mIndexHasChanged = in.readByte() != 0;
+        mAdvInfoHasChanged = in.readByte() != 0;
         if (in.readByte() == 0) {
             mAdvancedGrades = null;
         } else {
@@ -377,7 +374,7 @@ public class CoinSlot implements Parcelable {
         dest.writeString(mIdentifier);
         dest.writeString(mMint);
         dest.writeByte((byte) (mInCollection ? 1 : 0));
-        dest.writeByte((byte) (mIndexHasChanged ? 1 : 0));
+        dest.writeByte((byte) (mAdvInfoHasChanged ? 1 : 0));
         if (mAdvancedGrades == null) {
             dest.writeByte((byte) 0);
         } else {

--- a/app/src/main/java/com/coincollection/CoinSlotAdapter.java
+++ b/app/src/main/java/com/coincollection/CoinSlotAdapter.java
@@ -211,7 +211,7 @@ class CoinSlotAdapter extends BaseAdapter {
                     // Update the data structure and set index changed
                     // - Changes will be committed to the database when the user presses save
                     coinSlot.setAdvancedGrades(pos);
-                    coinSlot.setIndexChanged(true);
+                    coinSlot.setAdvInfoChanged(true);
 
                     // Tell the parent page to show the unsaved changes view
                     mCollectionPageContext.showUnsavedTextView();
@@ -239,7 +239,7 @@ class CoinSlotAdapter extends BaseAdapter {
                     // Update the data structure and set index changed
                     // - Changes will be committed to the database when the user presses save
                     coinSlot.setAdvancedQuantities(pos);
-                    coinSlot.setIndexChanged(true);
+                    coinSlot.setAdvInfoChanged(true);
 
                     // Tell the parent page to show the unsaved changes view
                     mCollectionPageContext.showUnsavedTextView();
@@ -277,7 +277,7 @@ class CoinSlotAdapter extends BaseAdapter {
                 CoinSlot viewTagCoinSlot = (CoinSlot) view.getTag();
                 boolean oldValue = viewTagCoinSlot.isInCollection();
                 viewTagCoinSlot.setInCollection(!oldValue);
-                viewTagCoinSlot.setIndexChanged(true);
+                viewTagCoinSlot.setAdvInfoChanged(true);
 
                 // Notify the adapter to re-draw the view
                 CoinSlotAdapter.this.notifyDataSetChanged();
@@ -403,7 +403,7 @@ class CoinSlotAdapter extends BaseAdapter {
         // Update the data structure and set index changed
         // - Changes will be committed to the database when the user presses save
         coinSlot.setAdvancedNotes(newText);
-        coinSlot.setIndexChanged(true);
+        coinSlot.setAdvInfoChanged(true);
 
         // Tell the parent page to show the unsaved changes view
         mCollectionPageContext.showUnsavedTextView();

--- a/app/src/main/java/com/coincollection/CoinSlotAdapter.java
+++ b/app/src/main/java/com/coincollection/CoinSlotAdapter.java
@@ -50,7 +50,7 @@ class CoinSlotAdapter extends BaseAdapter {
 
     /** mContext The context of the activity we are running in (for things like Toasts that have UI
      *           components) */
-    private final Context mContext;
+    private final CollectionPage mCollectionPageContext;
     private final Resources mRes;
 
     // Information about the collections needed for the basic coin list view
@@ -61,9 +61,9 @@ class CoinSlotAdapter extends BaseAdapter {
     private final ArrayList<CoinSlot> mCoinList;
 
     private OnItemSelectedListener mGradeOnItemSelectedListener = null;
-    private ArrayAdapter<CharSequence> mGradeArrayAdapter = null;
-    private OnItemSelectedListener mQuantityOnItemSelectedListener = null;
-    private ArrayAdapter<CharSequence> mQuantityArrayAdapter = null;
+    private ArrayAdapter<CharSequence> mGradeArrayAdapter;
+    private OnItemSelectedListener mQuantityOnItemSelectedListener;
+    private ArrayAdapter<CharSequence> mQuantityArrayAdapter;
 
     // Keep track of whether we are showing the advanced view so we can do extra setup
     private final int mDisplayType;
@@ -80,18 +80,18 @@ class CoinSlotAdapter extends BaseAdapter {
      * @param collectionTypeObj The backing object in the COLLECTION_TYPE list
      * @param coinList The list of coins
      */
-    CoinSlotAdapter(Context context, String tableName, CollectionInfo collectionTypeObj, ArrayList<CoinSlot> coinList, int displayType) {
+    CoinSlotAdapter(CollectionPage context, String tableName, CollectionInfo collectionTypeObj, ArrayList<CoinSlot> coinList, int displayType) {
         // Used for State, National Park, Presidential Coins, and Native American coins
         // and Pennies, Nickels, American Innovation Dollars
         super();
-        mContext = context;
+        mCollectionPageContext = context;
         mTableName = tableName;
         mCollectionTypeObj = collectionTypeObj;
         mCoinList = coinList;
         mDisplayType = displayType;
 
-        mRes = mContext.getResources();
-        SharedPreferences mainPreferences = mContext.getSharedPreferences(MainApplication.PREFS, Context.MODE_PRIVATE);
+        mRes = mCollectionPageContext.getResources();
+        SharedPreferences mainPreferences = mCollectionPageContext.getSharedPreferences(MainApplication.PREFS, Context.MODE_PRIVATE);
         mDisplayIsLocked = mainPreferences.getBoolean(mTableName + CollectionPage.IS_LOCKED, false);
     }
 
@@ -123,13 +123,13 @@ class CoinSlotAdapter extends BaseAdapter {
     public View getView(int position, View convertView, ViewGroup parent) {
 
         View coinView = convertView;
+        final boolean coinViewWasRecycled = (coinView != null);
 
-        if (coinView == null) {  // If we couldn't get a recycled one, create a new one
-
-            LayoutInflater vi = (LayoutInflater) mContext.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        if (!coinViewWasRecycled) {
+            // If we couldn't get a recycled one, create a new one
+            LayoutInflater vi = (LayoutInflater) mCollectionPageContext.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
 
             if(mDisplayType == CollectionPage.ADVANCED_DISPLAY){
-
                 if(!mDisplayIsLocked){
                   // If the collection isn't locked, we show spinners and an EditText
                   coinView = vi.inflate(R.layout.advanced_collection_slot, parent, false);
@@ -137,7 +137,6 @@ class CoinSlotAdapter extends BaseAdapter {
                   // The collection is locked, so we just show the advanced details in TextViews
                   coinView = vi.inflate(R.layout.advanced_collection_slot_locked, parent, false);
                 }
-
             } else if(mDisplayType == CollectionPage.SIMPLE_DISPLAY){
                 coinView = vi.inflate(R.layout.coin_slot, parent, false);
             }
@@ -145,7 +144,20 @@ class CoinSlotAdapter extends BaseAdapter {
 
         // Make lint happy
         if(coinView == null){
-            return coinView;
+            return null;
+        }
+
+        // Register a callback for when the view gets detached
+        if (!coinViewWasRecycled && mDisplayType == CollectionPage.ADVANCED_DISPLAY && !mDisplayIsLocked) {
+            coinView.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener() {
+                @Override
+                public void onViewAttachedToWindow(View view) { }
+
+                @Override
+                public void onViewDetachedFromWindow(View view) {
+                    onCoinSlotAdvNotesChanged(view);
+                }
+            });
         }
 
         // Display the basic info first
@@ -156,70 +168,136 @@ class CoinSlotAdapter extends BaseAdapter {
 
         // Set the coin identifier text (Year and Mint in most cases)
         // TODO Fix this so there is no space if there is no mint
-        // This actually puts in two spaces, since mint has a space as well
         coinText.setText(mRes.getString(R.string.coin_text_template, identifier, mint));
 
         //Set this image based on whether the coin has been obtained
         ImageView coinImage = coinView.findViewById(R.id.coinImage);
+        int imageIdentifier = mCollectionTypeObj.getCoinSlotImage(coinSlot);
+        coinImage.setImageResource(imageIdentifier);
 
         // Add an accessibility string to indicate that the coin has been found or not
         String contextDesc = mRes.getString(coinSlot.isInCollectionStringRes());
         contextDesc = mRes.getString(R.string.coin_content_desc_template, identifier, mint, contextDesc);
         coinImage.setContentDescription(contextDesc);
 
-        int imageIdentifier = mCollectionTypeObj.getCoinSlotImage(coinSlot);
-        coinImage.setImageResource(imageIdentifier);
-
         // Setup the rest of the view if it is the advanced view
         if(mDisplayType == CollectionPage.ADVANCED_DISPLAY){
-            setupAdvancedView(coinView, position);
+            setupAdvancedView(coinView, position, coinViewWasRecycled);
         }
 
         return coinView;
     }
 
     /**
+     * Setup advanced view state shared by all views in the adapter
+     */
+    private void setupAdvancedSharedViews() {
+
+        // Create the adapter that will handle grade selections
+        mGradeArrayAdapter = ArrayAdapter.createFromResource(
+                mCollectionPageContext, R.array.coin_grades, android.R.layout.simple_spinner_item);
+        mGradeArrayAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+
+        // Create the listener that will handle grade selections
+        mGradeOnItemSelectedListener = new OnItemSelectedListener() {
+            public void onItemSelected(AdapterView<?> parent,
+                                       View view, int pos, long id) {
+
+                CoinSlot coinSlot = (CoinSlot) parent.getTag();
+
+                // Update the values in the lists if this is a new value
+                if(pos != coinSlot.getAdvancedGrades()){
+
+                    // Update the data structure and set index changed
+                    // - Changes will be committed to the database when the user presses save
+                    coinSlot.setAdvancedGrades(pos);
+                    coinSlot.setIndexChanged(true);
+
+                    // Tell the parent page to show the unsaved changes view
+                    mCollectionPageContext.showUnsavedTextView();
+                }
+            }
+            public void onNothingSelected(AdapterView<?> parent) {}
+
+        };
+
+        // Create the adapter that will handle quantity selections
+        mQuantityArrayAdapter = ArrayAdapter.createFromResource (
+                mCollectionPageContext, R.array.coin_quantities, android.R.layout.simple_spinner_item);
+        mQuantityArrayAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+
+        // Create the listener that will handle quantity selected
+        mQuantityOnItemSelectedListener = new OnItemSelectedListener() {
+            public void onItemSelected(AdapterView<?> parent,
+                                       View view, int pos, long id) {
+
+                CoinSlot coinSlot = (CoinSlot) parent.getTag();
+
+                // Update the values in the lists if this is a new value
+                if(pos != coinSlot.getAdvancedQuantities()){
+
+                    // Update the data structure and set index changed
+                    // - Changes will be committed to the database when the user presses save
+                    coinSlot.setAdvancedQuantities(pos);
+                    coinSlot.setIndexChanged(true);
+
+                    // Tell the parent page to show the unsaved changes view
+                    mCollectionPageContext.showUnsavedTextView();
+                }
+            }
+
+            public void onNothingSelected(AdapterView<?> parent) {}
+        };
+    }
+
+    /**
      * Handles setting up the advanced view components in the case that we should display them
      * @param coinView The view that we are setting up
      * @param position The list index of the coin that we are making the view for
+     * @param coinViewWasRecycled true if the view was recycled and is being reused
      */
-    private void setupAdvancedView(View coinView, final int position) {
+    private void setupAdvancedView(View coinView, int position, boolean coinViewWasRecycled) {
 
-        // Use this so the listeners know the position of the item in the list
-        Integer positionObj = position;
+        // Get the coin slot at the position in the list
         CoinSlot coinSlot = mCoinList.get(position);
 
+        // Set up on-click listeners for the image
         final ImageView imageView = coinView.findViewById(R.id.coinImage);
-
-        imageView.setOnClickListener(v -> {
+        imageView.setTag(coinSlot);
+        imageView.setOnClickListener(view -> {
             // Need to check whether the collection is locked
             if(mDisplayIsLocked){
                 // Collection is locked
                 String text = mRes.getString(R.string.collection_locked);
-                Toast toast = Toast.makeText(mContext, text, Toast.LENGTH_SHORT);
+                Toast toast = Toast.makeText(mCollectionPageContext, text, Toast.LENGTH_SHORT);
                 toast.show();
             } else {
-                // Collection is unlocked, update value
-                //mDbAdapter.toggleInCollection(mTableName, mIdentifierList.get(position), mMintList.get(position));
+                // Update the data structure and set index changed
+                // - Changes will be committed to the database when the user presses save
+                CoinSlot viewTagCoinSlot = (CoinSlot) view.getTag();
+                boolean oldValue = viewTagCoinSlot.isInCollection();
+                viewTagCoinSlot.setInCollection(!oldValue);
+                viewTagCoinSlot.setIndexChanged(true);
 
-                // Tie the update to the save button
-                CoinSlot coinSlot1 = CoinSlotAdapter.this.mCoinList.get(position);
-                boolean oldValue = coinSlot1.isInCollection();
-                coinSlot1.setInCollection(!oldValue);
-                coinSlot1.setIndexChanged(true);
-
+                // Notify the adapter to re-draw the view
                 CoinSlotAdapter.this.notifyDataSetChanged();
 
-                CollectionPage collectionPage = (CollectionPage) mContext;
-                collectionPage.showUnsavedTextView();
+                // Tell the parent page to show the unsaved changes view
+                mCollectionPageContext.showUnsavedTextView();
             }
+        });
+
+        // Add long-press handler for additional actions
+        imageView.setOnLongClickListener(view -> {
+            mCollectionPageContext.promptCoinSlotActions(position);
+            return true;
         });
 
         // Everything below here is specific to whether the collection is locked or not.
         // Take care of the locked case first, since it is easier.
 
         if(mDisplayIsLocked){
-
+            // Setup the locked view and return
             String[] grades = mRes.getStringArray(R.array.coin_grades);
             TextView gradeTextView = coinView.findViewById(R.id.grade_textview);
             int gradeIndex = coinSlot.getAdvancedGrades();
@@ -242,110 +320,34 @@ class CoinSlotAdapter extends BaseAdapter {
 
         // The collection is not locked, we need to set up the spinners and edittext
 
+        // Setup shared advanced view state if needed
+        if (mGradeOnItemSelectedListener == null) {
+            setupAdvancedSharedViews();
+        }
+
         // Setup the spinner that will let you select the coin grade
         Spinner gradeSelector = coinView.findViewById(R.id.grade_selector);
-        gradeSelector.setTag(positionObj);
-
-        if(mGradeArrayAdapter == null){
-            // Create the adapter that will handle spinner selections
-            mGradeArrayAdapter = ArrayAdapter.createFromResource(
-                mContext, R.array.coin_grades, android.R.layout.simple_spinner_item);
-            mGradeArrayAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        }
+        gradeSelector.setTag(coinSlot);
         gradeSelector.setAdapter(mGradeArrayAdapter);
-
-        // Put the spinner at the value we have stored for this coin
         gradeSelector.setSelection(coinSlot.getAdvancedGrades(), false);
-
-        if(mGradeOnItemSelectedListener == null){
-            mGradeOnItemSelectedListener = new OnItemSelectedListener() {
-                public void onItemSelected(AdapterView<?> parent,
-                        View view, int pos, long id) {
-
-                    int posPrim = (int) parent.getTag();
-                    CoinSlot coinSlot = CoinSlotAdapter.this.mCoinList.get(posPrim);
-
-                    // Update the values in the lists if this is a new value
-                    if(pos != coinSlot.getAdvancedGrades()){
-                        // Value has changed
-                        coinSlot.setAdvancedGrades(pos);
-                        coinSlot.setIndexChanged(true);
-
-                        // Tell the parent page to show the unsaved changes view
-                        CollectionPage collectionPage = (CollectionPage) mContext;
-                        collectionPage.showUnsavedTextView();
-                    }
-                }
-                public void onNothingSelected(AdapterView<?> parent) {}
-
-            };
-        }
         gradeSelector.setOnItemSelectedListener(mGradeOnItemSelectedListener);
 
         // Setup the spinner that will let you select the coin quantity
         Spinner quantitySelector = coinView.findViewById(R.id.quantity_selector);
-        quantitySelector.setTag(positionObj);
-
-        if(mQuantityArrayAdapter == null){
-            mQuantityArrayAdapter = ArrayAdapter.createFromResource (
-                mContext, R.array.coin_quantities, android.R.layout.simple_spinner_item);
-            mQuantityArrayAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        }
-
+        quantitySelector.setTag(coinSlot);
         quantitySelector.setAdapter(mQuantityArrayAdapter);
-
-        // Put the spinner at the value we have stored for this coin
         quantitySelector.setSelection(coinSlot.getAdvancedQuantities(), false);
-
-        if(mQuantityOnItemSelectedListener == null) {
-            mQuantityOnItemSelectedListener = new OnItemSelectedListener() {
-                public void onItemSelected(AdapterView<?> parent,
-                                           View view, int pos, long id) {
-
-                    int posPrim = (Integer) parent.getTag();
-                    CoinSlot coinSlot = CoinSlotAdapter.this.mCoinList.get(posPrim);
-
-                    // Update the values in the lists if this is a new value
-                    if(pos != coinSlot.getAdvancedQuantities()){
-                        // Value has changed
-                        coinSlot.setAdvancedQuantities(pos);
-                        coinSlot.setIndexChanged(true);
-
-                        // Tell the parent page to show the unsaved changes view
-                        CollectionPage collectionPage = (CollectionPage) mContext;
-                        collectionPage.showUnsavedTextView();
-                    }
-                }
-
-                public void onNothingSelected(AdapterView<?> parent) {}
-            };
-        }
         quantitySelector.setOnItemSelectedListener(mQuantityOnItemSelectedListener);
 
         // Setup the edit text to allow for coin notes
         EditText notesEditText = coinView.findViewById(R.id.notes_edit_text);
-
-        // Get the current tag associated with this EditText.  We use this to know whether or not
-        // this is a new EditText that doesn't have a TextWatcher yet (as opposed to a recycled
-        // EditText that does.)
-        // http://stackoverflow.com/questions/14117204
-        Object previousTag = notesEditText.getTag();
-
-        // Set the tag on this EditText
-        if(previousTag != null){
-            // If the user has their cursor in the EditText when the view is recycled, the
-            // TextWatcher may not be triggered. So force the TextWatcher to trigger by
-            // setting the EditText text to itself.
-            notesEditText.setText(notesEditText.getText());
-        }
-        notesEditText.setTag(positionObj);
+        notesEditText.setTag(coinSlot);
 
         // Set the EditText to the string previously entered by the user
         // - This will trigger the TextWatcher if recycled but the new/old values should match
-        String text = coinSlot.getAdvancedNotes();
-        notesEditText.setText(text);
-        // http://stackoverflow.com/questions/6217378/place-cursor-at-the-end-of-text-in-edittext
-        notesEditText.setSelection(text.length());
+        String advancedNotesText = coinSlot.getAdvancedNotes();
+        notesEditText.setText(advancedNotesText);
+        notesEditText.setSelection(advancedNotesText.length());
 
         // Make the hint specific for this coin's notes field
         String notes = mRes.getString(R.string.notes);
@@ -354,9 +356,10 @@ class CoinSlotAdapter extends BaseAdapter {
 
         // If the display is not locked, we also need to set up a TextWatcher so that we can know
         // when the user types into the notes field. Create one for each unique EditText
-        if(previousTag == null) {
-            final EditText textWatcherEditText = notesEditText;
-            TextWatcher notesTextWatcher = new TextWatcher() {
+        if(!coinViewWasRecycled) {
+
+            // Add the TextWatcher for this EditText
+            notesEditText.addTextChangedListener(new TextWatcher() {
                 @Override
                 public void afterTextChanged(Editable s) {}
                 @Override
@@ -372,30 +375,37 @@ class CoinSlotAdapter extends BaseAdapter {
                         return;
                     }
 
-                    // Ignore if the text matches what's already temporarily saved
-                    int posPrim = (Integer) textWatcherEditText.getTag();
-                    CoinSlot coinSlot = CoinSlotAdapter.this.mCoinList.get(posPrim);
-                    String newText = s.toString();
-                    if (coinSlot.getAdvancedNotes().equals(newText)) {
-                        //Log.e(APP_NAME, "Text equals what is currently stored, not updating");
-                        return;
-                    }
-
-                    // Change detected - Temporarily store the modified text
-                    coinSlot.setAdvancedNotes(newText);
-                    coinSlot.setIndexChanged(true);
-                    //Log.e("CoinCollection", "Text has changed: " + newText + " position: " + Integer.toString(posPrim));
-
-                    CollectionPage collectionPage = (CollectionPage) mContext;
-                    collectionPage.showUnsavedTextView();
+                    onCoinSlotAdvNotesChanged(coinView);
                 }
-            };
-            // Add the TextWatcher for this EditText
-            notesEditText.addTextChangedListener(notesTextWatcher);
+            });
         }
 
         // Make the edittext scrollable
         // TODO Get scrolling working all the way
         // notesEditText.setMovementMethod(new ScrollingMovementMethod());
+    }
+
+    /**
+     * Called when advanced view notes are changed to capture the updated value
+     * @param coinView view to update
+     */
+    private void onCoinSlotAdvNotesChanged(View coinView) {
+
+        // Ignore if the text matches what's already saved
+        EditText notesEditText = coinView.findViewById(R.id.notes_edit_text);
+        CoinSlot coinSlot = (CoinSlot) notesEditText.getTag();
+        String newText = notesEditText.getText().toString();
+
+        if (coinSlot.getAdvancedNotes().equals(newText)) {
+            return;
+        }
+
+        // Update the data structure and set index changed
+        // - Changes will be committed to the database when the user presses save
+        coinSlot.setAdvancedNotes(newText);
+        coinSlot.setIndexChanged(true);
+
+        // Tell the parent page to show the unsaved changes view
+        mCollectionPageContext.showUnsavedTextView();
     }
 }

--- a/app/src/main/java/com/coincollection/CollectionListInfo.java
+++ b/app/src/main/java/com/coincollection/CollectionListInfo.java
@@ -100,6 +100,7 @@ public class CollectionListInfo implements Parcelable {
 
     // Database tables and keys
     public final static String TBL_COLLECTION_INFO = "collection_info";
+    public final static String COL_ID = "_id";
     public final static String COL_NAME = "name";
     public final static String COL_COIN_TYPE = "coinType";
     public final static String COL_TOTAL = "total";
@@ -568,8 +569,9 @@ public class CollectionListInfo implements Parcelable {
                     // Since the coin list is stored inside of the same JSON object, we'll populate the
                     // list of coinSlot objects here as well and return those to the caller
                     reader.beginArray();
+                    int coinIndex = 0;
                     while (reader.hasNext()) {
-                        coinList.add(new CoinSlot(reader));
+                        coinList.add(new CoinSlot(reader, coinIndex++));
                     }
                     reader.endArray();
                     break;

--- a/app/src/main/java/com/coincollection/CollectionPage.java
+++ b/app/src/main/java/com/coincollection/CollectionPage.java
@@ -761,7 +761,8 @@ public class CollectionPage extends BaseActivity {
         } else {
             // Create the new coin slot
             // - copy() also sets the sort order to original + 1
-            CoinSlot newCoinSlot = coinSlot.copy(coinSlot.getIdentifier(), coinSlot.getMint());
+            // - Mark as custom coin since it wasn't added when the collection was created
+            CoinSlot newCoinSlot = coinSlot.copy(coinSlot.getIdentifier(), coinSlot.getMint(), true);
             try {
                 // Update the sort order in the database and coin list
                 mDbAdapter.updateCoinSortOrderForInsert(mCollectionName, newCoinSlot.getSortOrder());

--- a/app/src/main/java/com/coincollection/CollectionPage.java
+++ b/app/src/main/java/com/coincollection/CollectionPage.java
@@ -20,7 +20,7 @@
 
 package com.coincollection;
 
-import static com.coincollection.CoinPageCreator.getCollectionNameFilter;
+import static com.coincollection.CoinPageCreator.getCollectionOrCoinNameFilter;
 import static com.spencerpages.MainApplication.APP_NAME;
 
 import android.content.Context;
@@ -31,6 +31,7 @@ import android.text.InputFilter;
 import android.text.InputType;
 import android.util.Log;
 import android.view.KeyEvent;
+import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -41,6 +42,7 @@ import android.widget.AbsListView.OnScrollListener;
 import android.widget.EditText;
 import android.widget.GridView;
 import android.widget.ListView;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -58,7 +60,7 @@ import java.util.ArrayList;
  */
 public class CollectionPage extends BaseActivity {
     private String mCollectionName;
-    private ArrayList<CoinSlot> mCoinList;
+    public ArrayList<CoinSlot> mCoinList;
     private CoinSlotAdapter mCoinSlotAdapter;
 
     // Saved Instance State Keywords
@@ -75,6 +77,13 @@ public class CollectionPage extends BaseActivity {
     public static final int ADVANCED_DISPLAY = 1;
 
     private int mDisplayType = SIMPLE_DISPLAY;
+
+    // Action menu items
+    private final static int NUM_ACTIONS = 4;
+    private final static int ACTIONS_TOGGLE = 0;
+    private final static int ACTIONS_EDIT = 1;
+    private final static int ACTIONS_COPY = 2;
+    private final static int ACTIONS_DELETE = 3;
 
     /* Used in conjunction with the ListView in the advance view case to scroll the view to the last
      * location.  Defaults to the first item, and will be set by:
@@ -127,7 +136,12 @@ public class CollectionPage extends BaseActivity {
 
         // Tell the user they can now lock the collections
         // Check whether it is the users first time using the app
-        createAndShowHelpDialog("first_Time_screen3", R.string.tutorial_add_to_and_lock_collection);
+        boolean displayedHelp = createAndShowHelpDialog("first_Time_screen3", R.string.tutorial_add_to_and_lock_collection);
+
+        // Tell the user they can edit/copy coins now
+        if (!displayedHelp) {
+            createAndShowHelpDialog("first_Time_screen5", R.string.tutorial_edit_copy_delete_coins);
+        }
 
         // Determine whether we should show the advanced view or the basic view
         mDisplayType = mDbAdapter.fetchTableDisplay(mCollectionName);
@@ -221,30 +235,13 @@ public class CollectionPage extends BaseActivity {
 
             // Set the onClick listener that will handle changing the coin state
             gridview.setOnItemClickListener((parent, v, position, id) -> {
-                // Need to check whether the collection is locked
-                SharedPreferences mainPreferences = getSharedPreferences(MainApplication.PREFS, MODE_PRIVATE);
+                toggleCoinSlotInCollection(mCoinList.get(position));
+            });
 
-                if(mainPreferences.getBoolean(mCollectionName + IS_LOCKED, false)){
-                    // Collection is locked
-                    showLockedMessage();
-                } else {
-                    // Preference doesn't exist or Collection is unlocked
-
-                    CoinSlot coinSlot = mCoinList.get(position);
-                    try {
-                        mDbAdapter.toggleInCollection(mCollectionName, coinSlot);
-                    } catch (SQLException e) {
-                        showCancelableAlert(mRes.getString(R.string.error_updating_database));
-                    }
-
-                    // Update the mCoinSlotAdapters copy of the coins in this collection
-                    boolean oldValue = coinSlot.isInCollection();
-                    coinSlot.setInCollection(!oldValue);
-
-                    // And have the adapter redraw with this new info
-
-                    mCoinSlotAdapter.notifyDataSetChanged();
-                }
+            // Add long-press handler for additional actions
+            gridview.setOnItemLongClickListener((parent, view, position, id) -> {
+                promptCoinSlotActions(position);
+                return true;
             });
 
         } else if(mDisplayType == ADVANCED_DISPLAY){
@@ -270,6 +267,11 @@ public class CollectionPage extends BaseActivity {
                 }
             });
 
+            // Add long-press handler for additional actions
+            listview.setOnItemLongClickListener((parent, view, position, id) -> {
+                promptCoinSlotActions(position);
+                return true;
+            });
         }
     }
 
@@ -404,14 +406,11 @@ public class CollectionPage extends BaseActivity {
                 // view.  Also, at this point there are no unsaved changes
 
                 // Save the position that the user was at for convenience
-                // http://stackoverflow.com/questions/3014089/maintain-save-restore-scroll-position-when-returning-to-a-listview
                 ListView listview = findViewById(R.id.advanced_collection_page);
-                int index = listview.getFirstVisiblePosition();
-                View v = listview.getChildAt(0);
-                int top = (v == null) ? 0 : v.getTop();
+                Integer[] viewPos = getAbsListViewPosition(listview);
 
-                mCallingIntent.putExtra(VIEW_INDEX, index);
-                mCallingIntent.putExtra(VIEW_POSITION, top);
+                mCallingIntent.putExtra(VIEW_INDEX, viewPos[0]);
+                mCallingIntent.putExtra(VIEW_POSITION, viewPos[1]);
                 mCallingIntent.putExtra(COLLECTION_NAME, mCollectionName);
 
                 finish();
@@ -429,14 +428,11 @@ public class CollectionPage extends BaseActivity {
                 }
 
                 // Save the position that the user was at for convenience
-                // http://stackoverflow.com/questions/3014089/maintain-save-restore-scroll-position-when-returning-to-a-listview
                 GridView gridview = findViewById(R.id.standard_collection_page);
-                int index = gridview.getFirstVisiblePosition();
-                View v = gridview.getChildAt(0);
-                int top = (v == null) ? 0 : v.getTop();
+                Integer[] viewPos = getAbsListViewPosition(gridview);
 
-                mCallingIntent.putExtra(VIEW_INDEX, index);
-                mCallingIntent.putExtra(VIEW_POSITION, top);
+                mCallingIntent.putExtra(VIEW_INDEX, viewPos[0]);
+                mCallingIntent.putExtra(VIEW_POSITION, viewPos[1]);
                 mCallingIntent.putExtra(COLLECTION_NAME, mCollectionName);
 
                 // Restart the activity
@@ -453,7 +449,7 @@ public class CollectionPage extends BaseActivity {
 
                 if (this.doUnsavedChangesExist()) {
 
-                    showUnsavedChangesAlertViewChange(mRes);
+                    showUnsavedChangesAlertViewChange();
                     return true;
                 }
 
@@ -466,14 +462,11 @@ public class CollectionPage extends BaseActivity {
                 }
 
                 // Save the position that the user was at for convenience
-                // http://stackoverflow.com/questions/3014089/maintain-save-restore-scroll-position-when-returning-to-a-listview
                 ListView listview = findViewById(R.id.advanced_collection_page);
-                int index = listview.getFirstVisiblePosition();
-                View v = listview.getChildAt(0);
-                int top = (v == null) ? 0 : v.getTop();
+                Integer[] viewPos = getAbsListViewPosition(listview);
 
-                mCallingIntent.putExtra(VIEW_INDEX, index);
-                mCallingIntent.putExtra(VIEW_POSITION, top);
+                mCallingIntent.putExtra(VIEW_INDEX, viewPos[0]);
+                mCallingIntent.putExtra(VIEW_POSITION, viewPos[1]);
                 mCallingIntent.putExtra(COLLECTION_NAME, mCollectionName);
 
                 // Restart the activity
@@ -486,7 +479,7 @@ public class CollectionPage extends BaseActivity {
             return true;
         } else if (itemId == R.id.rename_collection) {
             // Prompt user for new name via alert dialog
-            showRenamePrompt();
+            showCollectionRenamePrompt();
             return true;
         } else if (itemId == android.R.id.home) {
             // To support having a back arrow on the page
@@ -547,14 +540,53 @@ public class CollectionPage extends BaseActivity {
     }
 
     /**
+     * Update the coin name/mint details
+     * @param coinSlot coin slot to update
+     * @param coinName new name for the coin
+     * @param coinMint new mint mark for the coin
+     */
+    public void updateCoinDetails(CoinSlot coinSlot, String coinName, String coinMint){
+
+        // Do nothing if the name/mint isn't actually changed
+        if (coinName.equals(coinSlot.getIdentifier()) && coinMint.equals(coinSlot.getMint())){
+            return;
+        }
+
+        // Update the coin in the coin list
+        try {
+            coinSlot.setIdentifier(coinName);
+            coinSlot.setMint(coinMint);
+            mDbAdapter.updateCoinNameAndMint(mCollectionName, coinSlot);
+        } catch (SQLException e){
+            showCancelableAlert(mRes.getString(R.string.error_updating_coin));
+            return;
+        }
+
+        // Update the view
+        mCoinSlotAdapter.notifyDataSetChanged();
+    }
+
+    /**
+     * Get the position that the user was at for convenience
+     * http://stackoverflow.com/questions/3014089/maintain-save-restore-scroll-position-when-returning-to-a-listview
+     * @param view to capture position from
+     */
+    private static Integer[] getAbsListViewPosition(AbsListView view) {
+        int index = view.getFirstVisiblePosition();
+        View v = view.getChildAt(0);
+        int top = (v == null) ? 0 : v.getTop();
+        return new Integer[] {index, top};
+    }
+
+    /**
      * Prompts the user to rename the collection
      */
-    private void showRenamePrompt(){
+    private void showCollectionRenamePrompt(){
         // Create a text box for the new collection name
         final EditText input = new EditText(this);
         input.setInputType(InputType.TYPE_CLASS_TEXT);
         // Make a filter to block out bad characters
-        InputFilter nameFilter = getCollectionNameFilter();
+        InputFilter nameFilter = getCollectionOrCoinNameFilter();
         input.setFilters(new InputFilter[]{nameFilter});
         input.setText(mCollectionName);
 
@@ -620,34 +652,22 @@ public class CollectionPage extends BaseActivity {
         // to save off the lists storing the uncommitted changes of coin grades,
         // coin quantities, and coin notes.  This is pretty hacked together,
         // so fix sometime, maybe
-        
-        int index;
-        int top;
-        
-        if(mDisplayType == ADVANCED_DISPLAY){
 
+        // Save off position of listview/gridview
+        Integer[] viewPos;
+        if(mDisplayType == ADVANCED_DISPLAY){
             // Finally, save off the position of the listview
             ListView listview = findViewById(R.id.advanced_collection_page);
-
-            // save index and top position
-            // http://stackoverflow.com/questions/3014089/maintain-save-restore-scroll-position-when-returning-to-a-listview
-            index = listview.getFirstVisiblePosition();
-            View v = listview.getChildAt(0);
-            top = (v == null) ? 0 : v.getTop();
-
+            viewPos = getAbsListViewPosition(listview);
         } else {
-
             GridView gridview = findViewById(R.id.standard_collection_page);
-
-            index = gridview.getFirstVisiblePosition();
-            View v = gridview.getChildAt(0);
-            top = (v == null) ? 0 : v.getTop();
+            viewPos = getAbsListViewPosition(gridview);
         }
 
         // Save off these lists that may have unsaved user data
         outState.putParcelableArrayList(COIN_LIST, mCoinList);
-        outState.putInt(VIEW_INDEX, index);
-        outState.putInt(VIEW_POSITION, top);
+        outState.putInt(VIEW_INDEX, viewPos[0]);
+        outState.putInt(VIEW_POSITION, viewPos[1]);
         outState.putString(COLLECTION_NAME, mCollectionName);
     }
 
@@ -658,5 +678,213 @@ public class CollectionPage extends BaseActivity {
         String text = mRes.getString(R.string.collection_locked);
         Toast toast = Toast.makeText(CollectionPage.this, text, Toast.LENGTH_SHORT);
         toast.show();
+    }
+
+    /**
+     * Show an alert that changes aren't saved before changing views
+     */
+    public void showUnsavedChangesAlertViewChange() {
+        showAlert(newBuilder()
+                .setMessage(mRes.getString(R.string.dialog_unsaved_changes_change_views))
+                .setCancelable(false)
+                .setPositiveButton(mRes.getString(R.string.okay), (dialog, id) -> {
+                    // Nothing to do, just a warning
+                    dialog.dismiss();
+                }));
+    }
+
+    /**
+     * Show an alert that changes aren't saved before exiting activity
+     */
+    public void showUnsavedChangesAlertAndExitActivity(){
+        showAlert(newBuilder()
+                .setMessage(mRes.getString(R.string.dialog_unsaved_changes_exit))
+                .setCancelable(false)
+                .setPositiveButton(mRes.getString(R.string.okay), (dialog, id) -> {
+                    dialog.dismiss();
+                    finish();
+                })
+                .setNegativeButton(mRes.getString(R.string.cancel), (dialog, id) -> dialog.cancel()));
+    }
+
+    /**
+     * Toggle whether a given coin slot is collected or not
+     * @param coinSlot the CoinSlot to update
+     */
+    private void toggleCoinSlotInCollection(CoinSlot coinSlot) {
+        // Need to check whether the collection is locked
+        SharedPreferences mainPreferences = getSharedPreferences(MainApplication.PREFS, MODE_PRIVATE);
+
+        if(mainPreferences.getBoolean(mCollectionName + IS_LOCKED, false)){
+            // Collection is locked
+            showLockedMessage();
+        } else {
+            // Preference doesn't exist or Collection is unlocked
+            try {
+                mDbAdapter.toggleInCollection(mCollectionName, coinSlot);
+            } catch (SQLException e) {
+                showCancelableAlert(mRes.getString(R.string.error_updating_database));
+            }
+
+            // Update the mCoinSlotAdapters copy of the coins in this collection
+            boolean oldValue = coinSlot.isInCollection();
+            coinSlot.setInCollection(!oldValue);
+
+            // And have the adapter redraw with this new info
+            mCoinSlotAdapter.notifyDataSetChanged();
+        }
+    }
+
+    /**
+     * Makes a copy of the coin slot in the collection
+     * @param coinSlot the CoinSlot to copy
+     */
+    public void copyCoinSlot(CoinSlot coinSlot, int coinListInsertIndex) {
+        // Need to check whether the collection is locked
+        SharedPreferences mainPreferences = getSharedPreferences(MainApplication.PREFS, MODE_PRIVATE);
+
+        if(mainPreferences.getBoolean(mCollectionName + IS_LOCKED, false)){
+            // Collection is locked
+            showLockedMessage();
+        } else {
+            // Create the new coin slot
+            // - copy() also sets the sort order to original + 1
+            CoinSlot newCoinSlot = coinSlot.copy(coinSlot.getIdentifier(), coinSlot.getMint());
+            try {
+                // Update the sort order in the database and coin list
+                mDbAdapter.updateCoinSortOrderForInsert(mCollectionName, newCoinSlot.getSortOrder());
+                for(CoinSlot currCoinSlot : mCoinList) {
+                    if (currCoinSlot.getSortOrder() >= newCoinSlot.getSortOrder()) {
+                        currCoinSlot.setSortOrder(currCoinSlot.getSortOrder() + 1);
+                    }
+                }
+
+                // Insert the new coin into the database
+                mDbAdapter.addCoinSlotToCollection(newCoinSlot, mCollectionName, true, mCoinList.size() + 1);
+            } catch (SQLException e) {
+                showCancelableAlert(mRes.getString(R.string.error_copying_coin));
+                return;
+            }
+
+            // Insert the new coin and update the view
+            mCoinList.add(coinListInsertIndex, newCoinSlot);
+            mCoinSlotAdapter.notifyDataSetChanged();
+        }
+    }
+
+    /**
+     * Deletes the coin slot in the collection at a given position
+     * @param position the CoinSlot index to delete
+     */
+    public void deleteCoinSlotAtPosition(int position) {
+        // Need to check whether the collection is locked
+        SharedPreferences mainPreferences = getSharedPreferences(MainApplication.PREFS, MODE_PRIVATE);
+
+        if(mainPreferences.getBoolean(mCollectionName + IS_LOCKED, false)){
+            // Collection is locked
+            showLockedMessage();
+        } else {
+            // Delete the coin from the coin list
+            CoinSlot coinSlot = mCoinList.remove(position);
+            try {
+                mDbAdapter.removeCoinSlotFromCollection(coinSlot, mCollectionName);
+            } catch (SQLException e) {
+                showCancelableAlert(mRes.getString(R.string.error_delete_coin));
+                return;
+            }
+
+            // Update the view
+            mCoinSlotAdapter.notifyDataSetChanged();
+        }
+    }
+
+    /**
+     * Prompts the user to rename the coin
+     * @param position the CoinSlot index to update
+     */
+    private void showCoinRenamePrompt(int position){
+        // Need to check whether the collection is locked
+        SharedPreferences mainPreferences = getSharedPreferences(MainApplication.PREFS, MODE_PRIVATE);
+
+        if(mainPreferences.getBoolean(mCollectionName + IS_LOCKED, false)){
+            // Collection is locked
+            showLockedMessage();
+        } else {
+            // Get coin slot at the position
+            CoinSlot coinSlot = mCoinList.get(position);
+
+            // Get inputs and set default text
+            LayoutInflater inflater = (LayoutInflater) getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+            RelativeLayout coinRenameView = (RelativeLayout) inflater.inflate(R.layout.coin_update_layout, null);
+            EditText nameInput = coinRenameView.findViewById(R.id.coin_name_edittext);
+            EditText mintInput = coinRenameView.findViewById(R.id.coin_mint_edittext);
+            nameInput.setText(coinSlot.getIdentifier());
+            mintInput.setText(coinSlot.getMint());
+
+            // Set filters to block out bad characters
+            InputFilter nameFilter = getCollectionOrCoinNameFilter();
+            nameInput.setFilters(new InputFilter[]{nameFilter});
+            mintInput.setFilters(new InputFilter[]{nameFilter});
+
+            // Build the alert dialog
+            showAlert(newBuilder()
+                    .setTitle(mRes.getString(R.string.edit_coin_info))
+                    .setView(coinRenameView)
+                    .setPositiveButton(mRes.getString(R.string.okay), (dialog, which) -> {
+                        dialog.dismiss();
+                        String newName = nameInput.getText().toString();
+                        if (newName.equals("")) {
+                            Toast.makeText(CollectionPage.this, mRes.getString(R.string.dialog_enter_coin_name), Toast.LENGTH_SHORT).show();
+                            return;
+                        }
+                        updateCoinDetails(mCoinList.get(position), newName, mintInput.getText().toString());
+                    })
+                    .setNegativeButton(mRes.getString(R.string.cancel), (dialog, which) -> dialog.cancel()));
+        }
+    }
+
+    /**
+     * Display additional actions list
+     * @param position the CoinSlot index to update
+     */
+    public void promptCoinSlotActions(int position) {
+
+        // Populate a menu of actions for the collection
+        CharSequence[] actionsList = new CharSequence[NUM_ACTIONS];
+        actionsList[ACTIONS_TOGGLE] = mRes.getString(R.string.toggle_collected);
+        actionsList[ACTIONS_EDIT] = mRes.getString(R.string.edit);
+        actionsList[ACTIONS_COPY] = mRes.getString(R.string.copy);
+        actionsList[ACTIONS_DELETE] = mRes.getString(R.string.delete);
+        final int actionPosition = position;
+        showAlert(newBuilder()
+                .setTitle(mRes.getString(R.string.coin_actions))
+                .setItems(actionsList, (dialog, item) -> {
+                    switch (item) {
+                        case ACTIONS_TOGGLE: {
+                            // Toggle collected or not
+                            dialog.dismiss();
+                            toggleCoinSlotInCollection(mCoinList.get(actionPosition));
+                            break;
+                        }
+                        case ACTIONS_EDIT: {
+                            // Launch edit view
+                            dialog.dismiss();
+                            showCoinRenamePrompt(actionPosition);
+                            break;
+                        }
+                        case ACTIONS_COPY: {
+                            // Perform copy
+                            dialog.dismiss();
+                            copyCoinSlot(mCoinList.get(actionPosition), actionPosition + 1);
+                            break;
+                        }
+                        case ACTIONS_DELETE: {
+                            // Perform delete
+                            dialog.dismiss();
+                            deleteCoinSlotAtPosition(actionPosition);
+                            break;
+                        }
+                    }
+                }));
     }
 }

--- a/app/src/main/java/com/coincollection/DatabaseAdapter.java
+++ b/app/src/main/java/com/coincollection/DatabaseAdapter.java
@@ -17,6 +17,28 @@
 
 package com.coincollection;
 
+import static com.coincollection.CoinSlot.COIN_SLOT_COIN_ID_WHERE_CLAUSE;
+import static com.coincollection.CoinSlot.COL_ADV_GRADE_INDEX;
+import static com.coincollection.CoinSlot.COL_ADV_NOTES;
+import static com.coincollection.CoinSlot.COL_ADV_QUANTITY_INDEX;
+import static com.coincollection.CoinSlot.COL_COIN_IDENTIFIER;
+import static com.coincollection.CoinSlot.COL_COIN_MINT;
+import static com.coincollection.CoinSlot.COL_COIN_ID;
+import static com.coincollection.CoinSlot.COL_IN_COLLECTION;
+import static com.coincollection.CoinSlot.COL_SORT_ORDER;
+import static com.coincollection.CollectionListInfo.COL_COIN_TYPE;
+import static com.coincollection.CollectionListInfo.COL_DISPLAY;
+import static com.coincollection.CollectionListInfo.COL_DISPLAY_ORDER;
+import static com.coincollection.CollectionListInfo.COL_END_YEAR;
+import static com.coincollection.CollectionListInfo.COL_NAME;
+import static com.coincollection.CollectionListInfo.COL_SHOW_CHECKBOXES;
+import static com.coincollection.CollectionListInfo.COL_SHOW_MINT_MARKS;
+import static com.coincollection.CollectionListInfo.COL_START_YEAR;
+import static com.coincollection.CollectionListInfo.COL_TOTAL;
+import static com.coincollection.CollectionListInfo.TBL_COLLECTION_INFO;
+import static com.coincollection.DatabaseHelper.simpleQueryForLong;
+import static com.coincollection.ExportImportHelper.LEGACY_EXPORT_COLLECTION_LIST_FILE_NAME;
+
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
@@ -31,26 +53,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
-
-import static com.coincollection.CoinSlot.COIN_SLOT_WHERE_CLAUSE;
-import static com.coincollection.CoinSlot.COL_ADV_GRADE_INDEX;
-import static com.coincollection.CoinSlot.COL_ADV_NOTES;
-import static com.coincollection.CoinSlot.COL_ADV_QUANTITY_INDEX;
-import static com.coincollection.CoinSlot.COL_COIN_IDENTIFIER;
-import static com.coincollection.CoinSlot.COL_COIN_MINT;
-import static com.coincollection.CoinSlot.COL_IN_COLLECTION;
-import static com.coincollection.CollectionListInfo.COL_COIN_TYPE;
-import static com.coincollection.CollectionListInfo.COL_DISPLAY;
-import static com.coincollection.CollectionListInfo.COL_DISPLAY_ORDER;
-import static com.coincollection.CollectionListInfo.COL_END_YEAR;
-import static com.coincollection.CollectionListInfo.COL_NAME;
-import static com.coincollection.CollectionListInfo.COL_SHOW_CHECKBOXES;
-import static com.coincollection.CollectionListInfo.COL_SHOW_MINT_MARKS;
-import static com.coincollection.CollectionListInfo.COL_START_YEAR;
-import static com.coincollection.CollectionListInfo.COL_TOTAL;
-import static com.coincollection.CollectionListInfo.TBL_COLLECTION_INFO;
-import static com.coincollection.DatabaseHelper.simpleQueryForLong;
-import static com.coincollection.ExportImportHelper.LEGACY_EXPORT_COLLECTION_LIST_FILE_NAME;
 
 /**
  * Adapter based on the Simple Notes Database Access Helper Class on the Android site.
@@ -117,10 +119,9 @@ public class DatabaseAdapter {
     // TODO Retrieving the coin information individually (and onScroll) is inefficient... We should
     // instead have one query that returns all of the info.
     public int fetchIsInCollection(String tableName, CoinSlot coinSlot) throws SQLException {
-        String sqlCmd = "SELECT " + COL_IN_COLLECTION + " FROM [" + tableName + "] WHERE " + COIN_SLOT_WHERE_CLAUSE + " LIMIT 1";
+        String sqlCmd = "SELECT " + COL_IN_COLLECTION + " FROM [" + tableName + "] WHERE " + COIN_SLOT_COIN_ID_WHERE_CLAUSE + " LIMIT 1";
         SQLiteStatement compiledStatement = mDb.compileStatement(sqlCmd);
-        compiledStatement.bindString(1, coinSlot.getIdentifier());
-        compiledStatement.bindString(2, coinSlot.getMint());
+        compiledStatement.bindString(1, String.valueOf(coinSlot.getDatabaseId()));
         int result = simpleQueryForLong(compiledStatement);
         compiledStatement.clearBindings();
         compiledStatement.close();
@@ -139,8 +140,8 @@ public class DatabaseAdapter {
         int newValue = (result + 1) % 2;
         ContentValues args = new ContentValues();
         args.put(COL_IN_COLLECTION, newValue);
-        String[] whereValues = new String[] {coinSlot.getIdentifier(), coinSlot.getMint()};
-        runSqlUpdateAndCheck(tableName, args, COIN_SLOT_WHERE_CLAUSE, whereValues);
+        String[] whereValues = new String[] {String.valueOf(coinSlot.getDatabaseId())};
+        runSqlUpdateAndCheck(tableName, args, COIN_SLOT_COIN_ID_WHERE_CLAUSE, whereValues);
     }
 
     /**
@@ -152,7 +153,7 @@ public class DatabaseAdapter {
      */
     public int fetchTableDisplay(String tableName) throws SQLException {
         // The database will only be set up this way in this case
-        String sqlCmd = "SELECT " + COL_DISPLAY + " FROM " + TBL_COLLECTION_INFO + " WHERE name=? LIMIT 1";
+        String sqlCmd = "SELECT " + COL_DISPLAY + " FROM " + TBL_COLLECTION_INFO + " WHERE " + COL_NAME + "=? LIMIT 1";
         SQLiteStatement compiledStatement = mDb.compileStatement(sqlCmd);
         compiledStatement.bindString(1, tableName);
         int result = simpleQueryForLong(compiledStatement);
@@ -201,8 +202,8 @@ public class DatabaseAdapter {
         args.put(COL_ADV_GRADE_INDEX, coinSlot.getAdvancedGrades());
         args.put(COL_ADV_QUANTITY_INDEX, coinSlot.getAdvancedQuantities());
         args.put(COL_ADV_NOTES, coinSlot.getAdvancedNotes());
-        String[] whereValues = new String[] {coinSlot.getIdentifier(), coinSlot.getMint()};
-        runSqlUpdateAndCheck(tableName, args, COIN_SLOT_WHERE_CLAUSE, whereValues);
+        String[] whereValues = new String[] {String.valueOf(coinSlot.getDatabaseId())};
+        runSqlUpdateAndCheck(tableName, args, COIN_SLOT_COIN_ID_WHERE_CLAUSE, whereValues);
     }
 
     /**
@@ -213,14 +214,15 @@ public class DatabaseAdapter {
     private void createCollectionTable(String tableName) throws SQLException {
         // v2.2.1 - Until this point all fields had '_id' created with 'autoincrement'
         // which is unnecessary for our purposes.  Removing to improve performance.
-        String sqlCmd = "CREATE TABLE [" + tableName
-        + "] (_id integer primary key,"
+        String sqlCmd = "CREATE TABLE [" + tableName + "] ("
+        + " " + COL_COIN_ID + " integer primary key,"
         + " " + COL_COIN_IDENTIFIER + " text not null,"
         + " " + COL_COIN_MINT + " text,"
         + " " + COL_IN_COLLECTION + " integer,"
         + " " + COL_ADV_GRADE_INDEX + " integer default 0,"
         + " " + COL_ADV_QUANTITY_INDEX + " integer default 0,"
-        + " " + COL_ADV_NOTES + " text default \"\");";
+        + " " + COL_ADV_NOTES + " text default \"\","
+        + " " + COL_SORT_ORDER + " integer not null);";
         mDb.execSQL(sqlCmd);
     }
 
@@ -240,14 +242,7 @@ public class DatabaseAdapter {
         // We have the list of identifiers, now set them correctly
         if (coinData != null) {
             for (CoinSlot coinSlot : coinData) {
-                ContentValues values = new ContentValues();
-                values.put(COL_COIN_IDENTIFIER, coinSlot.getIdentifier());
-                values.put(COL_COIN_MINT, coinSlot.getMint());
-                values.put(COL_IN_COLLECTION, coinSlot.isInCollectionInt());
-                values.put(COL_ADV_GRADE_INDEX, coinSlot.getAdvancedGrades());
-                values.put(COL_ADV_QUANTITY_INDEX, coinSlot.getAdvancedQuantities());
-                values.put(COL_ADV_NOTES, coinSlot.getAdvancedNotes());
-                runSqlInsert(tableName, values);
+                addCoinSlotToCollection(coinSlot, tableName, false, 0);
             }
         }
 
@@ -303,14 +298,16 @@ public class DatabaseAdapter {
 
         ArrayList<CoinSlot> coinList = new ArrayList<>();
         Cursor cursor = mDb.query("[" + tableName + "]",
-                new String[] {COL_COIN_IDENTIFIER, COL_COIN_MINT},
-                null, null, null, null, "_id");
+                new String[] {COL_COIN_ID, COL_COIN_IDENTIFIER, COL_COIN_MINT, COL_SORT_ORDER},
+                null, null, null, null, COL_SORT_ORDER);
         if (cursor.moveToFirst()){
             do {
                 coinList.add(new CoinSlot(
+                        cursor.getInt(cursor.getColumnIndex(COL_COIN_ID)),
                         cursor.getString(cursor.getColumnIndex(COL_COIN_IDENTIFIER)),
                         cursor.getString(cursor.getColumnIndex(COL_COIN_MINT)),
-                        false));
+                        false,
+                        cursor.getInt(cursor.getColumnIndex(COL_SORT_ORDER))));
             } while(cursor.moveToNext());
         }
         cursor.close();
@@ -370,6 +367,16 @@ public class DatabaseAdapter {
     }
 
     /**
+     * Get the next sort order for a new coin
+     * @param tableName the collection name to access
+     * @return The next display order to use
+     * @throws SQLException if a database error occurred
+     */
+    public int getNextCoinSortOrder(String tableName) throws SQLException {
+        return DatabaseHelper.getNextCoinSortOrder(mDb, tableName);
+    }
+
+    /**
      * Copy collection
      * @param sourceCollectionListInfo Source table info
      * @param newTableName Name of the new table to create
@@ -403,6 +410,20 @@ public class DatabaseAdapter {
     }
 
     /**
+     * Updates an existing coin's identifier and mint
+     * @param tableName the collection name
+     * @param coinSlot coin data to use for updates
+     * @throws SQLException if a database error occurs
+     */
+    public void updateCoinNameAndMint(String tableName, CoinSlot coinSlot) throws SQLException {
+        ContentValues values = new ContentValues();
+        values.put(COL_COIN_IDENTIFIER, coinSlot.getIdentifier());
+        values.put(COL_COIN_MINT, coinSlot.getMint());
+        String[] whereValues = new String[] {String.valueOf(coinSlot.getDatabaseId())};
+        runSqlUpdateAndCheck(tableName, values, COIN_SLOT_COIN_ID_WHERE_CLAUSE, whereValues);
+    }
+
+    /**
      * Update database info for an existing collection
      * @param oldTableName the original collection name
      * @param collectionListInfo new collection info
@@ -431,6 +452,69 @@ public class DatabaseAdapter {
     }
 
     /**
+     * Inserts a hole in the sort order at a given position (to accommodate a new coin being added)
+     * @param tableName table name to update
+     * @param insertSortOrder sort order where the new coin will be inserted
+     * @throws SQLException if a database error occurs
+     */
+    public void updateCoinSortOrderForInsert(String tableName, int insertSortOrder) throws SQLException {
+        mDb.execSQL("UPDATE [" + tableName + "] SET " + COL_SORT_ORDER + " = " + COL_SORT_ORDER + "+1 "
+                + "WHERE " + COL_SORT_ORDER + " >= " + insertSortOrder);
+    }
+
+    /**
+     * Add a coin slot to a collection
+     * @param coinSlot coin details to add
+     * @param tableName table name to add coin to
+     * @throws SQLException thrown if the database insert fails
+     */
+    public void addCoinSlotToCollection(CoinSlot coinSlot, String tableName, boolean updateTotal, int newCollectionSize) throws SQLException {
+        ContentValues values = new ContentValues();
+        values.put(COL_COIN_IDENTIFIER, coinSlot.getIdentifier());
+        values.put(COL_COIN_MINT, coinSlot.getMint());
+        values.put(COL_IN_COLLECTION, coinSlot.isInCollectionInt());
+        values.put(COL_ADV_GRADE_INDEX, coinSlot.getAdvancedGrades());
+        values.put(COL_ADV_QUANTITY_INDEX, coinSlot.getAdvancedQuantities());
+        values.put(COL_ADV_NOTES, coinSlot.getAdvancedNotes());
+        values.put(COL_SORT_ORDER, coinSlot.getSortOrder());
+
+        // Add coin into database and record database id in CoinSlot object
+        coinSlot.setDatabaseId(runSqlInsert(tableName, values));
+
+        // Update the collection total if needed
+        if (updateTotal) {
+            values = new ContentValues();
+            values.put(COL_TOTAL, newCollectionSize);
+            runSqlUpdateAndCheck(TBL_COLLECTION_INFO, values, COL_NAME + "=?", new String[] { tableName });
+        }
+    }
+
+    /**
+     * Deletes a coin from the collection
+     * @param coinSlot coin to delete
+     * @param tableName table name to delete from
+     * @throws SQLException if a database error occurs
+     */
+    public void removeCoinSlotFromCollection(CoinSlot coinSlot, String tableName) throws SQLException {
+        String[] whereValues = new String[] {String.valueOf(coinSlot.getDatabaseId())};
+        runSqlDeleteAndCheck(tableName, COIN_SLOT_COIN_ID_WHERE_CLAUSE, whereValues);
+        // Note: This doesn't update the sort order of all remaining coins, which means there
+        //       may be holes in the sort order after this.
+    }
+
+    /**
+     * Get the basic coin information
+     *
+     * @param tableName The name of the collection
+     * @param populateAdvInfo If true, includes advanced attributes
+     * @param useSortOrder If true, includes sort order and uses it for sorting
+     * @return CoinSlot list
+     */
+    public ArrayList<CoinSlot> getCoinList(String tableName, boolean populateAdvInfo, boolean useSortOrder) {
+        return DatabaseHelper.getCoinList(mDb, tableName, populateAdvInfo, useSortOrder);
+    }
+
+    /**
      * Get the basic coin information
      *
      * @param tableName The name of the collection
@@ -438,17 +522,17 @@ public class DatabaseAdapter {
      * @return CoinSlot list
      */
     public ArrayList<CoinSlot> getCoinList(String tableName, boolean populateAdvInfo) {
-        return DatabaseHelper.getCoinList(mDb, tableName, populateAdvInfo);
+        return DatabaseHelper.getCoinList(mDb, tableName, populateAdvInfo, true);
     }
-
     /**
      * Executes the SQL insert command and returns false if an error occurs
      * @param tableName The table to insert into
      * @param values Values to insert into the table
      * @throws SQLException if an insert error occurred
+     * @return id of row inserted into database
      */
-    void runSqlInsert(String tableName, ContentValues values) throws SQLException {
-        DatabaseHelper.runSqlInsert(mDb, tableName, values);
+    long runSqlInsert(String tableName, ContentValues values) throws SQLException {
+        return DatabaseHelper.runSqlInsert(mDb, tableName, values);
     }
 
     /**

--- a/app/src/main/java/com/coincollection/DatabaseAdapter.java
+++ b/app/src/main/java/com/coincollection/DatabaseAdapter.java
@@ -24,6 +24,7 @@ import static com.coincollection.CoinSlot.COL_ADV_QUANTITY_INDEX;
 import static com.coincollection.CoinSlot.COL_COIN_IDENTIFIER;
 import static com.coincollection.CoinSlot.COL_COIN_MINT;
 import static com.coincollection.CoinSlot.COL_COIN_ID;
+import static com.coincollection.CoinSlot.COL_CUSTOM_COIN;
 import static com.coincollection.CoinSlot.COL_IN_COLLECTION;
 import static com.coincollection.CoinSlot.COL_SORT_ORDER;
 import static com.coincollection.CollectionListInfo.COL_COIN_TYPE;
@@ -222,7 +223,8 @@ public class DatabaseAdapter {
         + " " + COL_ADV_GRADE_INDEX + " integer default 0,"
         + " " + COL_ADV_QUANTITY_INDEX + " integer default 0,"
         + " " + COL_ADV_NOTES + " text default \"\","
-        + " " + COL_SORT_ORDER + " integer not null);";
+        + " " + COL_SORT_ORDER + " integer not null,"
+        + " " + COL_CUSTOM_COIN + " integer default 0);";
         mDb.execSQL(sqlCmd);
     }
 
@@ -286,32 +288,6 @@ public class DatabaseAdapter {
      */
     public Cursor getAllCollectionNames() {
         return mDb.query(TBL_COLLECTION_INFO, new String[] {COL_NAME}, null, null, null, null, COL_DISPLAY_ORDER);
-    }
-
-    /**
-     * Get the list of identifiers for each collection
-     *
-     * @param tableName The name of the collection
-     * @return List of all coins in the collection
-     */
-    public ArrayList<CoinSlot> getAllIdentifiers(String tableName) {
-
-        ArrayList<CoinSlot> coinList = new ArrayList<>();
-        Cursor cursor = mDb.query("[" + tableName + "]",
-                new String[] {COL_COIN_ID, COL_COIN_IDENTIFIER, COL_COIN_MINT, COL_SORT_ORDER},
-                null, null, null, null, COL_SORT_ORDER);
-        if (cursor.moveToFirst()){
-            do {
-                coinList.add(new CoinSlot(
-                        cursor.getInt(cursor.getColumnIndex(COL_COIN_ID)),
-                        cursor.getString(cursor.getColumnIndex(COL_COIN_IDENTIFIER)),
-                        cursor.getString(cursor.getColumnIndex(COL_COIN_MINT)),
-                        false,
-                        cursor.getInt(cursor.getColumnIndex(COL_SORT_ORDER))));
-            } while(cursor.moveToNext());
-        }
-        cursor.close();
-        return coinList;
     }
 
     /**
@@ -477,6 +453,7 @@ public class DatabaseAdapter {
         values.put(COL_ADV_QUANTITY_INDEX, coinSlot.getAdvancedQuantities());
         values.put(COL_ADV_NOTES, coinSlot.getAdvancedNotes());
         values.put(COL_SORT_ORDER, coinSlot.getSortOrder());
+        values.put(COL_CUSTOM_COIN, coinSlot.isCustomCoinInt());
 
         // Add coin into database and record database id in CoinSlot object
         coinSlot.setDatabaseId(runSqlInsert(tableName, values));

--- a/app/src/main/java/com/coincollection/ExportImportHelper.java
+++ b/app/src/main/java/com/coincollection/ExportImportHelper.java
@@ -162,8 +162,9 @@ public class ExportImportHelper {
             ArrayList<CoinSlot> collectionContent = new ArrayList<>();
             try {
                 ArrayList<String[]> fileContents = getCsvFileContents(inputFile);
+                int coinIndex = 0;
                 for (String[] items : fileContents) {
-                    collectionContent.add(new CoinSlot(items));
+                    collectionContent.add(new CoinSlot(items, coinIndex++));
                 }
             } catch (IOException ignored) {
                 collectionErrorMessages.add(mRes.getString(R.string.error_open_file_reading, inputFile.getAbsolutePath()));
@@ -452,6 +453,7 @@ public class ExportImportHelper {
         SectionType currSectionType = SectionType.UNKNOWN;
         String[] lineValues;
         ArrayList<CoinSlot> currCoinList = new ArrayList<>();
+        int coinIndex = 0;
 
         // Tell the CSVReader to use the NULL character as the escape
         // character to effectively allow no escape characters
@@ -470,6 +472,7 @@ public class ExportImportHelper {
                 } else if ((lineValues.length == 2) && lineValues[0].equals(CSV_SEPARATOR)) {
                     // Look for CSV separators which we're using to put multiple files in a single CSV
                     currSectionType = SectionType.fromLabel(lineValues[1]);
+                    coinIndex = 0;
                     continue;
                 }
 
@@ -483,7 +486,7 @@ public class ExportImportHelper {
                         importedCollectionContents.add(currCoinList);
                         break;
                     case COIN_LIST:
-                        currCoinList.add(new CoinSlot(lineValues));
+                        currCoinList.add(new CoinSlot(lineValues, coinIndex++));
                         break;
                     default:
                         break;
@@ -527,7 +530,7 @@ public class ExportImportHelper {
 
                 csvWriter.writeNext(new String[]{CSV_SEPARATOR, SectionType.COIN_LIST.label});
                 for (CoinSlot coinSlot : coinList) {
-                    csvWriter.writeNext(coinSlot.getLegacyCsvExportProperties());
+                    csvWriter.writeNext(coinSlot.getCsvExportProperties());
                 }
             }
             return mRes.getString(R.string.success_export, filePath);

--- a/app/src/main/java/com/coincollection/MainActivity.java
+++ b/app/src/main/java/com/coincollection/MainActivity.java
@@ -590,10 +590,10 @@ public class MainActivity extends BaseActivity {
     }
 
     @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, int[] grantResults) {
-
-        if(  (grantResults.length > 0)
-          && (grantResults[0] == PackageManager.PERMISSION_GRANTED)){
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        if ((grantResults.length > 0)
+                && (grantResults[0] == PackageManager.PERMISSION_GRANTED)) {
             // Request Granted!
             switch (requestCode) {
                 case IMPORT_PERMISSIONS_REQUEST: {

--- a/app/src/main/java/com/spencerpages/collections/AmericanEagleSilverDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/AmericanEagleSilverDollars.java
@@ -74,25 +74,26 @@ public class AmericanEagleSilverDollars extends CollectionInfo {
         Integer startYear       = (Integer) parameters.get(CoinPageCreator.OPT_START_YEAR);
         Integer stopYear        = (Integer) parameters.get(CoinPageCreator.OPT_STOP_YEAR);
         Boolean showBurnished   = (Boolean) parameters.get(CoinPageCreator.OPT_CHECKBOX_2);
+        int coinIndex = 0;
 
         for(int i = startYear; i <= stopYear; i++){
 
-            coinList.add(new CoinSlot(Integer.toString(i), ""));
+            coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
 
             if(showBurnished){
                 if(i == 2006){
-                    coinList.add(new CoinSlot("2006 W Burnished", ""));
+                    coinList.add(new CoinSlot("2006 W Burnished", "", coinIndex++));
                 }
 
                 else if(i == 2007){
-                    coinList.add(new CoinSlot("2007 W Burnished", ""));
+                    coinList.add(new CoinSlot("2007 W Burnished", "", coinIndex++));
                 }
 
                 else if(i == 2008){
-                    coinList.add(new CoinSlot("2008 W Burnished", ""));
+                    coinList.add(new CoinSlot("2008 W Burnished", "", coinIndex++));
                 }
                 else if(i == 2011){
-                    coinList.add(new CoinSlot("2011 W Burnished", ""));
+                    coinList.add(new CoinSlot("2011 W Burnished", "", coinIndex++));
                 }
             }
         }

--- a/app/src/main/java/com/spencerpages/collections/AmericanInnovationDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/AmericanInnovationDollars.java
@@ -98,19 +98,20 @@ public class AmericanInnovationDollars extends CollectionInfo {
         Boolean showMintMarks   = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARKS);
         Boolean showP           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_1);
         Boolean showD           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_2);
+        int coinIndex = 0;
 
         for(Object[] coinData : COIN_IDENTIFIERS){
             String identifier = (String) coinData[0];
 
             if(showMintMarks){
                 if(showP){
-                    coinList.add(new CoinSlot(identifier, "P"));
+                    coinList.add(new CoinSlot(identifier, "P", coinIndex++));
                 }
                 if(showD){
-                    coinList.add(new CoinSlot(identifier, "D"));
+                    coinList.add(new CoinSlot(identifier, "D", coinIndex++));
                 }
             } else {
-                coinList.add(new CoinSlot(identifier, ""));
+                coinList.add(new CoinSlot(identifier, "", coinIndex++));
             }
         }
     }

--- a/app/src/main/java/com/spencerpages/collections/BarberDimes.java
+++ b/app/src/main/java/com/spencerpages/collections/BarberDimes.java
@@ -94,30 +94,31 @@ public class BarberDimes extends CollectionInfo {
         Boolean showD           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_2);
         Boolean showS           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_3);
         Boolean showO           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_4);
+        int coinIndex = 0;
 
         for(int i = startYear; i <= stopYear; i++){
 
             if(showMintMarks){
                 if(showP){
-                    coinList.add(new CoinSlot(Integer.toString(i), ""));
+                    coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
                 }
                 if(showD){
                     if( (i >= 1906 && i <= 1912) || i == 1914 ){
-                        coinList.add(new CoinSlot(Integer.toString(i), "D"));
+                        coinList.add(new CoinSlot(Integer.toString(i), "D", coinIndex++));
                     }
                 }
                 if(showS){
                     if(i != 1894){
-                        coinList.add(new CoinSlot(Integer.toString(i), "S"));
+                        coinList.add(new CoinSlot(Integer.toString(i), "S", coinIndex++));
                     }
                 }
                 if(showO){
                     if(i != 1904 && i < 1910 ){
-                        coinList.add(new CoinSlot(Integer.toString(i), "O"));
+                        coinList.add(new CoinSlot(Integer.toString(i), "O", coinIndex++));
                     }
                 }
             } else {
-                coinList.add(new CoinSlot(Integer.toString(i), ""));
+                coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
             }
         }
     }

--- a/app/src/main/java/com/spencerpages/collections/BarberHalfDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/BarberHalfDollars.java
@@ -94,27 +94,28 @@ public class BarberHalfDollars extends CollectionInfo {
         Boolean showD           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_2);
         Boolean showS           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_3);
         Boolean showO           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_4);
+        int coinIndex = 0;
 
         for(int i =startYear; i <= stopYear; i++){
             if(showMintMarks){
                 if(showP){
-                    coinList.add(new CoinSlot(Integer.toString(i), ""));
+                    coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
                 }
                 if(showD){
                     if( i >= 1906 && i != 1909 && i != 1910 && i != 1914){
-                        coinList.add(new CoinSlot(Integer.toString(i), "D"));
+                        coinList.add(new CoinSlot(Integer.toString(i), "D", coinIndex++));
                     }
                 }
                 if(showS){
-                    coinList.add(new CoinSlot(Integer.toString(i), "S"));
+                    coinList.add(new CoinSlot(Integer.toString(i), "S", coinIndex++));
                 }
                 if(showO){
                     if( i <= 1909 ){
-                        coinList.add(new CoinSlot(Integer.toString(i), "O"));
+                        coinList.add(new CoinSlot(Integer.toString(i), "O", coinIndex++));
                     }
                 }
             } else {
-                coinList.add(new CoinSlot(Integer.toString(i), ""));
+                coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
             }
         }
     }

--- a/app/src/main/java/com/spencerpages/collections/BarberQuarters.java
+++ b/app/src/main/java/com/spencerpages/collections/BarberQuarters.java
@@ -94,30 +94,31 @@ public class BarberQuarters extends CollectionInfo {
         Boolean showD           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_2);
         Boolean showS           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_3);
         Boolean showO           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_4);
+        int coinIndex = 0;
 
         for(int i = startYear; i <= stopYear; i++){
 
             if(showMintMarks){
                 if(showP){
-                    coinList.add(new CoinSlot(Integer.toString(i), ""));
+                    coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
                 }
                 if(showD){
                     if( i >= 1906 && i != 1912 ){
-                        coinList.add(new CoinSlot(Integer.toString(i), "D"));
+                        coinList.add(new CoinSlot(Integer.toString(i), "D", coinIndex++));
                     }
                 }
                 if(showS){
                     if(i != 1904 && i != 1906 && i != 1910 && i != 1916){
-                        coinList.add(new CoinSlot(Integer.toString(i), "S"));
+                        coinList.add(new CoinSlot(Integer.toString(i), "S", coinIndex++));
                     }
                 }
                 if(showO){
                     if(i <= 1909){
-                        coinList.add(new CoinSlot(Integer.toString(i), "O"));
+                        coinList.add(new CoinSlot(Integer.toString(i), "O", coinIndex++));
                     }
                 }
             } else {
-                coinList.add(new CoinSlot(Integer.toString(i), ""));
+                coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
             }
         }
     }

--- a/app/src/main/java/com/spencerpages/collections/BuffaloNickels.java
+++ b/app/src/main/java/com/spencerpages/collections/BuffaloNickels.java
@@ -88,6 +88,7 @@ public class BuffaloNickels extends CollectionInfo {
         Boolean showP           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_1);
         Boolean showD           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_2);
         Boolean showS           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_3);
+        int coinIndex = 0;
 
         for(int i = startYear; i <= stopYear; i++){
 
@@ -99,35 +100,35 @@ public class BuffaloNickels extends CollectionInfo {
                 if(showP){
                     if(i != 1931 && i != 1938){
                         if(i == 1913){
-                            coinList.add(new CoinSlot(Integer.toString(i), " Type 1"));
-                            coinList.add(new CoinSlot(Integer.toString(i), " Type 2"));
+                            coinList.add(new CoinSlot(Integer.toString(i), " Type 1", coinIndex++));
+                            coinList.add(new CoinSlot(Integer.toString(i), " Type 2", coinIndex++));
                         } else {
-                            coinList.add(new CoinSlot(Integer.toString(i), ""));
+                            coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
                         }
                     }
                 }
                 if(showD){
                     if(i != 1921 && i != 1923 && i != 1930 && i != 1931){
                         if(i == 1913){
-                            coinList.add(new CoinSlot(Integer.toString(i), " D Type 1"));
-                            coinList.add(new CoinSlot(Integer.toString(i), " D Type 2"));
+                            coinList.add(new CoinSlot(Integer.toString(i), " D Type 1", coinIndex++));
+                            coinList.add(new CoinSlot(Integer.toString(i), " D Type 2", coinIndex++));
                         } else {
-                            coinList.add(new CoinSlot(Integer.toString(i), "D"));
+                            coinList.add(new CoinSlot(Integer.toString(i), "D", coinIndex++));
                         }
                     }
                 }
                 if(showS){
                     if(i != 1934 && i != 1938){
                         if(i == 1913){
-                            coinList.add(new CoinSlot(Integer.toString(i), " S Type 1"));
-                            coinList.add(new CoinSlot(Integer.toString(i), " S Type 2"));
+                            coinList.add(new CoinSlot(Integer.toString(i), " S Type 1", coinIndex++));
+                            coinList.add(new CoinSlot(Integer.toString(i), " S Type 2", coinIndex++));
                         } else {
-                            coinList.add(new CoinSlot(Integer.toString(i), "S"));
+                            coinList.add(new CoinSlot(Integer.toString(i), "S", coinIndex++));
                         }
                     }
                 }
             } else {
-                coinList.add(new CoinSlot(Integer.toString(i), ""));
+                coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
             }
         }
     }

--- a/app/src/main/java/com/spencerpages/collections/EisenhowerDollar.java
+++ b/app/src/main/java/com/spencerpages/collections/EisenhowerDollar.java
@@ -20,20 +20,20 @@
 
 package com.spencerpages.collections;
 
+import static com.coincollection.CoinSlot.COL_COIN_IDENTIFIER;
+import static com.coincollection.CoinSlot.COL_COIN_MINT;
+import static com.coincollection.DatabaseHelper.runSqlDelete;
+
 import android.database.sqlite.SQLiteDatabase;
 
 import com.coincollection.CoinPageCreator;
 import com.coincollection.CoinSlot;
+import com.coincollection.CollectionInfo;
 import com.coincollection.CollectionListInfo;
 import com.spencerpages.R;
-import com.coincollection.CollectionInfo;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-
-import static com.coincollection.CoinSlot.COL_COIN_IDENTIFIER;
-import static com.coincollection.CoinSlot.COL_COIN_MINT;
-import static com.coincollection.DatabaseHelper.runSqlDelete;
 
 public class EisenhowerDollar extends CollectionInfo {
 
@@ -92,6 +92,7 @@ public class EisenhowerDollar extends CollectionInfo {
         Boolean showMintMarks = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARKS);
         Boolean showP = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_1);
         Boolean showD = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_2);
+        int coinIndex = 0;
 
         for (int i = startYear; i <= stopYear; i++) {
             String newValue = Integer.toString(i);
@@ -103,13 +104,13 @@ public class EisenhowerDollar extends CollectionInfo {
 
             if (showMintMarks) {
                 if (showP) {
-                    coinList.add(new CoinSlot(newValue, ""));
+                    coinList.add(new CoinSlot(newValue, "", coinIndex++));
                 }
                 if (showD) {
-                    coinList.add(new CoinSlot(newValue, "D"));
+                    coinList.add(new CoinSlot(newValue, "D", coinIndex++));
                 }
             } else {
-                coinList.add(new CoinSlot(newValue, ""));
+                coinList.add(new CoinSlot(newValue, "", coinIndex++));
             }
 
             //if(i < 1973){

--- a/app/src/main/java/com/spencerpages/collections/FirstSpouseGoldCoins.java
+++ b/app/src/main/java/com/spencerpages/collections/FirstSpouseGoldCoins.java
@@ -20,6 +20,9 @@
 
 package com.spencerpages.collections;
 
+import static com.coincollection.CoinSlot.COL_COIN_IDENTIFIER;
+import static com.coincollection.DatabaseHelper.runSqlUpdate;
+
 import android.content.ContentValues;
 import android.database.sqlite.SQLiteDatabase;
 
@@ -31,9 +34,6 @@ import com.spencerpages.R;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-
-import static com.coincollection.CoinSlot.COL_COIN_IDENTIFIER;
-import static com.coincollection.DatabaseHelper.runSqlUpdate;
 
 public class FirstSpouseGoldCoins extends CollectionInfo {
 
@@ -120,9 +120,10 @@ public class FirstSpouseGoldCoins extends CollectionInfo {
     @Override
     public void populateCollectionLists(HashMap<String, Object> parameters, ArrayList<CoinSlot> coinList) {
 
+        int coinIndex = 0;
         for (Object[] coinData : COIN_IDENTIFIERS) {
             String identifier = (String) coinData[0];
-            coinList.add(new CoinSlot(identifier, ""));
+            coinList.add(new CoinSlot(identifier, "", coinIndex++));
         }
     }
 

--- a/app/src/main/java/com/spencerpages/collections/FranklinHalfDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/FranklinHalfDollars.java
@@ -89,25 +89,26 @@ public class FranklinHalfDollars extends CollectionInfo {
         Boolean showP           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_1);
         Boolean showD           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_2);
         Boolean showS           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_3);
+        int coinIndex = 0;
 
         for(int i = startYear; i <= stopYear; i++){
 
             if(showMintMarks){
                 if(showP){
-                    coinList.add(new CoinSlot(Integer.toString(i), ""));
+                    coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
                 }
                 if(showD){
                     if( i != 1955 && i != 1956 ){
-                        coinList.add(new CoinSlot(Integer.toString(i), "D"));
+                        coinList.add(new CoinSlot(Integer.toString(i), "D", coinIndex++));
                     }
                 }
                 if(showS){
                     if(i != 1948 && i != 1950 && i <= 1954 ){
-                        coinList.add(new CoinSlot(Integer.toString(i), "S"));
+                        coinList.add(new CoinSlot(Integer.toString(i), "S", coinIndex++));
                     }
                 }
             } else {
-                coinList.add(new CoinSlot(Integer.toString(i), ""));
+                coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
             }
         }
     }

--- a/app/src/main/java/com/spencerpages/collections/IndianHeadCents.java
+++ b/app/src/main/java/com/spencerpages/collections/IndianHeadCents.java
@@ -84,6 +84,7 @@ public class IndianHeadCents extends CollectionInfo {
         Boolean showMintMarks   = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARKS);
         Boolean showP           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_1);
         Boolean showS           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_3);
+        int coinIndex = 0;
 
         for(int i = startYear; i <= stopYear; i++){
 
@@ -95,21 +96,21 @@ public class IndianHeadCents extends CollectionInfo {
                     // 1864 L
 
                     if(i == 1864){
-                        coinList.add(new CoinSlot(Integer.toString(i), " Copper"));
-                        coinList.add(new CoinSlot(Integer.toString(i), " Bronze"));
-                        coinList.add(new CoinSlot(Integer.toString(i), " L"));
+                        coinList.add(new CoinSlot(Integer.toString(i), " Copper", coinIndex++));
+                        coinList.add(new CoinSlot(Integer.toString(i), " Bronze", coinIndex++));
+                        coinList.add(new CoinSlot(Integer.toString(i), " L", coinIndex++));
                     } else {
-                        coinList.add(new CoinSlot(Integer.toString(i), ""));
+                        coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
                     }
                 }
                 if(showS){
                     if(i == 1908 || i == 1909){
-                        coinList.add(new CoinSlot(Integer.toString(i), "S"));
+                        coinList.add(new CoinSlot(Integer.toString(i), "S", coinIndex++));
                     }
                 }
 
             } else {
-                coinList.add(new CoinSlot(Integer.toString(i), ""));
+                coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
             }
         }
     }

--- a/app/src/main/java/com/spencerpages/collections/JeffersonNickels.java
+++ b/app/src/main/java/com/spencerpages/collections/JeffersonNickels.java
@@ -20,6 +20,9 @@
 
 package com.spencerpages.collections;
 
+import static com.coincollection.CoinSlot.COIN_SLOT_NAME_MINT_WHERE_CLAUSE;
+import static com.coincollection.DatabaseHelper.runSqlDelete;
+
 import android.database.sqlite.SQLiteDatabase;
 
 import com.coincollection.CoinPageCreator;
@@ -31,9 +34,6 @@ import com.spencerpages.R;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-
-import static com.coincollection.CoinSlot.COIN_SLOT_WHERE_CLAUSE;
-import static com.coincollection.DatabaseHelper.runSqlDelete;
 
 public class JeffersonNickels extends CollectionInfo {
 
@@ -119,6 +119,7 @@ public class JeffersonNickels extends CollectionInfo {
         Boolean showP           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_1);
         Boolean showD           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_2);
         Boolean showS           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_3);
+        int coinIndex = 0;
 
         for(int i = startYear; i <= stopYear; i++){
 
@@ -129,13 +130,13 @@ public class JeffersonNickels extends CollectionInfo {
 
                     if (showMintMarks) {
                         if (showP) {
-                            coinList.add(new CoinSlot(identifier, "P"));
+                            coinList.add(new CoinSlot(identifier, "P", coinIndex++));
                         }
                         if (showD) {
-                            coinList.add(new CoinSlot(identifier, "D"));
+                            coinList.add(new CoinSlot(identifier, "D", coinIndex++));
                         }
                     } else {
-                        coinList.add(new CoinSlot(identifier, ""));
+                        coinList.add(new CoinSlot(identifier, "", coinIndex++));
                     }
                 }
                 continue;
@@ -148,13 +149,13 @@ public class JeffersonNickels extends CollectionInfo {
 
                     if (showMintMarks) {
                         if (showP) {
-                            coinList.add(new CoinSlot(identifier, "P"));
+                            coinList.add(new CoinSlot(identifier, "P", coinIndex++));
                         }
                         if (showD) {
-                            coinList.add(new CoinSlot(identifier, "D"));
+                            coinList.add(new CoinSlot(identifier, "D", coinIndex++));
                         }
                     } else {
-                        coinList.add(new CoinSlot(identifier, ""));
+                        coinList.add(new CoinSlot(identifier, "", coinIndex++));
                     }
                 }
                 continue;
@@ -164,24 +165,24 @@ public class JeffersonNickels extends CollectionInfo {
                 if(showP) {
                     if (i != 1968 && i != 1969 && i != 1970) {
                         if (i >= 1980) {
-                            coinList.add(new CoinSlot(Integer.toString(i), "P"));
+                            coinList.add(new CoinSlot(Integer.toString(i), "P", coinIndex++));
                         } else {
-                            coinList.add(new CoinSlot(Integer.toString(i), ""));
+                            coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
                         }
                     }
                 }
                 if(showD){
                     if(i != 1965 && i != 1966 && i != 1967){
-                        coinList.add(new CoinSlot(Integer.toString(i), "D"));
+                        coinList.add(new CoinSlot(Integer.toString(i), "D", coinIndex++));
                     }
                 }
                 if(showS){
                     if(i <= 1970 && i != 1950 && (i < 1955 || i > 1967)){
-                        coinList.add(new CoinSlot(Integer.toString(i), "S"));
+                        coinList.add(new CoinSlot(Integer.toString(i), "S", coinIndex++));
                     }
                 }
             } else {
-                coinList.add(new CoinSlot(Integer.toString(i), ""));
+                coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
             }
         }
     }
@@ -210,11 +211,11 @@ public class JeffersonNickels extends CollectionInfo {
         if(oldVersion <= 2) {
 
             // Remove 1955s nickel
-            total -= runSqlDelete(db, tableName, COIN_SLOT_WHERE_CLAUSE, new String[]{"1955", "S"});
+            total -= runSqlDelete(db, tableName, COIN_SLOT_NAME_MINT_WHERE_CLAUSE, new String[]{"1955", "S"});
             // Remove 1965-1967 D Nickel
-            total -= runSqlDelete(db, tableName, COIN_SLOT_WHERE_CLAUSE, new String[]{"1965", "D"});
-            total -= runSqlDelete(db, tableName, COIN_SLOT_WHERE_CLAUSE, new String[]{"1966", "D"});
-            total -= runSqlDelete(db, tableName, COIN_SLOT_WHERE_CLAUSE, new String[]{"1967", "D"});
+            total -= runSqlDelete(db, tableName, COIN_SLOT_NAME_MINT_WHERE_CLAUSE, new String[]{"1965", "D"});
+            total -= runSqlDelete(db, tableName, COIN_SLOT_NAME_MINT_WHERE_CLAUSE, new String[]{"1966", "D"});
+            total -= runSqlDelete(db, tableName, COIN_SLOT_NAME_MINT_WHERE_CLAUSE, new String[]{"1967", "D"});
 
             // We can't add the new identifiers, just delete the old ones
             // TODO What should we do

--- a/app/src/main/java/com/spencerpages/collections/KennedyHalfDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/KennedyHalfDollars.java
@@ -81,6 +81,7 @@ public class KennedyHalfDollars extends CollectionInfo {
         Boolean showMintMarks   = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARKS);
         Boolean showP           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_1);
         Boolean showD           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_2);
+        int coinIndex = 0;
 
         for(int i = startYear; i <= stopYear; i++){
             String newValue = Integer.toString(i);
@@ -94,19 +95,19 @@ public class KennedyHalfDollars extends CollectionInfo {
                 if(showP){
                     if(i < 1968 || i > 1970){
                         if(i >= 1980){
-                            coinList.add(new CoinSlot(newValue, "P"));
+                            coinList.add(new CoinSlot(newValue, "P", coinIndex++));
                         } else {
-                            coinList.add(new CoinSlot(newValue, ""));
+                            coinList.add(new CoinSlot(newValue, "", coinIndex++));
                         }
                     }
                 }
                 if(showD){
                     if(i != 1965 && i != 1966 && i != 1967){
-                        coinList.add(new CoinSlot(newValue, "D"));
+                        coinList.add(new CoinSlot(newValue, "D", coinIndex++));
                     }
                 }
             } else {
-                coinList.add(new CoinSlot(newValue, ""));
+                coinList.add(new CoinSlot(newValue, "", coinIndex++));
             }
         }
     }

--- a/app/src/main/java/com/spencerpages/collections/LibertyHeadNickels.java
+++ b/app/src/main/java/com/spencerpages/collections/LibertyHeadNickels.java
@@ -89,6 +89,7 @@ public class LibertyHeadNickels extends CollectionInfo {
         Boolean showP           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_1);
         Boolean showD           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_2);
         Boolean showS           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_3);
+        int coinIndex = 0;
 
         boolean added1883WithCents = false;
         for(int i = startYear; i <= stopYear; i++){
@@ -105,18 +106,18 @@ public class LibertyHeadNickels extends CollectionInfo {
 
             if(showMintMarks){
                 if(showP){
-                    coinList.add(new CoinSlot(newValue, ""));
+                    coinList.add(new CoinSlot(newValue, "", coinIndex++));
                 }
                 if(i == 1912){
                     if(showD){
-                        coinList.add(new CoinSlot(newValue, "D"));
+                        coinList.add(new CoinSlot(newValue, "D", coinIndex++));
                     }
                     if(showS){
-                        coinList.add(new CoinSlot(newValue, "S"));
+                        coinList.add(new CoinSlot(newValue, "S", coinIndex++));
                     }
                 }
             } else {
-                coinList.add(new CoinSlot(newValue, ""));
+                coinList.add(new CoinSlot(newValue, "", coinIndex++));
             }
 
             if(i == 1883 && !added1883WithCents){

--- a/app/src/main/java/com/spencerpages/collections/LincolnCents.java
+++ b/app/src/main/java/com/spencerpages/collections/LincolnCents.java
@@ -20,6 +20,11 @@
 
 package com.spencerpages.collections;
 
+import static com.coincollection.CoinSlot.COL_COIN_MINT;
+import static com.coincollection.CoinSlot.COIN_SLOT_NAME_MINT_WHERE_CLAUSE;
+import static com.coincollection.DatabaseHelper.runSqlDelete;
+import static com.coincollection.DatabaseHelper.runSqlUpdate;
+
 import android.content.ContentValues;
 import android.database.sqlite.SQLiteDatabase;
 
@@ -32,11 +37,6 @@ import com.spencerpages.R;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-
-import static com.coincollection.CoinSlot.COIN_SLOT_WHERE_CLAUSE;
-import static com.coincollection.CoinSlot.COL_COIN_MINT;
-import static com.coincollection.DatabaseHelper.runSqlDelete;
-import static com.coincollection.DatabaseHelper.runSqlUpdate;
 
 public class LincolnCents extends CollectionInfo {
 
@@ -115,6 +115,7 @@ public class LincolnCents extends CollectionInfo {
         Boolean showP           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_1);
         Boolean showD           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_2);
         Boolean showS           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_3);
+        int coinIndex = 0;
 
         boolean addedVdb = false;
 
@@ -134,13 +135,13 @@ public class LincolnCents extends CollectionInfo {
 
                     if (showMintMarks) {
                         if (showP) {
-                            coinList.add(new CoinSlot(bicentIdentifier, ""));
+                            coinList.add(new CoinSlot(bicentIdentifier, "", coinIndex++));
                         }
                         if (showD) {
-                            coinList.add(new CoinSlot(bicentIdentifier, "D"));
+                            coinList.add(new CoinSlot(bicentIdentifier, "D", coinIndex++));
                         }
                     } else {
-                        coinList.add(new CoinSlot(bicentIdentifier, ""));
+                        coinList.add(new CoinSlot(bicentIdentifier, "", coinIndex++));
                     }
                 }
                 continue;
@@ -149,20 +150,20 @@ public class LincolnCents extends CollectionInfo {
             if(showMintMarks){
                 if(showP){
                     // The P was never on any Pennies
-                    coinList.add(new CoinSlot(newValue, ""));
+                    coinList.add(new CoinSlot(newValue, "", coinIndex++));
                 }
                 if(showD){
                     if(i != 1909 && i != 1910 && i != 1921 && i != 1923 && i != 1965 && i != 1966 && i != 1967){
-                        coinList.add(new CoinSlot(newValue, "D"));
+                        coinList.add(new CoinSlot(newValue, "D", coinIndex++));
                     }
                 }
                 if(showS){
                     if(i <= 1974 && i != 1922 && i != 1932 && i != 1933 && i != 1934 && (i < 1956 || i > 1967)){
-                        coinList.add(new CoinSlot(newValue, "S"));
+                        coinList.add(new CoinSlot(newValue, "S", coinIndex++));
                     }
                 }
             } else {
-                coinList.add(new CoinSlot(newValue, ""));
+                coinList.add(new CoinSlot(newValue, "", coinIndex++));
             }
 
             // If we are adding in the VDB, turn this off
@@ -197,7 +198,7 @@ public class LincolnCents extends CollectionInfo {
         if(oldVersion <= 2) {
 
             // Remove 1921 D Penny
-            total -= runSqlDelete(db, tableName, COIN_SLOT_WHERE_CLAUSE, new String[]{"1921", "D"});
+            total -= runSqlDelete(db, tableName, COIN_SLOT_NAME_MINT_WHERE_CLAUSE, new String[]{"1921", "D"});
 
             // TODO What should we do?
             // We can't add the new identifiers, just delete the old ones

--- a/app/src/main/java/com/spencerpages/collections/MercuryDimes.java
+++ b/app/src/main/java/com/spencerpages/collections/MercuryDimes.java
@@ -89,6 +89,7 @@ public class MercuryDimes extends CollectionInfo {
         Boolean showP           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_1);
         Boolean showD           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_2);
         Boolean showS           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_3);
+        int coinIndex = 0;
 
         for(int i = startYear; i <= stopYear; i++){
 
@@ -97,20 +98,20 @@ public class MercuryDimes extends CollectionInfo {
 
             if(showMintMarks){
                 if(showP){
-                    coinList.add(new CoinSlot(Integer.toString(i), ""));
+                    coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
                 }
                 if(showD){
                     if(i != 1923 && i != 1930){
-                        coinList.add(new CoinSlot(Integer.toString(i), "D"));
+                        coinList.add(new CoinSlot(Integer.toString(i), "D", coinIndex++));
                     }
                 }
                 if(showS){
                     if(i != 1921 && i != 1934){
-                        coinList.add(new CoinSlot(Integer.toString(i), "S"));
+                        coinList.add(new CoinSlot(Integer.toString(i), "S", coinIndex++));
                     }
                 }
             } else {
-                coinList.add(new CoinSlot(Integer.toString(i), ""));
+                coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
             }
         }
     }

--- a/app/src/main/java/com/spencerpages/collections/MorganDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/MorganDollars.java
@@ -99,6 +99,7 @@ public class MorganDollars extends CollectionInfo {
         Boolean showS           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_3);
         Boolean showO           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_4);
         Boolean showCC           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_5);
+        int coinIndex = 0;
 
         for(int i = startYear; i <= stopYear; i++){
 
@@ -109,32 +110,32 @@ public class MorganDollars extends CollectionInfo {
             if(showMintMarks){
                 if(showP){
                     if(i == 1878){
-                        coinList.add(new CoinSlot("1878 8 Feathers", ""));
-                        coinList.add(new CoinSlot("1878 7 Feathers", ""));
+                        coinList.add(new CoinSlot("1878 8 Feathers", "", coinIndex++));
+                        coinList.add(new CoinSlot("1878 7 Feathers", "", coinIndex++));
                     } else if(i != 1895){
-                        coinList.add(new CoinSlot(Integer.toString(i), ""));
+                        coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
                     }
                 }
                 if(showD){
                     if(i == 1921){
-                        coinList.add(new CoinSlot(Integer.toString(i), "D"));
+                        coinList.add(new CoinSlot(Integer.toString(i), "D", coinIndex++));
                     }
                 }
                 if(showO){
                     if(i != 1878 && i != 1921){
-                        coinList.add(new CoinSlot(Integer.toString(i), "O"));
+                        coinList.add(new CoinSlot(Integer.toString(i), "O", coinIndex++));
                     }
                 }
                 if(showCC){
                     if( i != 1886 && i != 1887 && i != 1888 && i <= 1893 ){
-                        coinList.add(new CoinSlot(Integer.toString(i), "CC"));
+                        coinList.add(new CoinSlot(Integer.toString(i), "CC", coinIndex++));
                     }
                 }
                 if(showS){
-                    coinList.add(new CoinSlot(Integer.toString(i), "S"));
+                    coinList.add(new CoinSlot(Integer.toString(i), "S", coinIndex++));
                 }
             } else {
-                coinList.add(new CoinSlot(Integer.toString(i), ""));
+                coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
             }
         }
     }

--- a/app/src/main/java/com/spencerpages/collections/NationalParkQuarters.java
+++ b/app/src/main/java/com/spencerpages/collections/NationalParkQuarters.java
@@ -20,6 +20,9 @@
 
 package com.spencerpages.collections;
 
+import static com.coincollection.CoinSlot.COL_COIN_IDENTIFIER;
+import static com.coincollection.DatabaseHelper.runSqlUpdate;
+
 import android.content.ContentValues;
 import android.database.sqlite.SQLiteDatabase;
 
@@ -32,9 +35,6 @@ import com.spencerpages.R;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-
-import static com.coincollection.CoinSlot.COL_COIN_IDENTIFIER;
-import static com.coincollection.DatabaseHelper.runSqlUpdate;
 
 public class NationalParkQuarters extends CollectionInfo {
 
@@ -150,19 +150,20 @@ public class NationalParkQuarters extends CollectionInfo {
         Boolean showMintMarks   = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARKS);
         Boolean showP           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_1);
         Boolean showD           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_2);
+        int coinIndex = 0;
 
         for (Object[] parksImageIdentifier : COIN_IDENTIFIERS) {
             String identifier = (String) parksImageIdentifier[0];
 
             if (showMintMarks) {
                 if (showP) {
-                    coinList.add(new CoinSlot(identifier, "P"));
+                    coinList.add(new CoinSlot(identifier, "P", coinIndex++));
                 }
                 if (showD) {
-                    coinList.add(new CoinSlot(identifier, "D"));
+                    coinList.add(new CoinSlot(identifier, "D", coinIndex++));
                 }
             } else {
-                coinList.add(new CoinSlot(identifier, ""));
+                coinList.add(new CoinSlot(identifier, "", coinIndex++));
             }
         }
     }

--- a/app/src/main/java/com/spencerpages/collections/NativeAmericanDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/NativeAmericanDollars.java
@@ -113,19 +113,20 @@ public class NativeAmericanDollars extends CollectionInfo {
         Boolean showMintMarks   = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARKS);
         Boolean showP           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_1);
         Boolean showD           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_2);
+        int coinIndex = 0;
 
         for(int i = startYear; i <= stopYear; i++){
 
             if(showMintMarks){
                 if(showP){
-                    coinList.add(new CoinSlot(Integer.toString(i), "P"));
+                    coinList.add(new CoinSlot(Integer.toString(i), "P", coinIndex++));
                 }
             } else {
-                coinList.add(new CoinSlot(Integer.toString(i), ""));
+                coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
             }
 
             if(showMintMarks && showD){
-                coinList.add(new CoinSlot(Integer.toString(i), "D"));
+                coinList.add(new CoinSlot(Integer.toString(i), "D", coinIndex++));
             }
         }
     }

--- a/app/src/main/java/com/spencerpages/collections/PeaceDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/PeaceDollars.java
@@ -89,6 +89,7 @@ public class PeaceDollars extends CollectionInfo {
         Boolean showP           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_1);
         Boolean showD           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_2);
         Boolean showS           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_3);
+        int coinIndex = 0;
 
         for (int i = startYear; i <= stopYear; i++) {
 
@@ -100,20 +101,20 @@ public class PeaceDollars extends CollectionInfo {
 
             if (showMintMarks) {
                 if (showP) {
-                    coinList.add(new CoinSlot(newValue, ""));
+                    coinList.add(new CoinSlot(newValue, "", coinIndex++));
                 }
                 if (showD) {
                     if (i != 1921 && i != 1924 && i != 1925 && i != 1928 && i != 1935) {
-                        coinList.add(new CoinSlot(newValue, "D"));
+                        coinList.add(new CoinSlot(newValue, "D", coinIndex++));
                     }
                 }
                 if (showS) {
                     if (i != 1921) {
-                        coinList.add(new CoinSlot(newValue, "S"));
+                        coinList.add(new CoinSlot(newValue, "S", coinIndex++));
                     }
                 }
             } else {
-                coinList.add(new CoinSlot(newValue, ""));
+                coinList.add(new CoinSlot(newValue, "", coinIndex++));
             }
         }
     }

--- a/app/src/main/java/com/spencerpages/collections/PresidentialDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/PresidentialDollars.java
@@ -133,19 +133,20 @@ public class PresidentialDollars extends CollectionInfo {
         Boolean showMintMarks   = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARKS);
         Boolean showP           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_1);
         Boolean showD           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_2);
+        int coinIndex = 0;
 
         for (Object[] coinData : COIN_IDENTIFIERS){
             String identifier = (String) coinData[0];
 
             if (showMintMarks) {
                 if (showP) {
-                    coinList.add(new CoinSlot(identifier, "P"));
+                    coinList.add(new CoinSlot(identifier, "P", coinIndex++));
                 }
                 if (showD) {
-                    coinList.add(new CoinSlot(identifier, "D"));
+                    coinList.add(new CoinSlot(identifier, "D", coinIndex++));
                 }
             } else {
-                coinList.add(new CoinSlot(identifier, ""));
+                coinList.add(new CoinSlot(identifier, "", coinIndex++));
             }
         }
     }

--- a/app/src/main/java/com/spencerpages/collections/RooseveltDimes.java
+++ b/app/src/main/java/com/spencerpages/collections/RooseveltDimes.java
@@ -86,20 +86,21 @@ public class RooseveltDimes extends CollectionInfo {
         Boolean showP           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_1);
         Boolean showD           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_2);
         Boolean showS           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_3);
+        int coinIndex = 0;
 
         for(int i = startYear; i <= stopYear; i++){
 
             if(showMintMarks){
                 if(showP){
                     if(i >= 1980){
-                        coinList.add(new CoinSlot(Integer.toString(i), "P"));
+                        coinList.add(new CoinSlot(Integer.toString(i), "P", coinIndex++));
                     } else {
-                        coinList.add(new CoinSlot(Integer.toString(i), ""));
+                        coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
                     }
                 }
                 if(showD){
                     if(i != 1965 && i != 1966 && i != 1967){
-                        coinList.add(new CoinSlot(Integer.toString(i), "D"));
+                        coinList.add(new CoinSlot(Integer.toString(i), "D", coinIndex++));
                     }
                 }
                 if(showS){
@@ -107,11 +108,11 @@ public class RooseveltDimes extends CollectionInfo {
                     // Greater than 1967 were only in proof sets
                     // TODO - Check and simplify weird logic here
                     if(i < 1975 && (i < 1956)){
-                        coinList.add(new CoinSlot(Integer.toString(i), "S"));
+                        coinList.add(new CoinSlot(Integer.toString(i), "S", coinIndex++));
                     }
                 }
             } else {
-                coinList.add(new CoinSlot(Integer.toString(i), ""));
+                coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
             }
         }
     }

--- a/app/src/main/java/com/spencerpages/collections/StandingLibertyQuarters.java
+++ b/app/src/main/java/com/spencerpages/collections/StandingLibertyQuarters.java
@@ -89,6 +89,7 @@ public class StandingLibertyQuarters extends CollectionInfo {
         Boolean showP           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_1);
         Boolean showD           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_2);
         Boolean showS           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_3);
+        int coinIndex = 0;
 
         boolean addedTypeOne = false;
 
@@ -111,20 +112,20 @@ public class StandingLibertyQuarters extends CollectionInfo {
 
             if(showMintMarks){
                 if(showP){
-                    coinList.add(new CoinSlot(newValue, ""));
+                    coinList.add(new CoinSlot(newValue, "", coinIndex++));
                 }
                 if(showD){
                     if(i != 1916 && i != 1921 && i != 1925 && i != 1923 && i != 1930){
-                        coinList.add(new CoinSlot(newValue, "D"));
+                        coinList.add(new CoinSlot(newValue, "D", coinIndex++));
                     }
                 }
                 if(showS){
                     if(i != 1916 && i != 1921 && i != 1925){
-                        coinList.add(new CoinSlot(newValue, "S"));
+                        coinList.add(new CoinSlot(newValue, "S", coinIndex++));
                     }
                 }
             } else {
-                coinList.add(new CoinSlot(newValue, ""));
+                coinList.add(new CoinSlot(newValue, "", coinIndex++));
             }
 
             if(i == 1917 && !addedTypeOne){

--- a/app/src/main/java/com/spencerpages/collections/StateQuarters.java
+++ b/app/src/main/java/com/spencerpages/collections/StateQuarters.java
@@ -159,19 +159,20 @@ public class StateQuarters extends CollectionInfo {
         Boolean showP           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_1);
         Boolean showD           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_2);
         Boolean showTerritories = (Boolean) parameters.get(CoinPageCreator.OPT_CHECKBOX_1);
+        int coinIndex = 0;
 
         for(Object[] coinData : STATES_COIN_IDENTIFIERS){
             String identifier = (String) coinData[0];
 
             if (showMintMarks) {
                 if (showP) {
-                    coinList.add(new CoinSlot(identifier, "P"));
+                    coinList.add(new CoinSlot(identifier, "P", coinIndex++));
                 }
                 if (showD) {
-                    coinList.add(new CoinSlot(identifier, "D"));
+                    coinList.add(new CoinSlot(identifier, "D", coinIndex++));
                 }
             } else {
-                coinList.add(new CoinSlot(identifier, ""));
+                coinList.add(new CoinSlot(identifier, "", coinIndex++));
             }
         }
         if(showTerritories){
@@ -181,13 +182,13 @@ public class StateQuarters extends CollectionInfo {
 
                 if (showMintMarks) {
                     if (showP) {
-                        coinList.add(new CoinSlot(identifier, "P"));
+                        coinList.add(new CoinSlot(identifier, "P", coinIndex++));
                     }
                     if (showD) {
-                        coinList.add(new CoinSlot(identifier, "D"));
+                        coinList.add(new CoinSlot(identifier, "D", coinIndex++));
                     }
                 } else {
-                    coinList.add(new CoinSlot(identifier, ""));
+                    coinList.add(new CoinSlot(identifier, "", coinIndex++));
                 }
             }
         }

--- a/app/src/main/java/com/spencerpages/collections/SusanBAnthonyDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/SusanBAnthonyDollars.java
@@ -20,6 +20,9 @@
 
 package com.spencerpages.collections;
 
+import static com.coincollection.CoinSlot.COL_COIN_IDENTIFIER;
+import static com.coincollection.DatabaseHelper.runSqlDelete;
+
 import android.database.sqlite.SQLiteDatabase;
 
 import com.coincollection.CoinPageCreator;
@@ -30,9 +33,6 @@ import com.spencerpages.R;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-
-import static com.coincollection.CoinSlot.COL_COIN_IDENTIFIER;
-import static com.coincollection.DatabaseHelper.runSqlDelete;
 
 public class SusanBAnthonyDollars extends CollectionInfo {
 
@@ -88,6 +88,7 @@ public class SusanBAnthonyDollars extends CollectionInfo {
         Boolean showP           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_1);
         Boolean showD           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_2);
         Boolean showS           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_3);
+        int coinIndex = 0;
 
         for(int i = startYear; i <= stopYear; i++){
             if(i > 1981 && i < 1999)
@@ -97,21 +98,21 @@ public class SusanBAnthonyDollars extends CollectionInfo {
                 // 1979 showed the P mint mark
                 if(showP) {
                     if (i >= 1979) {
-                        coinList.add(new CoinSlot(Integer.toString(i), "P"));
+                        coinList.add(new CoinSlot(Integer.toString(i), "P", coinIndex++));
                     } else {
-                        coinList.add(new CoinSlot(Integer.toString(i), ""));
+                        coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
                     }
                 }
                 if(showD){
-                    coinList.add(new CoinSlot(Integer.toString(i), "D"));
+                    coinList.add(new CoinSlot(Integer.toString(i), "D", coinIndex++));
                 }
                 if(showS){
                     if(i != 1999){
-                        coinList.add(new CoinSlot(Integer.toString(i), "S"));
+                        coinList.add(new CoinSlot(Integer.toString(i), "S", coinIndex++));
                     }
                 }
             } else {
-                coinList.add(new CoinSlot(Integer.toString(i), ""));
+                coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
             }
         }
     }

--- a/app/src/main/java/com/spencerpages/collections/WalkingLibertyHalfDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/WalkingLibertyHalfDollars.java
@@ -89,6 +89,7 @@ public class WalkingLibertyHalfDollars extends CollectionInfo {
         Boolean showP           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_1);
         Boolean showD           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_2);
         Boolean showS           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_3);
+        int coinIndex = 0;
 
         for(int i = startYear; i <= stopYear; i++){
 
@@ -100,31 +101,31 @@ public class WalkingLibertyHalfDollars extends CollectionInfo {
             if(showMintMarks){
                 if(showP){
                     if( (i < 1923 || i > 1933) ){
-                        coinList.add(new CoinSlot(Integer.toString(i), ""));
+                        coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
                     }
                 }
                 if(showD){
                     if( (i < 1923 || i > 1928) && i != 1933 && i != 1940){
                         if(i == 1917){
-                            coinList.add(new CoinSlot(Integer.toString(i), " D Obv"));
-                            coinList.add(new CoinSlot(Integer.toString(i), " D Rev"));
+                            coinList.add(new CoinSlot(Integer.toString(i), " D Obv", coinIndex++));
+                            coinList.add(new CoinSlot(Integer.toString(i), " D Rev", coinIndex++));
                         } else {
-                            coinList.add(new CoinSlot(Integer.toString(i), "D"));
+                            coinList.add(new CoinSlot(Integer.toString(i), "D", coinIndex++));
                         }
                     }
                 }
                 if(showS){
                     if(i != 1938 && i != 1947){
                         if(i == 1917){
-                            coinList.add(new CoinSlot(Integer.toString(i), " S Obv"));
-                            coinList.add(new CoinSlot(Integer.toString(i), " S Rev"));
+                            coinList.add(new CoinSlot(Integer.toString(i), " S Obv", coinIndex++));
+                            coinList.add(new CoinSlot(Integer.toString(i), " S Rev", coinIndex++));
                         } else {
-                            coinList.add(new CoinSlot(Integer.toString(i), "S"));
+                            coinList.add(new CoinSlot(Integer.toString(i), "S", coinIndex++));
                         }
                     }
                 }
             } else {
-                coinList.add(new CoinSlot(Integer.toString(i), ""));
+                coinList.add(new CoinSlot(Integer.toString(i), "", coinIndex++));
             }
         }
     }

--- a/app/src/main/java/com/spencerpages/collections/WashingtonQuarters.java
+++ b/app/src/main/java/com/spencerpages/collections/WashingtonQuarters.java
@@ -20,6 +20,9 @@
 
 package com.spencerpages.collections;
 
+import static com.coincollection.CoinSlot.COIN_SLOT_NAME_MINT_WHERE_CLAUSE;
+import static com.coincollection.DatabaseHelper.runSqlDelete;
+
 import android.database.sqlite.SQLiteDatabase;
 
 import com.coincollection.CoinPageCreator;
@@ -31,9 +34,6 @@ import com.spencerpages.R;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-
-import static com.coincollection.CoinSlot.COIN_SLOT_WHERE_CLAUSE;
-import static com.coincollection.DatabaseHelper.runSqlDelete;
 
 public class WashingtonQuarters extends CollectionInfo {
 
@@ -111,6 +111,7 @@ public class WashingtonQuarters extends CollectionInfo {
         Boolean showP           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_1);
         Boolean showD           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_2);
         Boolean showS           = (Boolean) parameters.get(CoinPageCreator.OPT_SHOW_MINT_MARK_3);
+        int coinIndex = 0;
 
         for(int i = startYear; i <= stopYear; i++){
             String newValue = Integer.toString(i);
@@ -128,23 +129,23 @@ public class WashingtonQuarters extends CollectionInfo {
             if(showMintMarks){
                 if(showP){
                     if(i >= 1980){
-                        coinList.add(new CoinSlot(newValue, "P"));
+                        coinList.add(new CoinSlot(newValue, "P", coinIndex++));
                     } else {
-                        coinList.add(new CoinSlot(newValue, ""));
+                        coinList.add(new CoinSlot(newValue, "", coinIndex++));
                     }
                 }
                 if(showD){
                     if(i != 1938 && (i < 1965 || i > 1967)){
-                        coinList.add(new CoinSlot(newValue, "D"));
+                        coinList.add(new CoinSlot(newValue, "D", coinIndex++));
                     }
                 }
                 if(showS){
                     if(i < 1955 && i != 1934 && i != 1949){
-                        coinList.add(new CoinSlot(newValue, "S"));
+                        coinList.add(new CoinSlot(newValue, "S", coinIndex++));
                     }
                 }
             } else {
-                coinList.add(new CoinSlot(newValue, ""));
+                coinList.add(new CoinSlot(newValue, "", coinIndex++));
             }
         }
     }
@@ -172,9 +173,9 @@ public class WashingtonQuarters extends CollectionInfo {
 
         if(oldVersion <= 2) {
             // Remove 1965 - 1967 D quarters
-            total -= runSqlDelete(db, tableName, COIN_SLOT_WHERE_CLAUSE, new String[]{"1965", "D"});
-            total -= runSqlDelete(db, tableName, COIN_SLOT_WHERE_CLAUSE, new String[]{"1966", "D"});
-            total -= runSqlDelete(db, tableName, COIN_SLOT_WHERE_CLAUSE, new String[]{"1967", "D"});
+            total -= runSqlDelete(db, tableName, COIN_SLOT_NAME_MINT_WHERE_CLAUSE, new String[]{"1965", "D"});
+            total -= runSqlDelete(db, tableName, COIN_SLOT_NAME_MINT_WHERE_CLAUSE, new String[]{"1966", "D"});
+            total -= runSqlDelete(db, tableName, COIN_SLOT_NAME_MINT_WHERE_CLAUSE, new String[]{"1967", "D"});
         }
 
         if (oldVersion <= 16) {

--- a/app/src/main/res/layout/advanced_collection_page.xml
+++ b/app/src/main/res/layout/advanced_collection_page.xml
@@ -1,24 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent" >
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent">
+
     <ListView
         android:id="@+id/advanced_collection_page"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    android:descendantFocusability="beforeDescendants" >
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:descendantFocusability="beforeDescendants">
     </ListView>
-    
-    <TextView  
+
+    <TextView
         android:id="@+id/unsaved_message_textview"
-        android:layout_width="fill_parent"  
-        android:layout_height="wrap_content"  
-        android:text="@string/unsaved_message"  
-        android:layout_gravity="bottom"  
-        android:gravity="center"  
-        android:textColor="#ff0000"
-        android:visibility="gone"  
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
         android:background="#000000"
-        android:textSize="14sp" /> 
+        android:gravity="center"
+        android:padding="8dp"
+        android:text="@string/unsaved_message"
+        android:textColor="#ff0000"
+        android:textSize="18sp"
+        android:visibility="gone" />
 </merge>

--- a/app/src/main/res/layout/coin_update_layout.xml
+++ b/app/src/main/res/layout/coin_update_layout.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+        <TextView
+            android:id="@+id/coin_name_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentTop="true"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentLeft="true"
+            android:layout_alignTop="@id/coin_name_edittext"
+            android:layout_alignBottom="@id/coin_name_edittext"
+            android:gravity="center_vertical"
+            android:text="@string/name_label" />
+        <EditText
+            android:id="@+id/coin_name_edittext"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:importantForAutofill="no"
+            android:inputType="text"
+            android:layout_alignParentTop="true"
+            android:layout_alignParentEnd="true"
+            android:layout_alignParentRight="true"
+            android:layout_toEndOf="@id/coin_name_text"
+            android:layout_toRightOf="@id/coin_name_text">
+        </EditText>
+        <TextView
+            android:id="@+id/coin_mint_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentLeft="true"
+            android:layout_below="@id/coin_name_text"
+            android:layout_alignTop="@id/coin_mint_edittext"
+            android:layout_alignBottom="@id/coin_mint_edittext"
+            android:layout_alignEnd="@id/coin_name_text"
+            android:layout_alignRight="@id/coin_name_text"
+            android:gravity="center_vertical"
+            android:text="@string/mint_label" />
+        <EditText
+            android:id="@+id/coin_mint_edittext"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:importantForAutofill="no"
+            android:inputType="text"
+            android:layout_alignParentEnd="true"
+            android:layout_alignParentRight="true"
+            android:layout_below="@id/coin_name_edittext"
+            android:layout_toEndOf="@id/coin_mint_text"
+            android:layout_toRightOf="@id/coin_mint_text">
+        </EditText>
+</RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,6 +110,7 @@
     <string name="collection_complete">Collection Complete!</string>
     <string name="select_collection_name">Select a new collection name</string>
     <string name="view">View</string>
+    <string name="toggle_collected">Toggle Collected</string>
     <string name="edit">Edit</string>
     <string name="copy">Copy</string>
     <string name="delete">Delete</string>
@@ -129,6 +130,7 @@
     <string name="info_overview">This App is meant to help you keep track of which coins you have already come across and saved in your collection. To help keep your collection organized, we recommend purchasing a coin album specific to each type of coin.\n\nThe mint marking on most coins can be found near the date that appears on the face of the coin. If no mint mark is present, it typically symbolizes that this coin was produced at the Philadelphia (P) mint. Other possible mint marks include that of the Denver mint (D) and the San Francisco mint (S), although the San Francisco mint has not produced coins for circulation for some time now. Also, for some older coins, the mint marks of the Carson City mint (CC) and the New Orleans mint (O) can be found, and special coins like the American Eagle Silver Dollars may carry the West Point mint mark (W). For more information, feel free to check out the website of the U.S. Mint.\n\nIf you have any suggestions or questions about the app, feel free to send an email to andrew27379091@gmail.com.\n\nThis app is not endorsed by the United States Mint.</string>
     <string name="select_collection_delete">Select a collection to delete</string>
     <string name="collection_actions">Collection Actions</string>
+    <string name="coin_actions">Coin Actions</string>
     <string name="copy_name_suffix">\ Copy</string>
     <string name="opening_database">Opening Databases…</string>
     <string name="importing_collections">Importing Collections…</string>
@@ -181,10 +183,15 @@
 
     <!-- Collection Page -->
     <string name="dialog_enter_collection_name">Please enter a name for the collection</string>
+    <string name="dialog_enter_coin_name">Please enter a name for the coin</string>
     <string name="tutorial_add_to_and_lock_collection">Add a coin to your collection by clicking the space above its year or name.  Also, you can prevent accidental changes using the \'LOCK\' action</string>
     <string name="dialog_unsaved_changes_change_views">This collection has unsaved changes, please save before changing views.</string>
     <string name="dialog_unsaved_changes_exit">Leaving this page will erase your unsaved changes, are you sure you want to exit?</string>
     <string name="collection_locked">Collection is currently locked, hit the \'Edit\' action to unlock</string>
+    <string name="edit_coin_info">Edit coin details</string>
+    <string name="name_label">Name:</string>
+    <string name="mint_label">Mint:</string>
+    <string name="tutorial_edit_copy_delete_coins">Press and hold on a coin image to edit, copy, or delete!</string>
 
     <!-- Error and Status Messages -->
     <string name="failed_mk_dir">Failed to make/find directory at %1$s</string>
@@ -197,7 +204,10 @@
     <string name="cannot_find_export_dir">Failed to find existing export directory at %1$s</string>
     <string name="error_open_file_reading">Error when opening input file for reading at %1$s</string>
     <string name="error_copying_database">An error occurred while trying to copy the collection</string>
+    <string name="error_copying_coin">An error occurred while trying to copy the coin</string>
     <string name="error_delete_database">An error occurred while trying to delete the database</string>
+    <string name="error_delete_coin">An error occurred while trying to delete the coin</string>
+    <string name="error_updating_coin">An error occurred while trying to update the coin</string>
     <string name="error_opening_database">An error occurred while trying to open the database</string>
     <string name="error_creating_database">An error occurred while trying to create the database</string>
     <string name="error_updating_database">An error occurred while trying to update the database</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -185,13 +185,14 @@
     <string name="dialog_enter_collection_name">Please enter a name for the collection</string>
     <string name="dialog_enter_coin_name">Please enter a name for the coin</string>
     <string name="tutorial_add_to_and_lock_collection">Add a coin to your collection by clicking the space above its year or name.  Also, you can prevent accidental changes using the \'LOCK\' action</string>
-    <string name="dialog_unsaved_changes_change_views">This collection has unsaved changes, please save before changing views.</string>
+    <string name="dialog_unsaved_changes_change_views">This collection has unsaved changes. Please save before changing views.</string>
     <string name="dialog_unsaved_changes_exit">Leaving this page will erase your unsaved changes, are you sure you want to exit?</string>
     <string name="collection_locked">Collection is currently locked, hit the \'Edit\' action to unlock</string>
     <string name="edit_coin_info">Edit coin details</string>
     <string name="name_label">Name:</string>
     <string name="mint_label">Mint:</string>
     <string name="tutorial_edit_copy_delete_coins">Press and hold on a coin image to edit, copy, or delete!</string>
+    <string name="save_changes_first">This collection has unsaved changes. Please save changes before performing this action.</string>
 
     <!-- Error and Status Messages -->
     <string name="failed_mk_dir">Failed to make/find directory at %1$s</string>

--- a/app/src/sharedTest/java/com/spencerpages/SharedTest.java
+++ b/app/src/sharedTest/java/com/spencerpages/SharedTest.java
@@ -20,10 +20,6 @@
 
 package com.spencerpages;
 
-import com.coincollection.CoinSlot;
-import com.coincollection.CollectionListInfo;
-import com.coincollection.helper.ParcelableHashMap;
-
 import static com.coincollection.CoinPageCreator.OPT_CHECKBOX_1;
 import static com.coincollection.CoinPageCreator.OPT_CHECKBOX_2;
 import static com.coincollection.CoinPageCreator.OPT_EDIT_DATE_RANGE;
@@ -36,6 +32,12 @@ import static com.coincollection.CoinPageCreator.OPT_SHOW_MINT_MARK_5;
 import static com.coincollection.CoinPageCreator.OPT_START_YEAR;
 import static com.coincollection.CoinPageCreator.OPT_STOP_YEAR;
 import static com.spencerpages.MainApplication.getIndexFromCollectionNameStr;
+
+import com.coincollection.CoinSlot;
+import com.coincollection.CollectionListInfo;
+import com.coincollection.helper.ParcelableHashMap;
+
+import java.util.ArrayList;
 
 public class SharedTest {
 
@@ -72,11 +74,11 @@ public class SharedTest {
 
     public static final CoinSlot[] COIN_SLOT_SCENARIOS =
             {
-                    new CoinSlot("1989", "", true, 0, 0, ""),
-                    new CoinSlot("1776-1976", "P", false, 2, 10, "Advanced Notes"),
-                    new CoinSlot("State Park", "CC", true, 20, 1, "293370#$%@#^$#@^"),
-                    new CoinSlot("2000 Type 1", "D", true, 0, 0, "These are my notes\n\n"),
-                    new CoinSlot("Some Coin", "S", false, 11, 11, ""),
+                    new CoinSlot(0, "1989", "", true, 0, 0, "", 0),
+                    new CoinSlot(1, "1776-1976", "P", false, 2, 10, "Advanced Notes", 1),
+                    new CoinSlot(2, "State Park", "CC", true, 20, 1, "293370#$%@#^$#@^", 2),
+                    new CoinSlot(3, "2000 Type 1", "D", true, 0, 0, "These are my notes\n\n", 3),
+                    new CoinSlot(4, "Some Coin", "S", false, 11, 11, "", 4),
             };
 
     public static final ParcelableHashMap[] PARAMETER_SCENARIOS =
@@ -140,16 +142,36 @@ public class SharedTest {
      * Compare two CoinSlot objects to ensure they're the same
      * @param base CoinSlot
      * @param check CoinSlot
+     * @param compareAdvInfo if true, enables comparison of advanced details
      * @return true if they have the same contents, false otherwise
      */
-    public static boolean compareCoinSlots(CoinSlot base, CoinSlot check) {
+    public static boolean compareCoinSlots(CoinSlot base, CoinSlot check, boolean compareAdvInfo) {
         // TODO - Not sure how to add assertions here
         return (base.getIdentifier().equals(check.getIdentifier()) &&
                 (base.getMint().equals(check.getMint())) &&
                 (base.isInCollection() == check.isInCollection()) &&
-                (base.getAdvancedGrades().equals(check.getAdvancedGrades())) &&
-                (base.getAdvancedQuantities().equals(check.getAdvancedQuantities())) &&
-                (base.getAdvancedNotes().equals(check.getAdvancedNotes())));
+                (!compareAdvInfo || (base.getAdvancedGrades().equals(check.getAdvancedGrades()))) &&
+                (!compareAdvInfo || (base.getAdvancedQuantities().equals(check.getAdvancedQuantities()))) &&
+                (!compareAdvInfo || (base.getAdvancedNotes().equals(check.getAdvancedNotes()))));
+    }
+
+    /**
+     * Compare two lists of CoinSlot objects
+     * @param base list of CoinSlots
+     * @param check list of CoinSlots
+     * @param compareAdvInfo if true, enables comparison of advanced details
+     * @return true if they have the same contents, false otherwise
+     */
+    public static boolean compareCoinSlotLists(ArrayList<CoinSlot> base, ArrayList<CoinSlot> check, boolean compareAdvInfo) {
+        if (base.size() != check.size()) {
+            return false;
+        }
+        for (int i = 0; i < base.size(); i++) {
+            if (!compareCoinSlots(base.get(i), check.get(i), compareAdvInfo)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/app/src/sharedTest/java/com/spencerpages/SharedTest.java
+++ b/app/src/sharedTest/java/com/spencerpages/SharedTest.java
@@ -74,11 +74,11 @@ public class SharedTest {
 
     public static final CoinSlot[] COIN_SLOT_SCENARIOS =
             {
-                    new CoinSlot(0, "1989", "", true, 0, 0, "", 0),
-                    new CoinSlot(1, "1776-1976", "P", false, 2, 10, "Advanced Notes", 1),
-                    new CoinSlot(2, "State Park", "CC", true, 20, 1, "293370#$%@#^$#@^", 2),
-                    new CoinSlot(3, "2000 Type 1", "D", true, 0, 0, "These are my notes\n\n", 3),
-                    new CoinSlot(4, "Some Coin", "S", false, 11, 11, "", 4),
+                    new CoinSlot(0, "1989", "", true, 0, 0, "", 0, false),
+                    new CoinSlot(1, "1776-1976", "P", false, 2, 10, "Advanced Notes", 1, false),
+                    new CoinSlot(2, "State Park", "CC", true, 20, 1, "293370#$%@#^$#@^", 2, false),
+                    new CoinSlot(3, "2000 Type 1", "D", true, 0, 0, "These are my notes\n\n", 3, false),
+                    new CoinSlot(4, "Some Coin", "S", false, 11, 11, "", 4, false),
             };
 
     public static final ParcelableHashMap[] PARAMETER_SCENARIOS =

--- a/app/src/test/java/BaseTestCase.java
+++ b/app/src/test/java/BaseTestCase.java
@@ -326,7 +326,7 @@ public class BaseTestCase {
                 collectionInfo.populateCollectionLists(parameters, newCoinList);
 
                 // Get coins from the updated database
-                ArrayList<CoinSlot> dbCoinList = activity.mDbAdapter.getAllIdentifiers(collectionName);
+                ArrayList<CoinSlot> dbCoinList = activity.mDbAdapter.getCoinList(collectionName, true);
                 assertNotNull(dbCoinList);
 
                 // Make sure coin lists match

--- a/app/src/test/java/BaseTestCase.java
+++ b/app/src/test/java/BaseTestCase.java
@@ -74,6 +74,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Random;
 
 public class BaseTestCase {
@@ -371,12 +372,44 @@ public class BaseTestCase {
     }
 
     /**
-     * Compare two CollectionListInfo classes to ensure they're the same
+     * Compare two CollectionListInfo objects to ensure they're the same
      * @param base CollectionListInfo
      * @param check CollectionListInfo
      */
     void compareCollectionListInfos(CollectionListInfo base, CollectionListInfo check) {
         assertTrue(SharedTest.compareCollectionListInfos(base, check));
+    }
+
+    /**
+     * Compare two lists of CoinSlot objects to ensure they're the same
+     * @param base ArrayList<CoinSlot>
+     * @param check ArrayList<CoinSlot>
+     * @param compareAdvInfo if true, enables comparison of advanced details
+     */
+    void compareCoinSlotLists(ArrayList<CoinSlot> base, ArrayList<CoinSlot> check, boolean compareAdvInfo) {
+        assertTrue(SharedTest.compareCoinSlotLists(base, check, compareAdvInfo));
+    }
+
+    /**
+     * Get a list of the sort orders from a coin slot list
+     * @param coinList list of coin slots
+     * @return list of sort orders
+     */
+    ArrayList<Integer> getSortOrderList(ArrayList<CoinSlot> coinList) {
+        ArrayList<Integer> sortOrderList = new ArrayList<>();
+        for (CoinSlot coinSlot : coinList) {
+            sortOrderList.add(coinSlot.getSortOrder());
+        }
+        return sortOrderList;
+    }
+
+    /**
+     * Check that the sort orders in a list of coin slots are unique
+     * @param coinList list of coins to check sort order
+     */
+    void checkCoinSortOrdersUnique(ArrayList<CoinSlot> coinList) {
+        ArrayList<Integer> sortOrderList = getSortOrderList(coinList);
+        assertEquals(new HashSet<>(sortOrderList).size(), sortOrderList.size());
     }
 
     /**
@@ -391,8 +424,15 @@ public class BaseTestCase {
         // Make sure the collection list info is correct in the database
         ArrayList<CollectionListInfo> collectionListEntries = new ArrayList<>();
         activity.mDbAdapter.getAllTables(collectionListEntries);
-        assertEquals(1, collectionListEntries.size());
-        compareCollectionListInfos(collectionListEntries.get(0), collectionListInfo);
+        assertTrue(collectionListEntries.size() > 0);
+        CollectionListInfo matchingDbCollectionListInfo = null;
+        for (CollectionListInfo dbCollectionListInfo : collectionListEntries) {
+            if (dbCollectionListInfo.getName().equals(collectionListInfo.getName())) {
+                matchingDbCollectionListInfo = dbCollectionListInfo;
+            }
+        }
+        assertNotNull(matchingDbCollectionListInfo);
+        compareCollectionListInfos(matchingDbCollectionListInfo, collectionListInfo);
 
         // Test table display database methods
         int originalDisplayType = collectionListInfo.getDisplayType();
@@ -418,8 +458,8 @@ public class BaseTestCase {
         // Make sure the coin list is correct in the database
         if (coinList != null) {
             boolean populateAdvInfo = (collectionListInfo.getDisplayType() == ADVANCED_DISPLAY);
-            ArrayList<CoinSlot> checkCoinList = activity.mDbAdapter.getCoinList(tableName, populateAdvInfo);
-            assertEquals(coinList, checkCoinList);
+            ArrayList<CoinSlot> checkCoinList = activity.mDbAdapter.getCoinList(tableName, populateAdvInfo, false);
+            compareCoinSlotLists(coinList, checkCoinList, populateAdvInfo);
 
             // Test coin slot database methods
             for (CoinSlot coinSlot : coinList) {
@@ -436,10 +476,10 @@ public class BaseTestCase {
     /**
      * Generate test scenarios for each collection
      * @param coinClass collection type
-     * @param numScenarios Number of scenarios to generate
+     * @param numRandomScenarios Number of additional random scenarios to generate
      * @return scenario list containing [start, end] dates (if dates are used)
      */
-    ArrayList<Integer[]> getTestScenarios(CollectionInfo coinClass, int numScenarios) {
+    ArrayList<Integer[]> getTestScenarios(CollectionInfo coinClass, int numRandomScenarios) {
         ArrayList<Integer[]> scenarioList = new ArrayList<>();
         if (CollectionListInfo.doesCollectionTypeUseDates(coinClass.getCoinType())) {
             // Add some coin date scenarios to test
@@ -452,14 +492,14 @@ public class BaseTestCase {
             scenarioList.add(new Integer[]{startYear, startYear + 1});
             scenarioList.add(new Integer[]{endYear - 1, endYear});
             // Choose some random date ranges
-            for (int i = 0; i < numScenarios; i++) {
+            for (int i = 0; i < numRandomScenarios; i++) {
                 int randStartYear = startYear + DatabaseAccessTests.random.nextInt(endYear - startYear + 1);
                 int randEndYear = randStartYear + random.nextInt(endYear - randStartYear + 1);
                 scenarioList.add(new Integer[]{randStartYear, randEndYear});
             }
         } else {
             // Add a fixed number of scenarios if dates aren't used
-            for (int i = 0; i < numScenarios; i++) {
+            for (int i = 0; i < numRandomScenarios; i++) {
                 scenarioList.add(new Integer[]{0, 0});
             }
         }
@@ -467,60 +507,80 @@ public class BaseTestCase {
     }
 
     /**
+     * Get collection with random information filled in
+     * @param coinType type of collection to make
+     * @param dates start and end dates
+     * @return generated collection
+     */
+    FullCollection getRandomTestScenario(CollectionInfo coinType, Integer[] dates) {
+
+        // Select a unique name
+        String collectionName;
+        do {
+            collectionName = getRandCollectionName();
+        } while (mPreviousRandCollectionNames.contains(collectionName));
+        mPreviousRandCollectionNames.add(collectionName);
+
+        return getRandomTestScenario(coinType, collectionName, dates);
+    }
+    /**
+     * Get collection with random information filled in
+     * @param coinType type of collection to make
+     * @param collectionName name of the collection
+     * @param dates start and end dates
+     * @return generated collection
+     */
+    FullCollection getRandomTestScenario(CollectionInfo coinType, String collectionName,
+                                         Integer[] dates) {
+        int maxGrades = 100;
+        int maxQuantities = 20;
+        int startDate = dates[0];
+        int endDate = dates[1];
+        int displayOrder = random.nextInt(100000);
+
+        // Create CollectionListInfo
+        int displayType = ((random.nextInt() % 2) == 1 ? SIMPLE_DISPLAY : ADVANCED_DISPLAY);
+        CollectionListInfo collectionListInfo = new CollectionListInfo(
+                collectionName,
+                0,
+                0,
+                MainApplication.getIndexFromCollectionNameStr(coinType.getCoinType()),
+                displayType,
+                startDate,
+                endDate,
+                random.nextInt() & CollectionListInfo.ALL_MINT_MASK,
+                random.nextInt() & CollectionListInfo.ALL_CHECKBOXES_MASK);
+
+        // Populate coin list
+        ParcelableHashMap parameters = CoinPageCreator.getParametersFromCollectionListInfo(collectionListInfo);
+        ArrayList<CoinSlot> coinList = new ArrayList<>();
+        coinType.populateCollectionLists(parameters, coinList);
+        int numCollected = 0;
+        for (CoinSlot coinSlot : coinList) {
+            boolean collected = (random.nextInt() % 2) == 1;
+            coinSlot.setInCollection(collected);
+            coinSlot.setAdvancedGrades(random.nextInt() % maxGrades);
+            coinSlot.setAdvancedQuantities(random.nextInt() % maxQuantities);
+            coinSlot.setAdvancedNotes(Integer.toString(random.nextInt()));
+            numCollected += collected ? 1 : 0;
+        }
+        collectionListInfo.setMax(coinList.size());
+        collectionListInfo.setCollected(numCollected);
+
+        return new FullCollection(collectionListInfo, coinList, displayOrder);
+    }
+    /**
      * Get collections with random information filled in
-     * @param activity activity needed to access some resources
      * @param coinType type of collection to make
      * @param numScenarios number of collections to make
      * @return list of generated collections
      */
-    ArrayList<FullCollection> getRandomTestScenarios(BaseActivity activity, CollectionInfo coinType, int numScenarios) {
-        String[] grades = activity.getResources().getStringArray(R.array.coin_grades);
-        String[] quantities = activity.getResources().getStringArray(R.array.coin_quantities);
+    ArrayList<FullCollection> getRandomTestScenarios(CollectionInfo coinType, int numScenarios) {
         ArrayList<Integer[]> scenarioList = getTestScenarios(coinType, numScenarios);
         ArrayList<FullCollection> testCollections = new ArrayList<>();
 
         for (int i = 0; i < scenarioList.size(); i++) {
-            int startDate = scenarioList.get(i)[0];
-            int endDate = scenarioList.get(i)[1];
-            int displayOrder = random.nextInt(100000);
-
-            // Select a unique name
-            String collectionName;
-            do {
-                collectionName = getRandCollectionName();
-            } while (mPreviousRandCollectionNames.contains(collectionName));
-            mPreviousRandCollectionNames.add(collectionName);
-
-            // Create CollectionListInfo
-            int displayType = ((random.nextInt() % 2) == 1 ? SIMPLE_DISPLAY : ADVANCED_DISPLAY);
-            CollectionListInfo collectionListInfo = new CollectionListInfo(
-                    collectionName,
-                    0,
-                    0,
-                    MainApplication.getIndexFromCollectionNameStr(coinType.getCoinType()),
-                    displayType,
-                    startDate,
-                    endDate,
-                    random.nextInt() & CollectionListInfo.ALL_MINT_MASK,
-                    random.nextInt() & CollectionListInfo.ALL_CHECKBOXES_MASK);
-
-            // Populate coin list
-            ParcelableHashMap parameters = CoinPageCreator.getParametersFromCollectionListInfo(collectionListInfo);
-            ArrayList<CoinSlot> coinList = new ArrayList<>();
-            coinType.populateCollectionLists(parameters, coinList);
-            int numCollected = 0;
-            for (CoinSlot coinSlot : coinList) {
-                boolean collected = (random.nextInt() % 2) == 1;
-                coinSlot.setInCollection(collected);
-                coinSlot.setAdvancedGrades(random.nextInt() % grades.length);
-                coinSlot.setAdvancedQuantities(random.nextInt() % quantities.length);
-                coinSlot.setAdvancedNotes(Integer.toString(random.nextInt()));
-                numCollected += collected ? 1 : 0;
-            }
-            collectionListInfo.setMax(coinList.size());
-            collectionListInfo.setCollected(numCollected);
-
-            testCollections.add(new FullCollection(collectionListInfo, coinList, displayOrder));
+            testCollections.add(getRandomTestScenario(coinType, scenarioList.get(i)));
         }
         return testCollections;
     }

--- a/app/src/test/java/CollectionPageActivityTests.java
+++ b/app/src/test/java/CollectionPageActivityTests.java
@@ -113,7 +113,7 @@ public class CollectionPageActivityTests extends BaseTestCase {
                     }
 
                     // Check that the copied collection was made correctly in the database
-                    ArrayList<CoinSlot> checkCoinList = activity.mDbAdapter.getCoinList(collectionName, true, true);
+                    ArrayList<CoinSlot> checkCoinList = activity.mDbAdapter.getCoinList(collectionName, true);
                     compareCoinSlotLists(activity.mCoinList, checkCoinList, true);
                     checkCoinSortOrdersUnique(activity.mCoinList);
                     assertEquals(getSortOrderList(activity.mCoinList), getSortOrderList(checkCoinList));

--- a/app/src/test/java/CollectionPageActivityTests.java
+++ b/app/src/test/java/CollectionPageActivityTests.java
@@ -1,0 +1,124 @@
+/*
+ * Coin Collection, an Android app that helps users track the coins that they've collected
+ * Copyright (C) 2010-2016 Andrew Williams
+ *
+ * This file is part of Coin Collection.
+ *
+ * Coin Collection is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Coin Collection is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Coin Collection.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import static com.spencerpages.SharedTest.COLLECTION_LIST_INFO_SCENARIOS;
+
+import static org.junit.Assert.assertEquals;
+
+import android.content.Intent;
+import android.os.Build;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.core.app.ApplicationProvider;
+
+import com.coincollection.CoinPageCreator;
+import com.coincollection.CoinSlot;
+import com.coincollection.CollectionListInfo;
+import com.coincollection.CollectionPage;
+import com.coincollection.helper.ParcelableHashMap;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.ArrayList;
+
+@RunWith(RobolectricTestRunner.class)
+// TODO - Must keep at 28 until Robolectric supports Java 9 (required to use 29+)
+@Config(sdk = Build.VERSION_CODES.P)
+public class CollectionPageActivityTests extends BaseTestCase {
+
+    private final ArrayList<FullCollection> mCollectionList = new ArrayList<>();
+
+    @Before
+    public void databaseSetup() {
+        try(ActivityScenario<CoinPageCreator> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), CoinPageCreator.class)
+                        .putExtra(CoinPageCreator.UNIT_TEST_USE_ASYNC_TASKS, false))) {
+            scenario.onActivity(activity -> {
+                for (CollectionListInfo info : COLLECTION_LIST_INFO_SCENARIOS) {
+                    activity.mCoinList = new ArrayList<>();
+                    ParcelableHashMap parameters = CoinPageCreator.getParametersFromCollectionListInfo(info);
+                    int index = info.getCollectionTypeIndex();
+                    activity.setInternalStateFromCollectionIndex(index, parameters);
+                    activity.createOrUpdateCoinListForAsyncThread();
+                    // Create the collection in the database
+                    activity.mDbAdapter.createAndPopulateNewTable(info, 0, activity.mCoinList);
+                    mCollectionList.add(new FullCollection(info, activity.mCoinList, 0));
+                }
+            });
+        }
+    }
+
+    /**
+     * Test updating coin details
+     */
+    @Test
+    public void test_coinActions() {
+        for (FullCollection collection : mCollectionList) {
+            String collectionName = collection.mCollectionListInfo.getName();
+            int coinTypeIdx = collection.mCollectionListInfo.getCollectionTypeIndex();
+            try (ActivityScenario<CollectionPage> scenario = ActivityScenario.launch(
+                    new Intent(ApplicationProvider.getApplicationContext(), CollectionPage.class)
+                            .putExtra(CollectionPage.COLLECTION_TYPE_INDEX, coinTypeIdx)
+                            .putExtra(CollectionPage.COLLECTION_NAME, collectionName))) {
+                scenario.onActivity(activity -> {
+
+                    if (activity.mCoinList.size() > 0) {
+
+                        // Make copy of coins
+                        activity.copyCoinSlot(activity.mCoinList.get(0), 1);
+                        activity.copyCoinSlot(activity.mCoinList.get(0), 1);
+                        activity.copyCoinSlot(activity.mCoinList.get(0), 1);
+
+                        int lastIndex = activity.mCoinList.size() - 1;
+                        activity.copyCoinSlot(activity.mCoinList.get(lastIndex), lastIndex+1);
+
+                        // Update coin names
+                        activity.updateCoinDetails(activity.mCoinList.get(0), "First Coin", "First");
+                        activity.updateCoinDetails(activity.mCoinList.get(1), "Second Coin", "Second");
+                        activity.updateCoinDetails(activity.mCoinList.get(2), "Third Coin", "Third");
+
+                        lastIndex = activity.mCoinList.size() - 1;
+                        activity.updateCoinDetails(activity.mCoinList.get(lastIndex), "Last Coin", "Last");
+
+                        // Delete coins
+                        activity.deleteCoinSlotAtPosition(0);
+                        activity.deleteCoinSlotAtPosition(2);
+                        int secondToLastIndex = activity.mCoinList.size() - 2;
+                        activity.deleteCoinSlotAtPosition(secondToLastIndex);
+
+                        // Add coins
+                        activity.copyCoinSlot(activity.mCoinList.get(0), 1);
+                        activity.updateCoinDetails(activity.mCoinList.get(0), "First Coin2", "First2");
+                    }
+
+                    // Check that the copied collection was made correctly in the database
+                    ArrayList<CoinSlot> checkCoinList = activity.mDbAdapter.getCoinList(collectionName, true, true);
+                    compareCoinSlotLists(activity.mCoinList, checkCoinList, true);
+                    checkCoinSortOrdersUnique(activity.mCoinList);
+                    assertEquals(getSortOrderList(activity.mCoinList), getSortOrderList(checkCoinList));
+                });
+            }
+        }
+    }
+}

--- a/app/src/test/java/DatabaseAccessTests.java
+++ b/app/src/test/java/DatabaseAccessTests.java
@@ -60,7 +60,7 @@ public class DatabaseAccessTests extends BaseTestCase {
                         .putExtra(CoinPageCreator.UNIT_TEST_USE_ASYNC_TASKS, false))) {
             scenario.onActivity(activity -> {
 
-                for (FullCollection scenario1 : getRandomTestScenarios(activity, mCoinTypeObj, 20)) {
+                for (FullCollection scenario1 : getRandomTestScenarios(mCoinTypeObj, 20)) {
                     String collectionName = scenario1.mCollectionListInfo.getName();
 
                     // Create the collection in the database

--- a/app/src/test/java/ExportImportJsonTests.java
+++ b/app/src/test/java/ExportImportJsonTests.java
@@ -95,7 +95,7 @@ public class ExportImportJsonTests extends BaseTestCase {
                 new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class)
                         .putExtra(MainActivity.UNIT_TEST_USE_ASYNC_TASKS, false))) {
             scenario.onActivity(activity -> {
-                for (FullCollection scenario1 : getRandomTestScenarios(activity, mCoinTypeObj, 1)) {
+                for (FullCollection scenario1 : getRandomTestScenarios(mCoinTypeObj, 1)) {
                     // Create the collection in the database
                     activity.mDbAdapter.createAndPopulateNewTable(scenario1.mCollectionListInfo,
                             scenario1.mDisplayOrder, scenario1.mCoinList);

--- a/app/src/test/java/LaunchCoinPageTests.java
+++ b/app/src/test/java/LaunchCoinPageTests.java
@@ -65,7 +65,7 @@ public class LaunchCoinPageTests extends BaseTestCase {
                 new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class)
                         .putExtra(MainActivity.UNIT_TEST_USE_ASYNC_TASKS, false))) {
             scenario.onActivity(activity -> {
-                for (FullCollection scenario1 : getRandomTestScenarios(activity, mCoinTypeObj, 1)) {
+                for (FullCollection scenario1 : getRandomTestScenarios(mCoinTypeObj, 1)) {
                     // Create the collection in the database
                     activity.mDbAdapter.createAndPopulateNewTable(scenario1.mCollectionListInfo,
                             scenario1.mDisplayOrder, scenario1.mCoinList);

--- a/app/src/test/java/MainActivityTests.java
+++ b/app/src/test/java/MainActivityTests.java
@@ -72,25 +72,25 @@ public class MainActivityTests extends BaseTestCase {
                         .putExtra(MainActivity.UNIT_TEST_USE_ASYNC_TASKS, false))) {
             scenario.onActivity(activity -> {
                 for (CollectionInfo coinType : MainApplication.COLLECTION_TYPES) {
-                    for (FullCollection scenario1 : getRandomTestScenarios(activity, coinType, 2)) {
-                        String collectionName = scenario1.mCollectionListInfo.getName();
+                    for (FullCollection collection : getRandomTestScenarios(coinType, 2)) {
+                        String collectionName = collection.mCollectionListInfo.getName();
 
                         // Create the collection in the database
-                        activity.mDbAdapter.createAndPopulateNewTable(scenario1.mCollectionListInfo,
-                                scenario1.mDisplayOrder, scenario1.mCoinList);
+                        activity.mDbAdapter.createAndPopulateNewTable(collection.mCollectionListInfo,
+                                collection.mDisplayOrder, collection.mCoinList);
                         activity.updateCollectionListFromDatabase();
 
                         // Make a copy
                         String newDbName = collectionName + " Copy";
                         activity.copyCollection(collectionName);
-                        CollectionListInfo copiedCollectionListInfo = scenario1.mCollectionListInfo.copy(newDbName);
+                        CollectionListInfo copiedCollectionListInfo = collection.mCollectionListInfo.copy(newDbName);
 
                         // Drop the original
                         activity.mDbAdapter.dropCollectionTable(collectionName);
 
                         // Check that the copied collection was made correctly in the database
                         compareCollectionWithDb(activity, copiedCollectionListInfo,
-                                scenario1.mCoinList, scenario1.mDisplayOrder);
+                                collection.mCoinList, collection.mDisplayOrder);
 
                         // Delete the collection from the database
                         activity.mDbAdapter.dropCollectionTable(newDbName);


### PR DESCRIPTION
Adding a coin options menu with support to edit the coin's name and mint, delete a coin, and copy a coin in a collection.

With this update it's now possible to insert custom coins, however adding separate 'add coin' and 'reorder coins' features would likely also improve the user experience.

I need to think a little more about how editing an existing collection should work with copied/edited coins. Right now when a collection is edited, the details from the old list are pulled into the new collection based on matching name/mint; now there can be multiple coins with the same name/mint, and any copied coins will be removed (because their names/mints won't match anything in the new set). We should at least generate a warning for this.

[Update] - I've updated the collection update code to preserve manually-entered coins, and should preserve their sort order in most cases.