### PR TITLE
Adding ability to control images shown for coins

### DIFF
--- a/app/src/main/java/com/coincollection/CoinSlot.java
+++ b/app/src/main/java/com/coincollection/CoinSlot.java
@@ -72,6 +72,11 @@ public class CoinSlot implements Parcelable {
     private int mSortOrder;
 
     /**
+     * Optional image id, associating coin slot to a specific coin image
+     **/
+    private int mImageId = -1;
+
+    /**
      * Whether the coin is custom (i.e. added by the user after the collection was created)
      */
     private boolean mCustomCoin = false;
@@ -86,6 +91,7 @@ public class CoinSlot implements Parcelable {
     public final static String COL_ADV_NOTES = "advNotes";
     public final static String COL_SORT_ORDER = "sortOrder";
     public final static String COL_CUSTOM_COIN = "customCoin";
+    public final static String COL_IMAGE_ID = "imageId";
 
     // Database helpers
     public final static String COIN_SLOT_COIN_ID_WHERE_CLAUSE = COL_COIN_ID + "=?";
@@ -108,9 +114,11 @@ public class CoinSlot implements Parcelable {
      * @param advancedNotes      coin notes
      * @param sortOrder          sort order in the collection
      * @param customCoin         whether the coin was manually added by the user
+     * @param imageId            optional image id
      */
     public CoinSlot(long databaseId, String identifier, String mint, boolean inCollection, Integer advancedGrades,
-                    Integer advancedQuantities, String advancedNotes, int sortOrder, boolean customCoin) {
+                    Integer advancedQuantities, String advancedNotes, int sortOrder, boolean customCoin,
+                    int imageId) {
         mDatabaseId = databaseId;
         mIdentifier = identifier;
         mMint = mint;
@@ -120,6 +128,7 @@ public class CoinSlot implements Parcelable {
         mAdvancedNotes = advancedNotes;
         mSortOrder = sortOrder;
         mCustomCoin = customCoin;
+        mImageId = imageId;
     }
 
     /**
@@ -131,14 +140,17 @@ public class CoinSlot implements Parcelable {
      * @param inCollection whether the coin has been collected
      * @param sortOrder    sort order in the collection
      * @param customCoin   whether the coin was manually added by the user
+     * @param imageId      optional image id
      */
-    public CoinSlot(long databaseId, String identifier, String mint, boolean inCollection, int sortOrder, boolean customCoin) {
+    public CoinSlot(long databaseId, String identifier, String mint, boolean inCollection, int sortOrder,
+                    boolean customCoin, int imageId) {
         mDatabaseId = databaseId;
         mIdentifier = identifier;
         mMint = mint;
         mInCollection = inCollection;
         mSortOrder = sortOrder;
         mCustomCoin = customCoin;
+        mImageId = imageId;
     }
 
     /**
@@ -152,6 +164,21 @@ public class CoinSlot implements Parcelable {
         mIdentifier = identifier;
         mMint = mint;
         mSortOrder = sortOrder;
+    }
+
+    /**
+     * Constructor used when creating a new collection from scratch
+     *
+     * @param identifier coin name
+     * @param mint       coin mint
+     * @param sortOrder  sort order in collection
+     * @param imageId    image id
+     */
+    public CoinSlot(String identifier, String mint, int sortOrder, int imageId) {
+        mIdentifier = identifier;
+        mMint = mint;
+        mSortOrder = sortOrder;
+        mImageId = imageId;
     }
 
     public void setDatabaseId(long databaseId) {
@@ -246,6 +273,14 @@ public class CoinSlot implements Parcelable {
         this.mCustomCoin = customCoin;
     }
 
+    public int getImageId() {
+        return this.mImageId;
+    }
+
+    public void setImageId(int imageId) {
+        this.mImageId = imageId;
+    }
+
     /**
      * Get the coin slot parameters to export to legacy CSV
      *
@@ -275,7 +310,8 @@ public class CoinSlot implements Parcelable {
                 String.valueOf(mAdvancedQuantities),
                 mAdvancedNotes,
                 String.valueOf(mSortOrder),
-                String.valueOf(isCustomCoinInt())};
+                String.valueOf(isCustomCoinInt()),
+                String.valueOf(mImageId)};
     }
 
     /**
@@ -292,7 +328,8 @@ public class CoinSlot implements Parcelable {
                 COL_ADV_QUANTITY_INDEX,
                 COL_ADV_NOTES,
                 COL_SORT_ORDER,
-                COL_CUSTOM_COIN};
+                COL_CUSTOM_COIN,
+                COL_IMAGE_ID};
     }
 
     /**
@@ -312,6 +349,7 @@ public class CoinSlot implements Parcelable {
         writer.name(COL_ADV_NOTES).value(mAdvancedNotes);
         writer.name(COL_SORT_ORDER).value(mSortOrder);
         writer.name(COL_CUSTOM_COIN).value(mCustomCoin);
+        writer.name(COL_IMAGE_ID).value(mImageId);
         writer.endObject();
     }
 
@@ -332,6 +370,7 @@ public class CoinSlot implements Parcelable {
         String advancedNotes = "";
         int sortOrder = coinIndex;
         boolean customCoin = false;
+        int imageId = -1;
 
         reader.beginObject();
         while (reader.hasNext()) {
@@ -361,6 +400,9 @@ public class CoinSlot implements Parcelable {
                 case COL_CUSTOM_COIN:
                     customCoin = reader.nextBoolean();
                     break;
+                case COL_IMAGE_ID:
+                    imageId = reader.nextInt();
+                    break;
                 default:
                     reader.skipValue();
                     break;
@@ -376,6 +418,7 @@ public class CoinSlot implements Parcelable {
         mAdvancedNotes = advancedNotes;
         mSortOrder = sortOrder;
         mCustomCoin = customCoin;
+        mImageId = imageId;
     }
 
     /**
@@ -386,7 +429,7 @@ public class CoinSlot implements Parcelable {
      * @return true if the element at the index is present and not empty
      */
     private boolean isPresentInStringArray(String[] in, int index) {
-        return in.length > index && in[index].length() != 0;
+        return in.length > index && !in[index].isEmpty();
     }
 
     /**
@@ -403,6 +446,7 @@ public class CoinSlot implements Parcelable {
         mAdvancedNotes = isPresentInStringArray(in, 5) ? in[5] : "";
         mSortOrder = isPresentInStringArray(in, 6) ? Integer.parseInt(in[6]) : coinIndex;
         mCustomCoin = (isPresentInStringArray(in, 7) && (Integer.parseInt(in[7]) != 0));
+        mImageId = isPresentInStringArray(in, 8) ? Integer.parseInt(in[8]) : -1;
     }
 
     /**
@@ -424,7 +468,8 @@ public class CoinSlot implements Parcelable {
                 mAdvancedQuantities,
                 mAdvancedNotes,
                 mSortOrder + 1,
-                isCustomCoin);
+                isCustomCoin,
+                mImageId);
     }
 
     /* We make this object Parcelable so that the list can be passed between Activities in the case
@@ -449,6 +494,7 @@ public class CoinSlot implements Parcelable {
         mAdvancedNotes = in.readString();
         mSortOrder = in.readInt();
         mCustomCoin = in.readByte() != 0;
+        mImageId = in.readInt();
     }
 
     public static final Creator<CoinSlot> CREATOR = new Creator<CoinSlot>() {
@@ -490,6 +536,7 @@ public class CoinSlot implements Parcelable {
         dest.writeString(mAdvancedNotes);
         dest.writeInt(mSortOrder);
         dest.writeByte((byte) (mCustomCoin ? 1 : 0));
+        dest.writeInt(mImageId);
     }
 
     // NOTE: This will return true if identifier and mint are the same

--- a/app/src/main/java/com/coincollection/CoinSlotAdapter.java
+++ b/app/src/main/java/com/coincollection/CoinSlotAdapter.java
@@ -38,6 +38,8 @@ import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+
 import com.spencerpages.MainApplication;
 import com.spencerpages.R;
 
@@ -155,11 +157,11 @@ class CoinSlotAdapter extends BaseAdapter {
         if (!coinViewWasRecycled && mDisplayType == CollectionPage.ADVANCED_DISPLAY && !mDisplayIsLocked) {
             coinView.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener() {
                 @Override
-                public void onViewAttachedToWindow(View view) {
+                public void onViewAttachedToWindow(@NonNull View view) {
                 }
 
                 @Override
-                public void onViewDetachedFromWindow(View view) {
+                public void onViewDetachedFromWindow(@NonNull View view) {
                     onCoinSlotAdvNotesChanged(view);
                 }
             });
@@ -177,9 +179,9 @@ class CoinSlotAdapter extends BaseAdapter {
 
         //Set this image based on whether the coin has been obtained
         ImageView coinImage = coinView.findViewById(R.id.coinImage);
-        int imageIdentifier = mCollectionTypeObj.getCoinSlotImage(coinSlot);
+        int imageIdentifier = mCollectionTypeObj.getCoinSlotImage(coinSlot, false);
         coinImage.setImageResource(imageIdentifier);
-        coinImage.setAlpha(coinSlot.isInCollection() ? 255 : 64);
+        coinImage.setImageAlpha(coinSlot.isInCollection() ? 255 : 64);
 
         // Add an accessibility string to indicate that the coin has been found or not
         String contextDesc = mRes.getString(coinSlot.isInCollectionStringRes());

--- a/app/src/main/java/com/coincollection/CollectionInfo.java
+++ b/app/src/main/java/com/coincollection/CollectionInfo.java
@@ -36,25 +36,13 @@ public abstract class CollectionInfo {
     /**
      * Returns the image id (R.drawable.image_name) that should be
      * displayed for collections of this type given the specified coin
-     * identifier, coin mint, and whether the coin is in the
-     * collection.  The convention used in Coin Collection for determining
-     * the value to return is:
-     * <p>
-     * For simple collections:
-     * - The obverse coin image is returned if inCollection
-     * - R.drawable.openslot is returned if not inCollection
-     * <p>
-     * For collections with special/individualized coins:
-     * - The reverse (uniquely-styled side) is returned if inCollection
-     * - The reverse at a 25% opacity is returned if not inCollection (there
-     * is a script in the repo that will generate the 25% opacity images
-     * automatically from thee regular images.  See image-prep.py for more
-     * details.)
+     * identifier, coin mint, and image id.
      *
      * @param coinSlot the coin slot to return an image for
+     * @param ignoreImageId when set, image ids should be ignored
      * @return the id of an image to use for this coin
      */
-    abstract public int getCoinSlotImage(CoinSlot coinSlot);
+    abstract public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId);
 
     /**
      * Returns a string used to identify this collection type
@@ -147,4 +135,16 @@ public abstract class CollectionInfo {
      * @return Returns 0 if start/stop years aren't used by this series
      */
     abstract public int getStopYear();
+
+    /**
+     * A collection should populate this if it has multiple coin images and
+     * populates the image id of coin slots to display a specific image for
+     * certain coins. Collections that select the image based solely on the
+     * coin name do not need to populate this.
+     *s
+     * @return Array of {"image description", image id}, or empty if unused
+     */
+    public Object[][] getImageIds() {
+        return new Object[][]{};
+    }
 }

--- a/app/src/main/java/com/coincollection/DatabaseAdapter.java
+++ b/app/src/main/java/com/coincollection/DatabaseAdapter.java
@@ -25,6 +25,7 @@ import static com.coincollection.CoinSlot.COL_COIN_ID;
 import static com.coincollection.CoinSlot.COL_COIN_IDENTIFIER;
 import static com.coincollection.CoinSlot.COL_COIN_MINT;
 import static com.coincollection.CoinSlot.COL_CUSTOM_COIN;
+import static com.coincollection.CoinSlot.COL_IMAGE_ID;
 import static com.coincollection.CoinSlot.COL_IN_COLLECTION;
 import static com.coincollection.CoinSlot.COL_SORT_ORDER;
 import static com.coincollection.CollectionListInfo.COL_COIN_TYPE;
@@ -228,7 +229,8 @@ public class DatabaseAdapter {
                 + " " + COL_ADV_QUANTITY_INDEX + " integer default 0,"
                 + " " + COL_ADV_NOTES + " text default \"\","
                 + " " + COL_SORT_ORDER + " integer not null,"
-                + " " + COL_CUSTOM_COIN + " integer default 0);";
+                + " " + COL_CUSTOM_COIN + " integer default 0,"
+                + " " + COL_IMAGE_ID + " integer default -1);";
         mDb.execSQL(sqlCmd);
     }
 
@@ -405,10 +407,11 @@ public class DatabaseAdapter {
      * @param coinSlot  coin data to use for updates
      * @throws SQLException if a database error occurs
      */
-    public void updateCoinNameAndMint(String tableName, CoinSlot coinSlot) throws SQLException {
+    public void updateCoinNameMintImage(String tableName, CoinSlot coinSlot) throws SQLException {
         ContentValues values = new ContentValues();
         values.put(COL_COIN_IDENTIFIER, coinSlot.getIdentifier());
         values.put(COL_COIN_MINT, coinSlot.getMint());
+        values.put(COL_IMAGE_ID, coinSlot.getImageId());
         String[] whereValues = new String[]{String.valueOf(coinSlot.getDatabaseId())};
         runSqlUpdateAndCheck(tableName, values, COIN_SLOT_COIN_ID_WHERE_CLAUSE, whereValues);
     }
@@ -473,6 +476,7 @@ public class DatabaseAdapter {
         values.put(COL_ADV_NOTES, coinSlot.getAdvancedNotes());
         values.put(COL_SORT_ORDER, coinSlot.getSortOrder());
         values.put(COL_CUSTOM_COIN, coinSlot.isCustomCoinInt());
+        values.put(COL_IMAGE_ID, coinSlot.getImageId());
 
         // Add coin into database and record database id in CoinSlot object
         coinSlot.setDatabaseId(runSqlInsert(tableName, values));

--- a/app/src/main/java/com/coincollection/ImageSpinnerAdapter.java
+++ b/app/src/main/java/com/coincollection/ImageSpinnerAdapter.java
@@ -1,0 +1,74 @@
+/*
+ * Coin Collection, an Android app that helps users track the coins that they've collected
+ * Copyright (C) 2010-2016 Andrew Williams
+ *
+ * This file is part of Coin Collection.
+ *
+ * Coin Collection is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Coin Collection is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Coin Collection.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.coincollection;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
+
+import com.spencerpages.R;
+
+import java.util.ArrayList;
+
+public class ImageSpinnerAdapter extends ArrayAdapter<String> {
+    private final Context mContext;
+    private final ArrayList<String> mNames;
+    private final ArrayList<Integer> mResIds;
+
+    public ImageSpinnerAdapter(Context context, ArrayList<String> names, ArrayList<Integer> resIds) {
+        super(context, R.layout.coin_image_spinner_item, names);
+        this.mContext = context;
+        this.mNames = names;
+        this.mResIds = resIds;
+    }
+
+    @NonNull
+    @Override
+    public View getView(int position, View convertView, @NonNull ViewGroup parent) {
+        return createCustomView(position, parent);
+    }
+
+    @Override
+    public View getDropDownView(int position, View convertView, @NonNull ViewGroup parent) {
+        return createCustomView(position, parent);
+    }
+
+    private View createCustomView(int position, ViewGroup parent) {
+        LayoutInflater inflater = LayoutInflater.from(mContext);
+        View view = inflater.inflate(R.layout.coin_image_spinner_item, parent, false);
+
+        // Set the text
+        TextView textView = (TextView) view;
+        textView.setText(mNames.get(position));
+
+        // Set the image
+        Drawable image = ContextCompat.getDrawable(mContext, mResIds.get(position));
+        textView.setCompoundDrawablesWithIntrinsicBounds(image, null, null, null);
+        return view;
+    }
+}

--- a/app/src/main/java/com/spencerpages/MainApplication.java
+++ b/app/src/main/java/com/spencerpages/MainApplication.java
@@ -127,8 +127,9 @@ public class MainApplication extends Application {
      * Version 18 - Used in Version 3.4.0 of the app
      * Version 19 - Used in Version 3.5.0 of the app
      * Version 20 - Used in Version 3.6.0 of the app
+     * Version 21 - Used in Version 3.7.0 of the app
      */
-    public static final int DATABASE_VERSION = 20;
+    public static final int DATABASE_VERSION = 21;
 
     /**
      * Get the collection index from collection type name

--- a/app/src/main/java/com/spencerpages/collections/AmericanEagleSilverDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/AmericanEagleSilverDollars.java
@@ -54,7 +54,7 @@ public class AmericanEagleSilverDollars extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         return OBVERSE_IMAGE_COLLECTED;
     }
 

--- a/app/src/main/java/com/spencerpages/collections/AmericanInnovationDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/AmericanInnovationDollars.java
@@ -86,7 +86,7 @@ public class AmericanInnovationDollars extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         Integer slotImage = COIN_MAP.get(coinSlot.getIdentifier());
         return (slotImage != null) ? slotImage : (int) COIN_IDENTIFIERS[0][1];
     }

--- a/app/src/main/java/com/spencerpages/collections/AmericanWomenQuarters.java
+++ b/app/src/main/java/com/spencerpages/collections/AmericanWomenQuarters.java
@@ -76,7 +76,7 @@ public class AmericanWomenQuarters extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         Integer slotImage = COIN_MAP.get(coinSlot.getIdentifier());
         return (slotImage != null) ? slotImage : (int) COIN_IDENTIFIERS[0][1];
     }

--- a/app/src/main/java/com/spencerpages/collections/BarberDimes.java
+++ b/app/src/main/java/com/spencerpages/collections/BarberDimes.java
@@ -57,7 +57,7 @@ public class BarberDimes extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         return OBVERSE_IMAGE_COLLECTED;
     }
 

--- a/app/src/main/java/com/spencerpages/collections/BarberHalfDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/BarberHalfDollars.java
@@ -57,7 +57,7 @@ public class BarberHalfDollars extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         return OBVERSE_IMAGE_COLLECTED;
     }
 

--- a/app/src/main/java/com/spencerpages/collections/BarberQuarters.java
+++ b/app/src/main/java/com/spencerpages/collections/BarberQuarters.java
@@ -57,7 +57,7 @@ public class BarberQuarters extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         return OBVERSE_IMAGE_COLLECTED;
     }
 

--- a/app/src/main/java/com/spencerpages/collections/BuffaloNickels.java
+++ b/app/src/main/java/com/spencerpages/collections/BuffaloNickels.java
@@ -56,7 +56,7 @@ public class BuffaloNickels extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         return OBVERSE_IMAGE_COLLECTED;
     }
 

--- a/app/src/main/java/com/spencerpages/collections/EisenhowerDollar.java
+++ b/app/src/main/java/com/spencerpages/collections/EisenhowerDollar.java
@@ -61,7 +61,7 @@ public class EisenhowerDollar extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         return OBVERSE_IMAGE_COLLECTED;
     }
 

--- a/app/src/main/java/com/spencerpages/collections/FirstSpouseGoldCoins.java
+++ b/app/src/main/java/com/spencerpages/collections/FirstSpouseGoldCoins.java
@@ -106,7 +106,7 @@ public class FirstSpouseGoldCoins extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         Integer slotImage = COIN_MAP.get(coinSlot.getIdentifier());
         return (slotImage != null) ? slotImage : (int) COIN_IDENTIFIERS[0][1];
     }

--- a/app/src/main/java/com/spencerpages/collections/FranklinHalfDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/FranklinHalfDollars.java
@@ -57,7 +57,7 @@ public class FranklinHalfDollars extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         return OBVERSE_IMAGE_COLLECTED;
     }
 

--- a/app/src/main/java/com/spencerpages/collections/IndianHeadCents.java
+++ b/app/src/main/java/com/spencerpages/collections/IndianHeadCents.java
@@ -56,7 +56,7 @@ public class IndianHeadCents extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         return OBVERSE_IMAGE_COLLECTED;
     }
 

--- a/app/src/main/java/com/spencerpages/collections/JeffersonNickels.java
+++ b/app/src/main/java/com/spencerpages/collections/JeffersonNickels.java
@@ -79,7 +79,7 @@ public class JeffersonNickels extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         Integer slotImage = COIN_MAP.get(coinSlot.getIdentifier());
         return (slotImage != null) ? slotImage : OBVERSE_IMAGE_COLLECTED;
     }

--- a/app/src/main/java/com/spencerpages/collections/KennedyHalfDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/KennedyHalfDollars.java
@@ -54,7 +54,7 @@ public class KennedyHalfDollars extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         return OBVERSE_IMAGE_COLLECTED;
     }
 

--- a/app/src/main/java/com/spencerpages/collections/LibertyHeadNickels.java
+++ b/app/src/main/java/com/spencerpages/collections/LibertyHeadNickels.java
@@ -57,7 +57,7 @@ public class LibertyHeadNickels extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         return OBVERSE_IMAGE_COLLECTED;
     }
 

--- a/app/src/main/java/com/spencerpages/collections/LincolnCents.java
+++ b/app/src/main/java/com/spencerpages/collections/LincolnCents.java
@@ -76,7 +76,7 @@ public class LincolnCents extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         Integer slotImage = COIN_MAP.get(coinSlot.getIdentifier());
         return (slotImage != null) ? slotImage : OBVERSE_IMAGE_COLLECTED;
     }

--- a/app/src/main/java/com/spencerpages/collections/MercuryDimes.java
+++ b/app/src/main/java/com/spencerpages/collections/MercuryDimes.java
@@ -57,7 +57,7 @@ public class MercuryDimes extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         return OBVERSE_IMAGE_COLLECTED;
     }
 

--- a/app/src/main/java/com/spencerpages/collections/MorganDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/MorganDollars.java
@@ -57,7 +57,7 @@ public class MorganDollars extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         return OBVERSE_IMAGE_COLLECTED;
     }
 

--- a/app/src/main/java/com/spencerpages/collections/NationalParkQuarters.java
+++ b/app/src/main/java/com/spencerpages/collections/NationalParkQuarters.java
@@ -121,7 +121,7 @@ public class NationalParkQuarters extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         Integer slotImage = COIN_MAP.get(coinSlot.getIdentifier());
         return (slotImage != null) ? slotImage : (int) COIN_IDENTIFIERS[0][1];
     }

--- a/app/src/main/java/com/spencerpages/collections/NativeAmericanDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/NativeAmericanDollars.java
@@ -82,7 +82,7 @@ public class NativeAmericanDollars extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         Integer slotImage = COIN_MAP.get(coinSlot.getIdentifier());
         return (slotImage != null) ? slotImage : OBVERSE_IMAGE_COLLECTED;
     }

--- a/app/src/main/java/com/spencerpages/collections/PeaceDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/PeaceDollars.java
@@ -57,7 +57,7 @@ public class PeaceDollars extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         return OBVERSE_IMAGE_COLLECTED;
     }
 

--- a/app/src/main/java/com/spencerpages/collections/PresidentialDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/PresidentialDollars.java
@@ -105,7 +105,7 @@ public class PresidentialDollars extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         Integer slotImage = COIN_MAP.get(coinSlot.getIdentifier());
         return (slotImage != null) ? slotImage : (int) COIN_IDENTIFIERS[0][1];
     }

--- a/app/src/main/java/com/spencerpages/collections/RooseveltDimes.java
+++ b/app/src/main/java/com/spencerpages/collections/RooseveltDimes.java
@@ -54,7 +54,7 @@ public class RooseveltDimes extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         return OBVERSE_IMAGE_COLLECTED;
     }
 

--- a/app/src/main/java/com/spencerpages/collections/StandingLibertyQuarters.java
+++ b/app/src/main/java/com/spencerpages/collections/StandingLibertyQuarters.java
@@ -57,7 +57,7 @@ public class StandingLibertyQuarters extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         return OBVERSE_IMAGE_COLLECTED;
     }
 

--- a/app/src/main/java/com/spencerpages/collections/StateQuarters.java
+++ b/app/src/main/java/com/spencerpages/collections/StateQuarters.java
@@ -125,7 +125,7 @@ public class StateQuarters extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         Integer slotImage = COIN_MAP.get(coinSlot.getIdentifier());
         return (slotImage != null) ? slotImage : (int) STATES_COIN_IDENTIFIERS[0][1];
     }

--- a/app/src/main/java/com/spencerpages/collections/SusanBAnthonyDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/SusanBAnthonyDollars.java
@@ -56,7 +56,7 @@ public class SusanBAnthonyDollars extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         return OBVERSE_IMAGE_COLLECTED;
     }
 

--- a/app/src/main/java/com/spencerpages/collections/WalkingLibertyHalfDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/WalkingLibertyHalfDollars.java
@@ -57,7 +57,7 @@ public class WalkingLibertyHalfDollars extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         return OBVERSE_IMAGE_COLLECTED;
     }
 

--- a/app/src/main/java/com/spencerpages/collections/WashingtonQuarters.java
+++ b/app/src/main/java/com/spencerpages/collections/WashingtonQuarters.java
@@ -72,7 +72,7 @@ public class WashingtonQuarters extends CollectionInfo {
     }
 
     @Override
-    public int getCoinSlotImage(CoinSlot coinSlot) {
+    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
         Integer slotImage = COIN_MAP.get(coinSlot.getIdentifier());
         return (slotImage != null) ? slotImage : OBVERSE_IMAGE_COLLECTED;
     }

--- a/app/src/main/res/layout/advanced_collection_slot.xml
+++ b/app/src/main/res/layout/advanced_collection_slot.xml
@@ -37,7 +37,7 @@
             android:id="@+id/grade_selector"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:minHeight="40dp"
+            android:minHeight="48dp"
             android:prompt="@string/select_grade" />
 
         <Spinner
@@ -47,7 +47,7 @@
             android:layout_below="@id/grade_selector"
             android:layout_alignEnd="@id/grade_selector"
             android:layout_alignRight="@id/grade_selector"
-            android:minHeight="40dp"
+            android:minHeight="48dp"
             android:prompt="@string/select_quantity" />
     </RelativeLayout>
 

--- a/app/src/main/res/layout/coin_image_spinner_item.xml
+++ b/app/src/main/res/layout/coin_image_spinner_item.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:drawablePadding="8dp"
+    android:gravity="center_vertical"
+    android:padding="8dp"
+    android:textSize="16sp" />

--- a/app/src/main/res/layout/coin_update_layout.xml
+++ b/app/src/main/res/layout/coin_update_layout.xml
@@ -1,56 +1,75 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:paddingStart="8dp"
+    android:paddingEnd="8dp">
 
-    <TextView
-        android:id="@+id/coin_name_text"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignTop="@id/coin_name_edittext"
-        android:layout_alignBottom="@id/coin_name_edittext"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentTop="true"
-        android:gravity="center_vertical"
-        android:text="@string/name_label" />
+        android:orientation="horizontal">
 
-    <EditText
-        android:id="@+id/coin_name_edittext"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentTop="true"
-        android:layout_alignParentEnd="true"
-        android:layout_alignParentRight="true"
-        android:layout_toEndOf="@id/coin_name_text"
-        android:layout_toRightOf="@id/coin_name_text"
-        android:importantForAutofill="no"
-        android:inputType="text"></EditText>
+        <TextView
+            android:id="@+id/coin_name_text"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center_vertical"
+            android:text="@string/name_label" />
 
-    <TextView
-        android:id="@+id/coin_mint_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/coin_name_text"
-        android:layout_alignTop="@id/coin_mint_edittext"
-        android:layout_alignEnd="@id/coin_name_text"
-        android:layout_alignRight="@id/coin_name_text"
-        android:layout_alignBottom="@id/coin_mint_edittext"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentLeft="true"
-        android:gravity="center_vertical"
-        android:text="@string/mint_label" />
+        <EditText
+            android:id="@+id/coin_name_edittext"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="5"
+            android:minHeight="48dp"
+            android:inputType="text" />
+    </LinearLayout>
 
-    <EditText
-        android:id="@+id/coin_mint_edittext"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@id/coin_name_edittext"
-        android:layout_alignParentEnd="true"
-        android:layout_alignParentRight="true"
-        android:layout_toEndOf="@id/coin_mint_text"
-        android:layout_toRightOf="@id/coin_mint_text"
-        android:importantForAutofill="no"
-        android:inputType="text"></EditText>
-</RelativeLayout>
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/coin_mint_text"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center_vertical"
+            android:text="@string/mint_label" />
+
+        <EditText
+            android:id="@+id/coin_mint_edittext"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="5"
+            android:minHeight="48dp"
+            android:inputType="text" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/coin_image_row"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/coin_image_text"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center_vertical"
+            android:minHeight="48dp"
+            android:text="@string/image_label" />
+
+        <Spinner
+            android:id="@+id/coin_image_select"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="5"
+            android:prompt="@string/select_image" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,6 +97,7 @@
     <string name="select_coin_type">Select Coin Type</string>
     <string name="select_grade">Grade</string>
     <string name="select_quantity">Quantity</string>
+    <string name="select_image">Coin Image</string>
     <string name="unsaved_message">Unsaved Changes</string>
     <string name="notes">Notes</string>
     <string name="change_view_string">Change Views</string>
@@ -106,6 +107,7 @@
     <string name="okay_exp">Okay!</string>
     <string name="okay">Okay</string>
     <string name="cancel">Cancel</string>
+    <string name="img_default">Default</string>
     <string name="collection_completion_template">%1$d/%2$d"</string>
     <string name="collection_complete">Collection Complete!</string>
     <string name="select_collection_name">Select a new collection name</string>
@@ -192,6 +194,7 @@
     <string name="edit_coin_info">Edit coin details</string>
     <string name="name_label">Name:</string>
     <string name="mint_label">Mint:</string>
+    <string name="image_label">Image:</string>
     <string name="tutorial_edit_copy_delete_coins">Press and hold on a coin image to edit, copy, or delete!</string>
     <string name="save_changes_first">This collection has unsaved changes. Please save changes before performing this action.</string>
 

--- a/app/src/test/java/com/spencerpages/CoinImageIdTests.java
+++ b/app/src/test/java/com/spencerpages/CoinImageIdTests.java
@@ -1,0 +1,118 @@
+/*
+ * Coin Collection, an Android app that helps users track the coins that they've collected
+ * Copyright (C) 2010-2016 Andrew Williams
+ *
+ * This file is part of Coin Collection.
+ *
+ * Coin Collection is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Coin Collection is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Coin Collection.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.spencerpages;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Intent;
+import android.os.Build;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.core.app.ApplicationProvider;
+
+import com.coincollection.CoinSlot;
+import com.coincollection.CollectionInfo;
+import com.coincollection.MainActivity;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.ParameterizedRobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.Arrays;
+import java.util.List;
+
+@RunWith(ParameterizedRobolectricTestRunner.class)
+// TODO - Must keep at 28 until Robolectric supports Java 9 (required to use 29+)
+@Config(sdk = Build.VERSION_CODES.P)
+public class CoinImageIdTests extends BaseTestCase {
+
+    private final CollectionInfo mCoinTypeObj;
+
+    public CoinImageIdTests(CollectionInfo coinTypeObj) {
+        mCoinTypeObj = coinTypeObj;
+    }
+
+    @ParameterizedRobolectricTestRunner.Parameters
+    public static List<?> getCoinTypeObj() {
+        return Arrays.asList(MainApplication.COLLECTION_TYPES);
+    }
+
+    /**
+     * Test that calling getCoinSlotImage() on collections that use image IDs returns
+     * an index within the bounds of the IMAGE ID list.
+     */
+    @Test
+    public void test_getCoinSlotImage() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class)
+                        .putExtra(MainActivity.UNIT_TEST_USE_ASYNC_TASKS, false))) {
+            scenario.onActivity(activity -> {
+                for (FullCollection scenario1 : getRandomTestScenarios(mCoinTypeObj, 1)) {
+                    // Add a coin into the collection used for this test
+                    scenario1.mCoinList.add(0, new CoinSlot("Name", "Mint", 0, -1));
+
+                    // Cover the range of possible image ids for this collection
+                    CollectionInfo collectionInfo = scenario1.mCollectionListInfo.getCollectionObj();
+                    Object[][] imageIds = collectionInfo.getImageIds();
+                    for(int i = 0; i < imageIds.length; i++) {
+                        // Test that getCoinSlotImage(false) gives the correct resource IDs
+                        CoinSlot coinSlot = scenario1.mCoinList.get(0);
+                        coinSlot.setImageId(i);
+                        int resId = collectionInfo.getCoinSlotImage(coinSlot, false);
+                        assertEquals((int)imageIds[i][1], resId);
+
+                        // Test that getCoinSlotImage(true) correctly ignores the image ID
+                        coinSlot.setImageId(-1);
+                        int chkResId = collectionInfo.getCoinSlotImage(coinSlot, false);
+                        coinSlot.setImageId(i);
+                        resId = collectionInfo.getCoinSlotImage(coinSlot, true);
+                        assertEquals(chkResId, resId);
+                    }
+                }
+            });
+        }
+    }
+
+    /**
+     * Test that creating collections does not assign image IDs that are out-of-bounds
+     * of the IMAGE ID list.
+     */
+    @Test
+    public void test_imageIdCreation() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class)
+                        .putExtra(MainActivity.UNIT_TEST_USE_ASYNC_TASKS, false))) {
+            scenario.onActivity(activity -> {
+                for (FullCollection scenario1 : getRandomTestScenarios(mCoinTypeObj, 5)) {
+                    // Assert that collection creation didn't allocate any invalid image IDs
+                    CollectionInfo collectionInfo = scenario1.mCollectionListInfo.getCollectionObj();
+                    Object[][] imageIds = collectionInfo.getImageIds();
+                    for (CoinSlot coinSlot : scenario1.mCoinList) {
+                        assertTrue(coinSlot.getImageId() >= -1);
+                        assertTrue(coinSlot.getImageId() < imageIds.length);
+                    }
+                }
+            });
+        }
+    }
+}

--- a/app/src/test/java/com/spencerpages/CollectionPageActivityTests.java
+++ b/app/src/test/java/com/spencerpages/CollectionPageActivityTests.java
@@ -95,12 +95,12 @@ public class CollectionPageActivityTests extends BaseTestCase {
                         activity.copyCoinSlot(activity.mCoinList.get(lastIndex), lastIndex + 1);
 
                         // Update coin names
-                        activity.updateCoinDetails(activity.mCoinList.get(0), "First Coin", "First");
-                        activity.updateCoinDetails(activity.mCoinList.get(1), "Second Coin", "Second");
-                        activity.updateCoinDetails(activity.mCoinList.get(2), "Third Coin", "Third");
+                        activity.updateCoinDetails(activity.mCoinList.get(0), "First Coin", "First", -1);
+                        activity.updateCoinDetails(activity.mCoinList.get(1), "Second Coin", "Second", -1);
+                        activity.updateCoinDetails(activity.mCoinList.get(2), "Third Coin", "Third", -1);
 
                         lastIndex = activity.mCoinList.size() - 1;
-                        activity.updateCoinDetails(activity.mCoinList.get(lastIndex), "Last Coin", "Last");
+                        activity.updateCoinDetails(activity.mCoinList.get(lastIndex), "Last Coin", "Last", -1);
 
                         // Delete coins
                         activity.deleteCoinSlotAtPosition(0);
@@ -110,8 +110,8 @@ public class CollectionPageActivityTests extends BaseTestCase {
 
                         // Add coins
                         activity.copyCoinSlot(activity.mCoinList.get(0), 1);
-                        activity.updateCoinDetails(activity.mCoinList.get(0), "First Coin2", "First2");
-                        activity.addNewCoin("New Coin", "Coin Mint");
+                        activity.updateCoinDetails(activity.mCoinList.get(0), "First Coin2", "First2", -1);
+                        activity.addNewCoin("New Coin", "Coin Mint", -1);
                     }
 
                     // Check that the copied collection was made correctly in the database

--- a/shared-test/src/main/java/com/spencerpages/SharedTest.java
+++ b/shared-test/src/main/java/com/spencerpages/SharedTest.java
@@ -75,11 +75,11 @@ public class SharedTest {
 
     public static final CoinSlot[] COIN_SLOT_SCENARIOS =
             {
-                    new CoinSlot(0, "1989", "", true, 0, 0, "", 0, false),
-                    new CoinSlot(1, "1776-1976", "P", false, 2, 10, "Advanced Notes", 1, false),
-                    new CoinSlot(2, "State Park", "CC", true, 20, 1, "293370#$%@#^$#@^", 2, false),
-                    new CoinSlot(3, "2000 Type 1", "D", true, 0, 0, "These are my notes\n\n", 3, false),
-                    new CoinSlot(4, "Some Coin", "S", false, 11, 11, "", 4, false),
+                    new CoinSlot(0, "1989", "", true, 0, 0, "", 0, false, -1),
+                    new CoinSlot(1, "1776-1976", "P", false, 2, 10, "Advanced Notes", 1, false, -1),
+                    new CoinSlot(2, "State Park", "CC", true, 20, 1, "293370#$%@#^$#@^", 2, false, -1),
+                    new CoinSlot(3, "2000 Type 1", "D", true, 0, 0, "These are my notes\n\n", 3, false, -1),
+                    new CoinSlot(4, "Some Coin", "S", false, 11, 11, "", 4, false, -1),
             };
 
     public static final ParcelableHashMap[] PARAMETER_SCENARIOS =


### PR DESCRIPTION
This PR adds image ids for coins which allows:
1. Collections can define an exact coin image to show for each coin, and don't need to rely on just the name/mint
2. Users can edit which image to display for each coin (for collections that support image ids).

No collections actually support image ids as part of this PR, but support will be added to new collections being worked on currently and we can go through and add to existing collections as it makes sense.

To update a collection, add the following:
```
...
    // Remember not to reorder this list and always add new one to the end
    private static final Object[][] COIN_IMG_IDS = {
        {"Coin A", R.drawable.women_2024_celia_cruz_unc},
        {"Coin B", R.drawable.women_2024_zitkala_sa_unc}
    };
...
    public int getCoinSlotImage(CoinSlot coinSlot, boolean ignoreImageId) {
        Integer slotImage;
        Integer imageId = coinSlot.getImageId();
        if (!ignoreImageId && (imageId >= 0 && imageId < COIN_IMG_IDS.length)) {
            slotImage = (Integer) COIN_IMG_IDS[imageId][1];
        } else {
            slotImage = COIN_MAP.get(coinSlot.getIdentifier());
        }
        return (slotImage != null) ? slotImage : (int) COIN_IDENTIFIERS[0][1];
    }
...
    @Override
    public Object[][] getImageIds() {
        return COIN_IMG_IDS;
    }
```

Note: with this update, getCoinSlotImage() has a new argument, `ignoreImageId`. This should be used to ignore the imageId field and to use the 'default' rules for determining the coin image. This allows the user to revert back to the 'default' at a later time, should they want to.

