### PR TITLE
Replacing references to master branch with main branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request_template.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.yaml
@@ -11,7 +11,7 @@ body:
         **Thanks for taking the time to fill out this feature request and helping us improve!**
         Kindly search to see if a similar issue [already exists](https://github.com/anwilli5/coin-collection-android-US/issues) for your feature.
 
-        We are also happy to accept contributions from our users. For more details see [here](https://github.com/anwilli5/coin-collection-android-US/blob/master/CONTRIBUTING.md).
+        We are also happy to accept contributions from our users. For more details see [here](https://github.com/anwilli5/coin-collection-android-US/blob/main/CONTRIBUTING.md).
 
   - type: textarea
     id: feature-description

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '24 13 * * 5'
 

--- a/.github/workflows/devskim-analysis.yml
+++ b/.github/workflows/devskim-analysis.yml
@@ -7,9 +7,9 @@ name: DevSkim
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '43 9 * * 3'
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -5,9 +5,9 @@ name: Android CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   test:

--- a/.github/workflows/ossar-analysis.yml
+++ b/.github/workflows/ossar-analysis.yml
@@ -10,10 +10,10 @@ name: OSSAR
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '33 4 * * 2'
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 If you want to make a contribution to the repository, follow these steps:
 
-*-- Please follow the [Code Of Conduct](https://github.com/anwilli5/coin-collection-android-US/blob/master/CODE_OF_CONDUCT.md) of this project and keep this in mind while contributing --*
+*-- Please follow the [Code Of Conduct](https://github.com/anwilli5/coin-collection-android-US/blob/main/CODE_OF_CONDUCT.md) of this project and keep this in mind while contributing --*
 
   1) **Fork this repository** to your own Github account by clicking the Fork button on the top right corner.
  

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Coin Collection helps people keep track of the coins they have or are missing fo
 ## Download the app
 <div style="display:flex;" >
 <a href="https://play.google.com/store/apps/details?id=com.spencerpages">
-    <img alt="Get it on Google Play" height="64" src="https://raw.githubusercontent.com/anwilli5/coin-collection-android-US/master/images/google-play-badge.png" />
+    <img alt="Get it on Google Play" height="64" src="https://raw.githubusercontent.com/anwilli5/coin-collection-android-US/main/images/google-play-badge.png" />
 </a>
 <a href="http://www.amazon.com/gp/product/B00KZ7PYPY/ref=mas_pm_coin_collection">
-    <img alt="Available at Amazon Appstore" height="64" src="https://raw.githubusercontent.com/anwilli5/coin-collection-android-US/master/images/amazon-appstore-badge.png" />
+    <img alt="Available at Amazon Appstore" height="64" src="https://raw.githubusercontent.com/anwilli5/coin-collection-android-US/main/images/amazon-appstore-badge.png" />
 </a>
 </div><br/>
 
@@ -63,7 +63,7 @@ Supported U.S. coin sets include:
 - Automatic and manual ways to backup/restore and share collections
 
 ## Contributions
-- Pull requests are welcome! For more details see [Contributing](https://github.com/anwilli5/coin-collection-android-US/blob/master/CONTRIBUTING.md)
+- Pull requests are welcome! For more details see [Contributing](https://github.com/anwilli5/coin-collection-android-US/blob/main/CONTRIBUTING.md)
 - Review open issues, feature requests, and add comments here [Open issues](https://github.com/anwilli5/coin-collection-android-US/issues)
 - Let us know if you've found an issue or would like to request a feature [Report an issue](https://github.com/anwilli5/coin-collection-android-US/issues/new/choose)
 


### PR DESCRIPTION
Fixing GitHub actions and links to replace master branch with main branch