### PR TITLE
Adding support for more mint marks/checkboxes

### DIFF
--- a/app/src/main/java/com/coincollection/BaseActivity.java
+++ b/app/src/main/java/com/coincollection/BaseActivity.java
@@ -164,7 +164,7 @@ public class BaseActivity extends AppCompatActivity implements AsyncProgressInte
      */
     @Override
     public void asyncProgressOnPostExecute(String resultStr) {
-        if (!resultStr.equals("")) {
+        if (!resultStr.isEmpty()) {
             showCancelableAlert(resultStr);
         }
     }

--- a/app/src/main/java/com/coincollection/CoinPageCreator.java
+++ b/app/src/main/java/com/coincollection/CoinPageCreator.java
@@ -555,8 +555,8 @@ public class CoinPageCreator extends BaseActivity {
 
         // Show a warning if changing the mint marks would remove some coins
         if (warningResId == -1) {
-            int mintMarkFlags = getMintMarkFlagsFromParameters(mParameters);
-            int checkboxFlags = getCheckboxFlagsFromParameters(mParameters);
+            long mintMarkFlags = getMintMarkFlagsFromParameters(mParameters);
+            long checkboxFlags = getCheckboxFlagsFromParameters(mParameters);
             if (mExistingCollection.checkIfNewFlagsRemoveCoins(mintMarkFlags, checkboxFlags)) {
                 warningResId = R.string.warning_collection_options_changed;
             }
@@ -1008,8 +1008,8 @@ public class CoinPageCreator extends BaseActivity {
      * @param parameters the user-selected parameters
      * @return mint mark flags
      */
-    public static int getMintMarkFlagsFromParameters(HashMap<String, Object> parameters) {
-        int mintMarkFlags = 0;
+    public static long getMintMarkFlagsFromParameters(HashMap<String, Object> parameters) {
+        long mintMarkFlags = 0;
         for (String optName : SHOW_MINT_MARK_CHECKBOX_STRING_ID_OPT_MAP.keySet()) {
             String stringIdOptName = SHOW_MINT_MARK_CHECKBOX_STRING_ID_OPT_MAP.get(optName);
             Boolean optionValue = (Boolean) parameters.get(optName);
@@ -1063,8 +1063,8 @@ public class CoinPageCreator extends BaseActivity {
      * @param parameters the user-selected parameters
      * @return checkbox flags
      */
-    public static int getCheckboxFlagsFromParameters(HashMap<String, Object> parameters) {
-        int checkboxFlags = 0;
+    public static long getCheckboxFlagsFromParameters(HashMap<String, Object> parameters) {
+        long checkboxFlags = 0;
         for (String optName : CUSTOMIZABLE_CHECKBOX_STRING_ID_OPT_MAP.keySet()) {
             String stringIdOptName = CUSTOMIZABLE_CHECKBOX_STRING_ID_OPT_MAP.get(optName);
             Boolean optionValue = (Boolean) parameters.get(optName);
@@ -1173,8 +1173,8 @@ public class CoinPageCreator extends BaseActivity {
         for (CoinSlot coinSlot : mCoinList) {
             totalCollected += coinSlot.isInCollectionInt();
         }
-        int mintMarkFlags = getMintMarkFlagsFromParameters(mParameters);
-        int checkboxFlags = getCheckboxFlagsFromParameters(mParameters);
+        long mintMarkFlags = getMintMarkFlagsFromParameters(mParameters);
+        long checkboxFlags = getCheckboxFlagsFromParameters(mParameters);
         int displayType = (mExistingCollection != null)
                 ? mExistingCollection.getDisplayType() : SIMPLE_DISPLAY;
         Integer startYear = (Integer) mParameters.get(OPT_START_YEAR);
@@ -1187,8 +1187,8 @@ public class CoinPageCreator extends BaseActivity {
                 displayType,
                 (startYear != null) ? startYear : 0,
                 (stopYear != null) ? stopYear : 0,
-                mintMarkFlags,
-                checkboxFlags);
+                Long.toString(mintMarkFlags),
+                Long.toString(checkboxFlags));
     }
 
     /**

--- a/app/src/main/java/com/coincollection/CollectionInfo.java
+++ b/app/src/main/java/com/coincollection/CollectionInfo.java
@@ -93,9 +93,6 @@ public abstract class CollectionInfo {
     /**
      * Performs any updates to a collection's database tables.  This allows
      * new coins to be added, incorrect coins to be fixed, etc.
-     * <p>
-     * TODO Document collection database fields
-     * <p>
      * The function should only operate on the tableName provided, and MUST
      * return the total number of coins added or removed from the collection
      * (this is used to keep an accurate count in the database table that

--- a/app/src/main/java/com/coincollection/CollectionListInfo.java
+++ b/app/src/main/java/com/coincollection/CollectionListInfo.java
@@ -69,75 +69,72 @@ public class CollectionListInfo implements Parcelable {
     private final int mDisplayType;
     private int mStartYear;
     private int mEndYear;
-    private int mMintMarkFlags;
-    private int mCheckboxFlags;
+    private String mMintMarkFlags;
+    private String mCheckboxFlags;
     private final CollectionInfo mCollectionInfo;
 
     // Flags for selected mint marks
-    public final static int ALL_MINT_MASK = 0x7FFF;
-    public final static int SHOW_MINT_MARKS = 0x1;
-    public final static int MINT_P = 0x2;
-    public final static int MINT_D = 0x4;
-    public final static int MINT_S = 0x8;
-    public final static int MINT_O = 0x10;
-    public final static int MINT_CC = 0x20;
-    public final static int MINT_W = 0x40;
-    public final static int MINT_S_PROOF = 0x80;
-    public final static int MINT_SILVER_PROOF = 0x100;
-    public final static int MINT_REV_PROOF = 0x200;
-    public final static int MINT_MEM_PROOF = 0x400;
-    public final static int MINT_SATIN = 0x800;
-    public final static int MINT_SETS = 0x1000;
-    public final static int MINT_PROOF_SETS = 0x2000;
-    public final static int MINT_SILVER_PROOF_SETS = 0x4000;
+    public final static long ALL_MINT_MASK = 0x7FFFL;
+    public final static long SHOW_MINT_MARKS = 0x1L;
+    public final static long MINT_P = 0x2L;
+    public final static long MINT_D = 0x4L;
+    public final static long MINT_S = 0x8L;
+    public final static long MINT_O = 0x10L;
+    public final static long MINT_CC = 0x20L;
+    public final static long MINT_W = 0x40L;
+    public final static long MINT_S_PROOF = 0x80L;
+    public final static long MINT_SILVER_PROOF = 0x100L;
+    public final static long MINT_REV_PROOF = 0x200L;
+    public final static long MINT_MEM_PROOF = 0x400L;
+    public final static long MINT_SATIN = 0x800L;
+    public final static long MINT_SETS = 0x1000L;
+    public final static long MINT_PROOF_SETS = 0x2000L;
+    public final static long MINT_SILVER_PROOF_SETS = 0x4000L;
 
     // Flags for show checkboxes options
-    public final static int ALL_CHECKBOXES_MASK = 0xFFFFFFFF;
-    public final static int CUSTOM_DATES = 0x1;
-    public final static int BURNISHED = 0x2;
-    public final static int TERRITORIES = 0x4;
-    public final static int SILVER_COINS = 0x8;
-    public final static int NICKEL_COINS = 0x10;
-    public final static int OLD_COINS = 0x20;
-    public final static int BUST_COINS = 0x40;
-    public final static int DRAPED_BUST_COINS = 0x80;
-    public final static int CAPPED_BUST_COINS = 0x100;
-    public final static int SEATED_COINS = 0x200;
-    public final static int CORONET_COINS = 0x400;
-    public final static int BARBER_QUARTERS = 0x800;
-    public final static int STANDING_QUARTERS = 0x1000;
-    public final static int CLASSIC_QUARTERS = 0x2000;
-    public final static int STATES_QUARTERS = 0x4000;
-    public final static int PARKS_QUARTERS = 0x8000;
-    public final static int WOMEN_QUARTERS = 0x10000;
-    public final static int EAGLE_CENTS = 0x20000;
-    public final static int INDIAN_CENTS = 0x40000;
-    public final static int WHEAT_CENTS = 0x80000;
-    public final static int MEMORIAL_CENTS = 0x100000;
-    public final static int BARBER_HALF = 0x200000;
-    public final static int WALKER_HALF = 0x400000;
-    public final static int FRANKLIN_HALF = 0x800000;
-    public final static int KENNEDY_HALF = 0x1000000;
-    public final static int SHIELD_NICKELS = 0x2000000;
-    public final static int LIBERTY_NICKELS = 0x4000000;
-    public final static int BUFFALO_NICKELS = 0x8000000;
-    public final static int JEFFERSON_NICKELS = 0x10000000;
-    public final static int BARBER_DIMES = 0x20000000;
-    public final static int MERCURY_DIMES = 0x40000000;
-    public final static int ROOSEVELT_DIMES = 0x80000000;
-    // Note: IDs below are shared with those above since currently a max
-    // of 32 are supported. This is fine as long as we don't ever expect
-    // them to be in the same collection together.
-    public final static int MORGAN_DOLLARS = 0x4; // Shared w/ TERRITORIES
-    public final static int PEACE_DOLLARS = 0x800; // Shared w/ BARBER_QUARTERS
-    public final static int IKE_DOLLARS = 0x1000; // Shared w/ STANDING_QUARTERS
-    public final static int EAGLE_DOLLARS = 0x4000; // Shared w/ STATES_QUARTERS
-    public final static int SBA_DOLLARS = 0x8000; // Shared w/ PARKS_QUARTERS
-    public final static int SAC_DOLLARS = 0x20000; // Shared w/ EAGLE_CENTS
-    public final static int PRES_DOLLARS = 0x40000; // Shared w/ INDIAN_CENTS
-    public final static int TRADE_DOLLARS = 0x80000; // Shared w/ WHEAT_CENTS
+    public final static long ALL_CHECKBOXES_MASK = 0xFFFFFFFFFFL;
+    public final static long CUSTOM_DATES = 0x1L;
+    public final static long BURNISHED = 0x2L;
+    public final static long TERRITORIES = 0x4L;
+    public final static long SILVER_COINS = 0x8L;
+    public final static long NICKEL_COINS = 0x10L;
+    public final static long OLD_COINS = 0x20L;
+    public final static long BUST_COINS = 0x40L;
+    public final static long DRAPED_BUST_COINS = 0x80L;
+    public final static long CAPPED_BUST_COINS = 0x100L;
+    public final static long SEATED_COINS = 0x200L;
+    public final static long CORONET_COINS = 0x400L;
+    public final static long BARBER_QUARTERS = 0x800L;
+    public final static long STANDING_QUARTERS = 0x1000L;
+    public final static long CLASSIC_QUARTERS = 0x2000L;
+    public final static long STATES_QUARTERS = 0x4000L;
+    public final static long PARKS_QUARTERS = 0x8000L;
+    public final static long WOMEN_QUARTERS = 0x10000L;
+    public final static long EAGLE_CENTS = 0x20000L;
+    public final static long INDIAN_CENTS = 0x40000L;
+    public final static long WHEAT_CENTS = 0x80000L;
+    public final static long MEMORIAL_CENTS = 0x100000L;
+    public final static long BARBER_HALF = 0x200000L;
+    public final static long WALKER_HALF = 0x400000L;
+    public final static long FRANKLIN_HALF = 0x800000L;
+    public final static long KENNEDY_HALF = 0x1000000L;
+    public final static long SHIELD_NICKELS = 0x2000000L;
+    public final static long LIBERTY_NICKELS = 0x4000000L;
+    public final static long BUFFALO_NICKELS = 0x8000000L;
+    public final static long JEFFERSON_NICKELS = 0x10000000L;
+    public final static long BARBER_DIMES = 0x20000000L;
+    public final static long MERCURY_DIMES = 0x40000000L;
+    public final static long ROOSEVELT_DIMES = 0x80000000L;
+    public final static long MORGAN_DOLLARS = 0x100000000L;
+    public final static long PEACE_DOLLARS = 0x200000000L;
+    public final static long IKE_DOLLARS = 0x400000000L;
+    public final static long EAGLE_DOLLARS = 0x800000000L;
+    public final static long SBA_DOLLARS = 0x1000000000L;
+    public final static long SAC_DOLLARS = 0x2000000000L;
+    public final static long PRES_DOLLARS = 0x4000000000L;
+    public final static long TRADE_DOLLARS = 0x8000000000L;
 
-    public final static HashMap<String, Integer> MINT_STRING_TO_FLAGS = new HashMap<>();
+    public final static HashMap<String, Long> MINT_STRING_TO_FLAGS = new HashMap<>();
 
     static {
         MINT_STRING_TO_FLAGS.put("P", MINT_P);
@@ -157,8 +154,10 @@ public class CollectionListInfo implements Parcelable {
     public final static String COL_DISPLAY = "display";
     public final static String COL_START_YEAR = "startYear";
     public final static String COL_END_YEAR = "endYear";
-    public final static String COL_SHOW_MINT_MARKS = "showMintMarks";
-    public final static String COL_SHOW_CHECKBOXES = "showCheckboxes";
+    public final static String COL_SHOW_MINT_MARKS_LEGACY = "showMintMarks";
+    public final static String COL_SHOW_MINT_MARKS = "showMintMarksStr";
+    public final static String COL_SHOW_CHECKBOXES_LEGACY = "showCheckboxes";
+    public final static String COL_SHOW_CHECKBOXES = "showCheckboxesStr";
     public final static String JSON_KEY_COLLECTED = "collected";
 
     // Collections in this list use the start/end years
@@ -186,8 +185,8 @@ public class CollectionListInfo implements Parcelable {
             WashingtonQuarters.COLLECTION_TYPE));
 
     public CollectionListInfo(String name, int max, int collected, int index, int displayType,
-                              int startYear, int stopYear, int mintMarkFlags,
-                              int checkboxFlags) {
+                              int startYear, int stopYear, String mintMarkFlags,
+                              String checkboxFlags) {
         mCollectionName = name;
         mTotalCoinsInCollection = max;
         mTotalCoinsCollected = collected;
@@ -272,232 +271,248 @@ public class CollectionListInfo implements Parcelable {
         return mEndYear;
     }
 
-    public int getMintMarkFlags() {
+    public String getMintMarkFlags() {
         return mMintMarkFlags;
     }
 
-    public int getCheckboxFlags() {
+    public long getMintMarkFlagsAsLong() {
+        if (mMintMarkFlags.isEmpty()){
+            return 0L;
+        } else {
+            return Long.parseLong(mMintMarkFlags);
+        }
+    }
+
+    public String getCheckboxFlags() {
         return mCheckboxFlags;
     }
 
+    public long getCheckboxFlagsAsLong() {
+        if (mCheckboxFlags.isEmpty()){
+            return 0L;
+        } else {
+            return Long.parseLong(mCheckboxFlags);
+        }
+    }
+
     public boolean hasMintMarks() {
-        return (mMintMarkFlags & SHOW_MINT_MARKS) != 0;
+        return (getMintMarkFlagsAsLong() & SHOW_MINT_MARKS) != 0;
     }
 
     public boolean hasPMintMarks() {
-        return (mMintMarkFlags & MINT_P) != 0;
+        return (getMintMarkFlagsAsLong() & MINT_P) != 0;
     }
 
     public boolean hasDMintMarks() {
-        return (mMintMarkFlags & MINT_D) != 0;
+        return (getMintMarkFlagsAsLong() & MINT_D) != 0;
     }
 
     public boolean hasSMintMarks() {
-        return (mMintMarkFlags & MINT_S) != 0;
+        return (getMintMarkFlagsAsLong() & MINT_S) != 0;
     }
 
     public boolean hasOMintMarks() {
-        return (mMintMarkFlags & MINT_O) != 0;
+        return (getMintMarkFlagsAsLong() & MINT_O) != 0;
     }
 
     public boolean hasCCMintMarks() {
-        return (mMintMarkFlags & MINT_CC) != 0;
+        return (getMintMarkFlagsAsLong() & MINT_CC) != 0;
     }
 
     public boolean hasWMintMarks() {
-        return (mMintMarkFlags & MINT_W) != 0;
+        return (getMintMarkFlagsAsLong() & MINT_W) != 0;
     }
 
     public boolean hasSProofMintMarks() {
-        return (mMintMarkFlags & MINT_S_PROOF) != 0;
+        return (getMintMarkFlagsAsLong() & MINT_S_PROOF) != 0;
     }
 
     public boolean hasSilverProofMintMarks() {
-        return (mMintMarkFlags & MINT_SILVER_PROOF) != 0;
+        return (getMintMarkFlagsAsLong() & MINT_SILVER_PROOF) != 0;
     }
 
     public boolean hasRevProofMintMarks() {
-        return (mMintMarkFlags & MINT_REV_PROOF) != 0;
+        return (getMintMarkFlagsAsLong() & MINT_REV_PROOF) != 0;
     }
 
     public boolean hasMemProofMintMarks() {
-        return (mMintMarkFlags & MINT_MEM_PROOF) != 0;
+        return (getMintMarkFlagsAsLong() & MINT_MEM_PROOF) != 0;
     }
 
     public boolean hasSatinMintMarks() {
-        return (mMintMarkFlags & MINT_SATIN) != 0;
+        return (getMintMarkFlagsAsLong() & MINT_SATIN) != 0;
     }
 
     public boolean hasMintSetsMintMarks() {
-        return (mMintMarkFlags & MINT_SETS) != 0;
+        return (getMintMarkFlagsAsLong() & MINT_SETS) != 0;
     }
 
     public boolean hasProofSetsMintMarks() {
-        return (mMintMarkFlags & MINT_PROOF_SETS) != 0;
+        return (getMintMarkFlagsAsLong() & MINT_PROOF_SETS) != 0;
     }
 
     public boolean hasSilverProofSetsMintMarks() {
-        return (mMintMarkFlags & MINT_SILVER_PROOF_SETS) != 0;
+        return (getMintMarkFlagsAsLong() & MINT_SILVER_PROOF_SETS) != 0;
     }
 
     public boolean hasCustomDates() {
-        return (mCheckboxFlags & CUSTOM_DATES) != 0;
+        return (getCheckboxFlagsAsLong() & CUSTOM_DATES) != 0;
     }
 
     public boolean hasBurnishedCoins() {
-        return (mCheckboxFlags & BURNISHED) != 0;
+        return (getCheckboxFlagsAsLong() & BURNISHED) != 0;
     }
 
     public boolean hasTerritoryCoins() {
-        return (mCheckboxFlags & TERRITORIES) != 0;
+        return (getCheckboxFlagsAsLong() & TERRITORIES) != 0;
     }
 
     public boolean hasSilverCoins() {
-        return (mCheckboxFlags & SILVER_COINS) != 0;
+        return (getCheckboxFlagsAsLong() & SILVER_COINS) != 0;
     }
 
     public boolean hasNickelCoins() {
-        return (mCheckboxFlags & NICKEL_COINS) != 0;
+        return (getCheckboxFlagsAsLong() & NICKEL_COINS) != 0;
     }
 
     public boolean hasOldCoins() {
-        return (mCheckboxFlags & OLD_COINS) != 0;
+        return (getCheckboxFlagsAsLong() & OLD_COINS) != 0;
     }
 
     public boolean hasBustCoins() {
-        return (mCheckboxFlags & BUST_COINS) != 0;
+        return (getCheckboxFlagsAsLong() & BUST_COINS) != 0;
     }
 
     public boolean hasDrapedBustCoins() {
-        return (mCheckboxFlags & DRAPED_BUST_COINS) != 0;
+        return (getCheckboxFlagsAsLong() & DRAPED_BUST_COINS) != 0;
     }
 
     public boolean hasCappedBustCoins() {
-        return (mCheckboxFlags & CAPPED_BUST_COINS) != 0;
+        return (getCheckboxFlagsAsLong() & CAPPED_BUST_COINS) != 0;
     }
 
     public boolean hasSeatedCoins() {
-        return (mCheckboxFlags & SEATED_COINS) != 0;
+        return (getCheckboxFlagsAsLong() & SEATED_COINS) != 0;
     }
 
     public boolean hasCoronetCoins() {
-        return (mCheckboxFlags & CORONET_COINS) != 0;
+        return (getCheckboxFlagsAsLong() & CORONET_COINS) != 0;
     }
 
     public boolean hasBarberQuarters() {
-        return (mCheckboxFlags & BARBER_QUARTERS) != 0;
+        return (getCheckboxFlagsAsLong() & BARBER_QUARTERS) != 0;
     }
 
     public boolean hasStandingQuarters() {
-        return (mCheckboxFlags & STANDING_QUARTERS) != 0;
+        return (getCheckboxFlagsAsLong() & STANDING_QUARTERS) != 0;
     }
 
     public boolean hasClassicQuarters() {
-        return (mCheckboxFlags & CLASSIC_QUARTERS) != 0;
+        return (getCheckboxFlagsAsLong() & CLASSIC_QUARTERS) != 0;
     }
 
     public boolean hasStatesQuarters() {
-        return (mCheckboxFlags & STATES_QUARTERS) != 0;
+        return (getCheckboxFlagsAsLong() & STATES_QUARTERS) != 0;
     }
 
     public boolean hasParksQuarters() {
-        return (mCheckboxFlags & PARKS_QUARTERS) != 0;
+        return (getCheckboxFlagsAsLong() & PARKS_QUARTERS) != 0;
     }
 
     public boolean hasWomenQuarters() {
-        return (mCheckboxFlags & WOMEN_QUARTERS) != 0;
+        return (getCheckboxFlagsAsLong() & WOMEN_QUARTERS) != 0;
     }
 
     public boolean hasEagleCents() {
-        return (mCheckboxFlags & EAGLE_CENTS) != 0;
+        return (getCheckboxFlagsAsLong() & EAGLE_CENTS) != 0;
     }
 
     public boolean hasIndianCents() {
-        return (mCheckboxFlags & INDIAN_CENTS) != 0;
+        return (getCheckboxFlagsAsLong() & INDIAN_CENTS) != 0;
     }
 
     public boolean hasWheatCents() {
-        return (mCheckboxFlags & WHEAT_CENTS) != 0;
+        return (getCheckboxFlagsAsLong() & WHEAT_CENTS) != 0;
     }
 
     public boolean hasMemorialCents() {
-        return (mCheckboxFlags & MEMORIAL_CENTS) != 0;
+        return (getCheckboxFlagsAsLong() & MEMORIAL_CENTS) != 0;
     }
 
     public boolean hasBarberHalf() {
-        return (mCheckboxFlags & BARBER_HALF) != 0;
+        return (getCheckboxFlagsAsLong() & BARBER_HALF) != 0;
     }
 
     public boolean hasWalkerHalf() {
-        return (mCheckboxFlags & WALKER_HALF) != 0;
+        return (getCheckboxFlagsAsLong() & WALKER_HALF) != 0;
     }
 
     public boolean hasFranklinHalf() {
-        return (mCheckboxFlags & FRANKLIN_HALF) != 0;
+        return (getCheckboxFlagsAsLong() & FRANKLIN_HALF) != 0;
     }
 
     public boolean hasKennedyHalf() {
-        return (mCheckboxFlags & KENNEDY_HALF) != 0;
+        return (getCheckboxFlagsAsLong() & KENNEDY_HALF) != 0;
     }
 
     public boolean hasShieldNickels() {
-        return (mCheckboxFlags & SHIELD_NICKELS) != 0;
+        return (getCheckboxFlagsAsLong() & SHIELD_NICKELS) != 0;
     }
 
     public boolean hasLibertyNickels() {
-        return (mCheckboxFlags & LIBERTY_NICKELS) != 0;
+        return (getCheckboxFlagsAsLong() & LIBERTY_NICKELS) != 0;
     }
 
     public boolean hasBuffaloNickels() {
-        return (mCheckboxFlags & BUFFALO_NICKELS) != 0;
+        return (getCheckboxFlagsAsLong() & BUFFALO_NICKELS) != 0;
     }
 
     public boolean hasJeffersonNickels() {
-        return (mCheckboxFlags & JEFFERSON_NICKELS) != 0;
+        return (getCheckboxFlagsAsLong() & JEFFERSON_NICKELS) != 0;
     }
 
     public boolean hasBarberDimes() {
-        return (mCheckboxFlags & BARBER_DIMES) != 0;
+        return (getCheckboxFlagsAsLong() & BARBER_DIMES) != 0;
     }
 
     public boolean hasMercuryDimes() {
-        return (mCheckboxFlags & MERCURY_DIMES) != 0;
+        return (getCheckboxFlagsAsLong() & MERCURY_DIMES) != 0;
     }
 
     public boolean hasRooseveltDimes() {
-        return (mCheckboxFlags & ROOSEVELT_DIMES) != 0;
+        return (getCheckboxFlagsAsLong() & ROOSEVELT_DIMES) != 0;
     }
 
     public boolean hasMorganDollars() {
-        return (mCheckboxFlags & MORGAN_DOLLARS) != 0;
+        return (getCheckboxFlagsAsLong() & MORGAN_DOLLARS) != 0;
     }
 
     public boolean hasPeaceDollars() {
-        return (mCheckboxFlags & PEACE_DOLLARS) != 0;
+        return (getCheckboxFlagsAsLong() & PEACE_DOLLARS) != 0;
     }
 
     public boolean hasIkeDollars() {
-        return (mCheckboxFlags & IKE_DOLLARS) != 0;
+        return (getCheckboxFlagsAsLong() & IKE_DOLLARS) != 0;
     }
 
     public boolean hasEagleDollars() {
-        return (mCheckboxFlags & EAGLE_DOLLARS) != 0;
+        return (getCheckboxFlagsAsLong() & EAGLE_DOLLARS) != 0;
     }
 
     public boolean hasSBADollars() {
-        return (mCheckboxFlags & SBA_DOLLARS) != 0;
+        return (getCheckboxFlagsAsLong() & SBA_DOLLARS) != 0;
     }
 
     public boolean hasSACDollars() {
-        return (mCheckboxFlags & SAC_DOLLARS) != 0;
+        return (getCheckboxFlagsAsLong() & SAC_DOLLARS) != 0;
     }
 
     public boolean hasPresDollars() {
-        return (mCheckboxFlags & PRES_DOLLARS) != 0;
+        return (getCheckboxFlagsAsLong() & PRES_DOLLARS) != 0;
     }
 
     public boolean hasTradeDollars() {
-        return (mCheckboxFlags & TRADE_DOLLARS) != 0;
+        return (getCheckboxFlagsAsLong() & TRADE_DOLLARS) != 0;
     }
 
     public void setEndYear(int endYear) {
@@ -506,13 +521,13 @@ public class CollectionListInfo implements Parcelable {
 
     /* setMintMarkFlags() used in unit tests
      */
-    public void setMintMarkFlags(int flags) {
+    public void setMintMarkFlags(String flags) {
         mMintMarkFlags = flags;
     }
 
     /* setCheckboxFlags() used in unit tests
      */
-    public void setCheckboxFlags(int flags) {
+    public void setCheckboxFlags(String flags) {
         mCheckboxFlags = flags;
     }
 
@@ -540,7 +555,7 @@ public class CollectionListInfo implements Parcelable {
         for (int i = 0; i < coinList.size(); i++) {
             String mintMark = coinList.get(i).getMint();
             String coinId = coinList.get(i).getIdentifier();
-            if (mintMark.equals("")) {
+            if (mintMark.isEmpty()) {
                 hasBlankMint = true;
             }
             if (mintMark.equals("P") || mintMark.equals(" P") || mintMark.contains(" P ")
@@ -585,7 +600,7 @@ public class CollectionListInfo implements Parcelable {
         // Get the start and end date
         boolean useCustomDateRange = false;
         if (doesCollectionTypeUseDates(coinType)) {
-            if (coinList.size() > 0) {
+            if (!coinList.isEmpty()) {
                 try {
                     // Start Year
                     int newStartYear = parseDateString(coinList.get(0).getIdentifier());
@@ -602,7 +617,7 @@ public class CollectionListInfo implements Parcelable {
         }
 
         // Combine flags for mint marks
-        int mintMarkFlags = showMintMarks ? CollectionListInfo.SHOW_MINT_MARKS : 0;
+        long mintMarkFlags = showMintMarks ? CollectionListInfo.SHOW_MINT_MARKS : 0;
         mintMarkFlags |= showP ? CollectionListInfo.MINT_P : 0;
         mintMarkFlags |= showD ? CollectionListInfo.MINT_D : 0;
         mintMarkFlags |= showS ? CollectionListInfo.MINT_S : 0;
@@ -610,7 +625,7 @@ public class CollectionListInfo implements Parcelable {
         mintMarkFlags |= showCC ? CollectionListInfo.MINT_CC : 0;
 
         // Combine flags for checkboxes
-        int checkboxFlags = useCustomDateRange ? CollectionListInfo.CUSTOM_DATES : 0;
+        long checkboxFlags = useCustomDateRange ? CollectionListInfo.CUSTOM_DATES : 0;
         checkboxFlags |= showBurnished ? CollectionListInfo.BURNISHED : 0;
         checkboxFlags |= showTerritories ? CollectionListInfo.TERRITORIES : 0;
 
@@ -618,8 +633,8 @@ public class CollectionListInfo implements Parcelable {
         this.setCreationParameters(
                 startYear,
                 endYear,
-                mintMarkFlags,
-                checkboxFlags
+                Long.toString(mintMarkFlags),
+                Long.toString(checkboxFlags)
         );
     }
 
@@ -661,7 +676,7 @@ public class CollectionListInfo implements Parcelable {
      * @return true if the coin is a special case of no mint marks, false otherwise
      */
     private boolean isHideMintMarkSpecialCase(String coinType, String coinId, String mintMark) {
-        if (coinType.equals(WalkingLibertyHalfDollars.COLLECTION_TYPE) && mintMark.equals("")) {
+        if (coinType.equals(WalkingLibertyHalfDollars.COLLECTION_TYPE) && mintMark.isEmpty()) {
             int dateInt = Integer.parseInt(coinId.substring(0, 4));
             return (dateInt >= 1923 && dateInt <= 1933);
         }
@@ -676,7 +691,7 @@ public class CollectionListInfo implements Parcelable {
      * @param mintMarkFlags int flags indicating which mint marks were used
      * @param checkboxFlags int flags indicating which checkboxes were check
      */
-    void setCreationParameters(int startYear, int endYear, int mintMarkFlags, int checkboxFlags) {
+    void setCreationParameters(int startYear, int endYear, String mintMarkFlags, String checkboxFlags) {
         mStartYear = startYear;
         mEndYear = endYear;
         mMintMarkFlags = mintMarkFlags;
@@ -705,8 +720,10 @@ public class CollectionListInfo implements Parcelable {
                 displayType, // See note above
                 String.valueOf(mStartYear),
                 String.valueOf(mEndYear),
-                String.valueOf(mMintMarkFlags),
-                String.valueOf(mCheckboxFlags)};
+                "0", // Legacy mint mark flags
+                "0", // Legacy checkbox flags
+                mMintMarkFlags,
+                mCheckboxFlags};
     }
 
     /**
@@ -744,12 +761,12 @@ public class CollectionListInfo implements Parcelable {
      * @param checkboxFlags new checkbox flags
      * @return true if the number of coins may be less, false otherwise
      */
-    public boolean checkIfNewFlagsRemoveCoins(int mintMarkFlags, int checkboxFlags) {
+    public boolean checkIfNewFlagsRemoveCoins(long mintMarkFlags, long checkboxFlags) {
         // Return true if:
         // - A mint mark that is set is unset
         // - a checkbox option that is set is unset (ignores custom dates)
-        return ((mMintMarkFlags & ~mintMarkFlags)
-                | (mCheckboxFlags & ~checkboxFlags & ~CUSTOM_DATES)) != 0;
+        return ((getMintMarkFlagsAsLong() & ~mintMarkFlags)
+                | (getCheckboxFlagsAsLong() & ~checkboxFlags & ~CUSTOM_DATES)) != 0;
     }
 
     /**
@@ -802,8 +819,8 @@ public class CollectionListInfo implements Parcelable {
         int displayType = SIMPLE_DISPLAY;
         int startYear = 0;
         int endYear = 0;
-        int mintMarkFlags = 0;
-        int checkboxFlags = 0;
+        String mintMarkFlags = "";
+        String checkboxFlags = "";
         int collectionTypeIndex = 0;
 
         reader.beginObject();
@@ -829,11 +846,17 @@ public class CollectionListInfo implements Parcelable {
                 case COL_END_YEAR:
                     endYear = reader.nextInt();
                     break;
+                case COL_SHOW_MINT_MARKS_LEGACY:
+                    mintMarkFlags = Integer.toString(reader.nextInt());
+                    break;
                 case COL_SHOW_MINT_MARKS:
-                    mintMarkFlags = reader.nextInt();
+                    mintMarkFlags = reader.nextString();
+                    break;
+                case COL_SHOW_CHECKBOXES_LEGACY:
+                    checkboxFlags = Integer.toString(reader.nextInt());
                     break;
                 case COL_SHOW_CHECKBOXES:
-                    checkboxFlags = reader.nextInt();
+                    checkboxFlags = reader.nextString();
                     break;
                 case COL_COIN_TYPE:
                     // If the coin type isn't recognized, an error occurred so just choose a safe value
@@ -886,8 +909,10 @@ public class CollectionListInfo implements Parcelable {
         // using setCreationParametersFromCoinData()
         mStartYear = (in.length > 5) ? Integer.parseInt(in[5]) : 0;
         mEndYear = (in.length > 6) ? Integer.parseInt(in[6]) : 0;
-        mMintMarkFlags = (in.length > 7) ? Integer.parseInt(in[7]) : 0;
-        mCheckboxFlags = (in.length > 8) ? Integer.parseInt(in[8]) : 0;
+        int mintMarkFlagsLegacy = (in.length > 7) ? Integer.parseInt(in[7]) : 0;
+        int checkboxFlagsLegacy = (in.length > 8) ? Integer.parseInt(in[8]) : 0;
+        mMintMarkFlags = (in.length > 9) ? in[9] : Integer.toString(mintMarkFlagsLegacy);
+        mCheckboxFlags = (in.length > 10) ? in[10] : Integer.toString(checkboxFlagsLegacy);
 
         // If the coin type isn't recognized, an error occurred so just choose a safe value
         int collectionTypeIndex = MainApplication.getIndexFromCollectionNameStr(in[1]);
@@ -908,8 +933,8 @@ public class CollectionListInfo implements Parcelable {
         mDisplayType = in.readInt();
         mStartYear = in.readInt();
         mEndYear = in.readInt();
-        mMintMarkFlags = in.readInt();
-        mCheckboxFlags = in.readInt();
+        mMintMarkFlags = in.readString();
+        mCheckboxFlags = in.readString();
         mCollectionInfo = MainApplication.COLLECTION_TYPES[mCollectionTypeIndex];
     }
 
@@ -922,8 +947,8 @@ public class CollectionListInfo implements Parcelable {
         dest.writeInt(mDisplayType);
         dest.writeInt(mStartYear);
         dest.writeInt(mEndYear);
-        dest.writeInt(mMintMarkFlags);
-        dest.writeInt(mCheckboxFlags);
+        dest.writeString(mMintMarkFlags);
+        dest.writeString(mCheckboxFlags);
     }
 
     @Override

--- a/app/src/main/java/com/coincollection/DatabaseAdapter.java
+++ b/app/src/main/java/com/coincollection/DatabaseAdapter.java
@@ -425,9 +425,8 @@ public class DatabaseAdapter {
      * @throws SQLException if a database error occurs
      */
     public void updateExistingCollection(String oldTableName, CollectionListInfo collectionListInfo, ArrayList<CoinSlot> coinData) throws SQLException {
-        DatabaseHelper.updateExistingCollection(mDb, oldTableName, collectionListInfo, coinData);
+        DatabaseHelper.updateExistingCollection(mDb, oldTableName, collectionListInfo, coinData, false);
     }
-
 
     /**
      * Creates the table of metadata for all the current collections
@@ -444,7 +443,7 @@ public class DatabaseAdapter {
      * @throws SQLException if a database error occurs
      */
     public void getAllTables(ArrayList<CollectionListInfo> collectionListEntries) throws SQLException {
-        DatabaseHelper.getAllTables(mDb, collectionListEntries);
+        DatabaseHelper.getAllTables(mDb, collectionListEntries, false);
     }
 
     /**

--- a/app/src/main/java/com/coincollection/ExportImportHelper.java
+++ b/app/src/main/java/com/coincollection/ExportImportHelper.java
@@ -43,7 +43,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 
 public class ExportImportHelper {
@@ -130,7 +129,7 @@ public class ExportImportHelper {
         ArrayList<ArrayList<CoinSlot>> importedCollectionContents = new ArrayList<>();
         try {
             ArrayList<String[]> fileContents = getCsvFileContents(inputFile);
-            if (fileContents.size() > 0 && fileContents.get(0).length > 0) {
+            if (!fileContents.isEmpty() && fileContents.get(0).length > 0) {
                 importDatabaseVersion = Integer.parseInt(fileContents.get(0)[0]);
             } else {
                 return mRes.getString(R.string.error_reading_file, inputFile.getAbsolutePath());
@@ -180,7 +179,7 @@ public class ExportImportHelper {
             importedCollectionContents.add(collectionContent);
         }
 
-        if (collectionErrorMessages.size() != 0) {
+        if (!collectionErrorMessages.isEmpty()) {
             // An error occurred in one or more of the databases so show an error
             StringBuilder problems = new StringBuilder();
             for (String message : collectionErrorMessages) {
@@ -322,8 +321,6 @@ public class ExportImportHelper {
             // All data has been parsed from CSV files so perform the DB steps to import
             return updateDatabaseFromImport(importDatabaseVersion, importedCollectionInfoList,
                     importedCollectionContents);
-        } catch (UnsupportedEncodingException e) {
-            return mRes.getString(R.string.error_importing, e.getMessage());
         } catch (IOException e) {
             return mRes.getString(R.string.error_importing, e.getMessage());
         }
@@ -486,7 +483,7 @@ public class ExportImportHelper {
                     // Make sure any cells following '-----', 'section' are blank, to avoid possible data row
                     boolean foundNonEmptyCell = false;
                     for (int i = 2; i < lineValues.length; i++) {
-                        if (lineValues[i].length() != 0) {
+                        if (!lineValues[i].isEmpty()) {
                             foundNonEmptyCell = true;
                             break;
                         }

--- a/app/src/main/java/com/coincollection/MainActivity.java
+++ b/app/src/main/java/com/coincollection/MainActivity.java
@@ -59,7 +59,6 @@ import com.spencerpages.MainApplication;
 import com.spencerpages.R;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -364,8 +363,6 @@ public class MainActivity extends BaseActivity {
                         } else {
                             return helper.importCollectionsFromJson(inputStream);
                         }
-                    } catch (FileNotFoundException e) {
-                        return mRes.getString(R.string.error_importing, e.getMessage());
                     } catch (IOException e) {
                         return mRes.getString(R.string.error_importing, e.getMessage());
                     }
@@ -383,8 +380,6 @@ public class MainActivity extends BaseActivity {
                         } else {
                             return helper.exportCollectionsToJson(outputStream, fileName);
                         }
-                    } catch (FileNotFoundException e) {
-                        return mRes.getString(R.string.error_exporting, e.getMessage());
                     } catch (IOException e) {
                         return mRes.getString(R.string.error_exporting, e.getMessage());
                     }
@@ -974,7 +969,7 @@ public class MainActivity extends BaseActivity {
                 continue;
             }
             String attributionStr = mRes.getString(attributionResId);
-            if (attributionStr.equals("")) {
+            if (attributionStr.isEmpty()) {
                 continue;
             }
             attributions.add(attributionStr);

--- a/app/src/main/java/com/spencerpages/MainApplication.java
+++ b/app/src/main/java/com/spencerpages/MainApplication.java
@@ -127,9 +127,9 @@ public class MainApplication extends Application {
      * Version 18 - Used in Version 3.4.0 of the app
      * Version 19 - Used in Version 3.5.0 of the app
      * Version 20 - Used in Version 3.6.0 of the app
-     * Version 21 - Used in Version 3.7.0 of the app
+     * Version 21-22 - Used in Version 3.7.0 of the app
      */
-    public static final int DATABASE_VERSION = 21;
+    public static final int DATABASE_VERSION = 22;
 
     /**
      * Get the collection index from collection type name

--- a/app/src/test/java/com/spencerpages/BaseTestCase.java
+++ b/app/src/test/java/com/spencerpages/BaseTestCase.java
@@ -32,6 +32,7 @@ import static com.coincollection.CollectionPage.SIMPLE_DISPLAY;
 import static com.spencerpages.MainApplication.COLLECTION_TYPES;
 import static com.spencerpages.MainApplication.DATABASE_NAME;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -133,7 +134,7 @@ public class BaseTestCase {
                 0,
                 MainApplication.getIndexFromCollectionNameStr(collectionInfo.getCoinType()),
                 SIMPLE_DISPLAY,
-                0, 0, 0, 0);
+                0, 0, "", "");
     }
 
     /**
@@ -374,7 +375,7 @@ public class BaseTestCase {
     void checkCreationParamsFromCoinList(ArrayList<CoinSlot> coinList, CollectionInfo coinClass) {
         // Note: Skips configurations resulting in 0 coins, as there's no way to recreate these.
         //       In this case, editing the collection will reset back to the original start/year
-        if (coinList.size() != 0) {
+        if (!coinList.isEmpty()) {
             CollectionListInfo collectionListInfo = getCollectionListInfo("X", coinClass, coinList);
             collectionListInfo.setCreationParametersFromCoinData(coinList);
             ParcelableHashMap checkParameters = CoinPageCreator.getParametersFromCollectionListInfo(collectionListInfo);
@@ -408,12 +409,11 @@ public class BaseTestCase {
     /**
      * Compare two lists of CoinSlot lists to ensure they're the same
      *
-     * @param base           list of CoinSlots lists
-     * @param check          list of CoinSlots lists
-     * @param compareAdvInfo if true, enables comparison of advanced details
+     * @param base  list of CoinSlots lists
+     * @param check list of CoinSlots lists
      */
-    void compareListOfCoinSlotLists(ArrayList<ArrayList<CoinSlot>> base, ArrayList<ArrayList<CoinSlot>> check, boolean compareAdvInfo) {
-        assertTrue(SharedTest.compareListOfCoinSlotLists(base, check, compareAdvInfo));
+    void compareListOfCoinSlotLists(ArrayList<ArrayList<CoinSlot>> base, ArrayList<ArrayList<CoinSlot>> check) {
+        assertTrue(SharedTest.compareListOfCoinSlotLists(base, check, true));
     }
 
     /**
@@ -453,7 +453,7 @@ public class BaseTestCase {
         // Make sure the collection list info is correct in the database
         ArrayList<CollectionListInfo> collectionListEntries = new ArrayList<>();
         activity.mDbAdapter.getAllTables(collectionListEntries);
-        assertTrue(collectionListEntries.size() > 0);
+        assertFalse(collectionListEntries.isEmpty());
         CollectionListInfo matchingDbCollectionListInfo = null;
         for (CollectionListInfo dbCollectionListInfo : collectionListEntries) {
             if (dbCollectionListInfo.getName().equals(collectionListInfo.getName())) {
@@ -581,8 +581,8 @@ public class BaseTestCase {
                 displayType,
                 startDate,
                 endDate,
-                random.nextInt() & CollectionListInfo.ALL_MINT_MASK,
-                random.nextInt() & CollectionListInfo.ALL_CHECKBOXES_MASK);
+                Long.toString(random.nextLong() & CollectionListInfo.ALL_MINT_MASK),
+                Long.toString(random.nextLong() & CollectionListInfo.ALL_CHECKBOXES_MASK));
 
         // Populate coin list
         ParcelableHashMap parameters = CoinPageCreator.getParametersFromCollectionListInfo(collectionListInfo);
@@ -695,13 +695,12 @@ public class BaseTestCase {
     /**
      * @param dbAdapter       database adapter
      * @param collectionNames List of collection names
-     * @param populateAdvInfo if true, populates the advanced info
      * @return a list of coin slot lists
      */
-    ArrayList<ArrayList<CoinSlot>> getCoinSlotListsFromCollectionNames(DatabaseAdapter dbAdapter, ArrayList<String> collectionNames, boolean populateAdvInfo) {
+    ArrayList<ArrayList<CoinSlot>> getCoinSlotListsFromCollectionNames(DatabaseAdapter dbAdapter, ArrayList<String> collectionNames) {
         ArrayList<ArrayList<CoinSlot>> coinSlotLists = new ArrayList<>();
         for (String collectionName : collectionNames) {
-            coinSlotLists.add(dbAdapter.getCoinList(collectionName, populateAdvInfo, false));
+            coinSlotLists.add(dbAdapter.getCoinList(collectionName, true, false));
         }
         return coinSlotLists;
     }

--- a/app/src/test/java/com/spencerpages/CoinPageCreatorTests.java
+++ b/app/src/test/java/com/spencerpages/CoinPageCreatorTests.java
@@ -113,8 +113,8 @@ public class CoinPageCreatorTests extends BaseTestCase {
     public void test_getCreationParameters() {
         for (CollectionInfo collectionInfo : COLLECTION_TYPES) {
             CollectionListInfo collectionListInfo = getCollectionListInfo("X", collectionInfo, new ArrayList<>());
-            collectionListInfo.setMintMarkFlags(-1); // All possible mint marks set
-            collectionListInfo.setCheckboxFlags(-1); // All possible checkboxes set
+            collectionListInfo.setMintMarkFlags(Long.toString(-1L)); // All possible mint marks set
+            collectionListInfo.setCheckboxFlags(Long.toString(-1L)); // All possible checkboxes set
             ParcelableHashMap parameters = CoinPageCreator.getParametersFromCollectionListInfo(collectionListInfo);
 
             // Assert that collections don't provide the same option twice
@@ -142,7 +142,6 @@ public class CoinPageCreatorTests extends BaseTestCase {
             }
 
             // Assert that parameters aren't outside the expected range
-            // noinspection ConstantValue
             assertEquals(0, (CoinPageCreator.getCheckboxFlagsFromParameters(parameters) & ~ALL_CHECKBOXES_MASK));
             assertEquals(0, (CoinPageCreator.getMintMarkFlagsFromParameters(parameters) & ~ALL_MINT_MASK));
         }

--- a/app/src/test/java/com/spencerpages/CollectionPageActivityTests.java
+++ b/app/src/test/java/com/spencerpages/CollectionPageActivityTests.java
@@ -84,7 +84,7 @@ public class CollectionPageActivityTests extends BaseTestCase {
                             .putExtra(CollectionPage.COLLECTION_NAME, collectionName))) {
                 scenario.onActivity(activity -> {
 
-                    if (activity.mCoinList.size() > 0) {
+                    if (!activity.mCoinList.isEmpty()) {
 
                         // Make copy of coins
                         activity.copyCoinSlot(activity.mCoinList.get(0), 1);

--- a/app/src/test/java/com/spencerpages/ExportImportTests.java
+++ b/app/src/test/java/com/spencerpages/ExportImportTests.java
@@ -106,7 +106,7 @@ public class ExportImportTests extends BaseTestCase {
                 assertTrue(setupOneOfEachCollectionTypes(activity));
                 activity.updateCollectionListFromDatabase();
                 ArrayList<String> beforeCollectionNames = getCollectionNames(activity);
-                ArrayList<ArrayList<CoinSlot>> beforeCoinLists = getCoinSlotListsFromCollectionNames(activity.mDbAdapter, beforeCollectionNames, true);
+                ArrayList<ArrayList<CoinSlot>> beforeCoinLists = getCoinSlotListsFromCollectionNames(activity.mDbAdapter, beforeCollectionNames);
 
                 // Export and check output
                 File exportDir = new File(activity.getLegacyExportFolderName());
@@ -139,10 +139,10 @@ public class ExportImportTests extends BaseTestCase {
                 // Run import and check results
                 assertEquals("", helper.importCollectionsFromLegacyCSV(activity.getLegacyExportFolderName()));
                 ArrayList<String> afterCollectionNames = getCollectionNames(activity);
-                ArrayList<ArrayList<CoinSlot>> afterCoinLists = getCoinSlotListsFromCollectionNames(activity.mDbAdapter, afterCollectionNames, true);
+                ArrayList<ArrayList<CoinSlot>> afterCoinLists = getCoinSlotListsFromCollectionNames(activity.mDbAdapter, afterCollectionNames);
                 assertEquals(afterCollectionNames.size(), COLLECTION_TYPES.length);
                 assertEquals(beforeCollectionNames, afterCollectionNames);
-                compareListOfCoinSlotLists(beforeCoinLists, afterCoinLists, true);
+                compareListOfCoinSlotLists(beforeCoinLists, afterCoinLists);
             });
         }
     }
@@ -162,7 +162,7 @@ public class ExportImportTests extends BaseTestCase {
                 assertTrue(setupOneOfEachCollectionTypes(activity));
                 activity.updateCollectionListFromDatabase();
                 ArrayList<String> beforeCollectionNames = getCollectionNames(activity);
-                ArrayList<ArrayList<CoinSlot>> beforeCoinLists = getCoinSlotListsFromCollectionNames(activity.mDbAdapter, beforeCollectionNames, true);
+                ArrayList<ArrayList<CoinSlot>> beforeCoinLists = getCoinSlotListsFromCollectionNames(activity.mDbAdapter, beforeCollectionNames);
 
                 // Export and check output
                 File exportFile = getTempFile("json-export.json");
@@ -184,10 +184,10 @@ public class ExportImportTests extends BaseTestCase {
                 InputStream inputStream = openInputStream(exportFile);
                 assertEquals("", helper.importCollectionsFromJson(inputStream));
                 ArrayList<String> afterCollectionNames = getCollectionNames(activity);
-                ArrayList<ArrayList<CoinSlot>> afterCoinLists = getCoinSlotListsFromCollectionNames(activity.mDbAdapter, afterCollectionNames, true);
+                ArrayList<ArrayList<CoinSlot>> afterCoinLists = getCoinSlotListsFromCollectionNames(activity.mDbAdapter, afterCollectionNames);
                 assertEquals(afterCollectionNames.size(), COLLECTION_TYPES.length);
                 assertEquals(beforeCollectionNames, afterCollectionNames);
-                compareListOfCoinSlotLists(beforeCoinLists, afterCoinLists, true);
+                compareListOfCoinSlotLists(beforeCoinLists, afterCoinLists);
                 closeStream(inputStream);
             });
         }
@@ -208,7 +208,7 @@ public class ExportImportTests extends BaseTestCase {
                 assertTrue(setupOneOfEachCollectionTypes(activity));
                 activity.updateCollectionListFromDatabase();
                 ArrayList<String> beforeCollectionNames = getCollectionNames(activity);
-                ArrayList<ArrayList<CoinSlot>> beforeCoinLists = getCoinSlotListsFromCollectionNames(activity.mDbAdapter, beforeCollectionNames, true);
+                ArrayList<ArrayList<CoinSlot>> beforeCoinLists = getCoinSlotListsFromCollectionNames(activity.mDbAdapter, beforeCollectionNames);
 
                 // Export and check output
                 File exportFile = getTempFile("csv-export.csv");
@@ -230,10 +230,10 @@ public class ExportImportTests extends BaseTestCase {
                 InputStream inputStream = openInputStream(exportFile);
                 assertEquals("", helper.importCollectionsFromSingleCSV(inputStream));
                 ArrayList<String> afterCollectionNames = getCollectionNames(activity);
-                ArrayList<ArrayList<CoinSlot>> afterCoinLists = getCoinSlotListsFromCollectionNames(activity.mDbAdapter, afterCollectionNames, true);
+                ArrayList<ArrayList<CoinSlot>> afterCoinLists = getCoinSlotListsFromCollectionNames(activity.mDbAdapter, afterCollectionNames);
                 assertEquals(afterCollectionNames.size(), COLLECTION_TYPES.length);
                 assertEquals(beforeCollectionNames, afterCollectionNames);
-                compareListOfCoinSlotLists(beforeCoinLists, afterCoinLists, true);
+                compareListOfCoinSlotLists(beforeCoinLists, afterCoinLists);
                 closeStream(inputStream);
             });
         }

--- a/shared-test/src/main/java/com/spencerpages/SharedTest.java
+++ b/shared-test/src/main/java/com/spencerpages/SharedTest.java
@@ -43,34 +43,34 @@ public class SharedTest {
 
     public static final CollectionListInfo[] COLLECTION_LIST_INFO_SCENARIOS =
             {
-                    new CollectionListInfo("My Pennies", 275, 0, getIndexFromCollectionNameStr("Pennies"), 0, 1909, 2020, 15, 1),
-                    new CollectionListInfo("@#$#@%$#^$#$%^%$&^^&%$", 19, 0, getIndexFromCollectionNameStr("Nickels"), 0, 1938, 2020, 9, 0),
-                    new CollectionListInfo("My\\Collection/", 2, 0, getIndexFromCollectionNameStr("Dimes"), 0, 1950, 1951, 2, 1),
-                    new CollectionListInfo("my,coll,ection.", 65, 0, getIndexFromCollectionNameStr("Quarters"), 0, 1932, 1998, 3, 0),
-                    new CollectionListInfo("<>STATE QUARTERS\n\n", 112, 0, getIndexFromCollectionNameStr("State Quarters"), 0, 0, 0, 7, 4),
-                    new CollectionListInfo("</></>", 56, 0, getIndexFromCollectionNameStr("National Park Quarters"), 0, 0, 0, 5, 0),
-                    new CollectionListInfo("~", 56, 0, getIndexFromCollectionNameStr("Half-Dollars"), 0, 1964, 2020, 2, 1),
-                    new CollectionListInfo("Eisenhower", 2, 0, getIndexFromCollectionNameStr("Eisenhower Dollars"), 0, 1971, 1971, 7, 1),
-                    new CollectionListInfo("Susan's \"Dollars!", 4, 0, getIndexFromCollectionNameStr("Susan B. Anthony Dollars"), 0, 1979, 1999, 2, 0),
-                    new CollectionListInfo("; DROP TABLES;", 16, 0, getIndexFromCollectionNameStr("Sacagawea/Native American Dollars"), 0, 2002, 2009, 7, 1),
-                    new CollectionListInfo("😁😁😁😁😁😍😄", 80, 0, getIndexFromCollectionNameStr("Presidential Dollars"), 0, 0, 0, 7, 0),
-                    new CollectionListInfo("| | | | | ", 2, 0, getIndexFromCollectionNameStr("Indian Head Cents"), 0, 1859, 1909, 9, 0),
-                    new CollectionListInfo(" ", 32, 0, getIndexFromCollectionNameStr("Liberty Head Nickels"), 0, 1883, 1912, 7, 1),
-                    new CollectionListInfo("  ", 25, 0, getIndexFromCollectionNameStr("Barber Dimes"), 0, 1892, 1916, 2, 0),
-                    new CollectionListInfo("Barb Quarts", 25, 0, getIndexFromCollectionNameStr("Barber Quarters"), 0, 1892, 1916, 2, 0),
-                    new CollectionListInfo("_)(*&^%", 12, 0, getIndexFromCollectionNameStr("Standing Liberty Quarters"), 0, 1916, 1930, 9, 0),
-                    new CollectionListInfo("Frankline", 19, 0, getIndexFromCollectionNameStr("Franklin Half Dollars"), 0, 1948, 1963, 13, 1),
-                    new CollectionListInfo("✓✓✓✓✓™", 96, 0, getIndexFromCollectionNameStr("Morgan Dollars"), 0, 1878, 1921, 63, 0),
-                    new CollectionListInfo("🐶✌️", 1, 0, getIndexFromCollectionNameStr("Peace Dollars"), 0, 1921, 1921, 2, 1),
-                    new CollectionListInfo("Eagles", 39, 0, getIndexFromCollectionNameStr("American Eagle Silver Dollars"), 0, 1986, 2020, 0, 2),
-                    new CollectionListInfo("()", 42, 0, getIndexFromCollectionNameStr("First Spouse Gold Coins"), 0, 0, 0, 0, 0),
-                    new CollectionListInfo("S Pennies", 0, 0, getIndexFromCollectionNameStr("Pennies"), 0, 2000, 2020, 9, 1),
-                    new CollectionListInfo("50-States", 50, 0, getIndexFromCollectionNameStr("State Quarters"), 0, 0, 0, 3, 0),
-                    new CollectionListInfo("$PATH", 56, 0, getIndexFromCollectionNameStr("National Park Quarters"), 0, 0, 0, 5, 0),
-                    new CollectionListInfo("CHAR(0x54)", 11, 0, getIndexFromCollectionNameStr("Sacagawea/Native American Dollars"), 0, 2010, 2020, 2, 1),
-                    new CollectionListInfo("<a href=\"#\">Click Here</a>", 14, 0, getIndexFromCollectionNameStr("American Eagle Silver Dollars"), 0, 1986, 1999, 0, 1),
-                    new CollectionListInfo("# comment", 18, 0, getIndexFromCollectionNameStr("Barber Quarters"), 0, 1892, 1916, 17, 0),
-                    new CollectionListInfo("American_Women", 45, 0, getIndexFromCollectionNameStr("American Women Quarters"), 0, 0, 0, 15, 0),
+                    new CollectionListInfo("My Pennies", 275, 0, getIndexFromCollectionNameStr("Pennies"), 0, 1909, 2020, "15", "1"),
+                    new CollectionListInfo("@#$#@%$#^$#$%^%$&^^&%$", 19, 0, getIndexFromCollectionNameStr("Nickels"), 0, 1938, 2020, "9", "0"),
+                    new CollectionListInfo("My\\Collection/", 2, 0, getIndexFromCollectionNameStr("Dimes"), 0, 1950, 1951, "2", "1"),
+                    new CollectionListInfo("my,coll,ection.", 65, 0, getIndexFromCollectionNameStr("Quarters"), 0, 1932, 1998, "3", "0"),
+                    new CollectionListInfo("<>STATE QUARTERS\n\n", 112, 0, getIndexFromCollectionNameStr("State Quarters"), 0, 0, 0, "7", "4"),
+                    new CollectionListInfo("</></>", 56, 0, getIndexFromCollectionNameStr("National Park Quarters"), 0, 0, 0, "5", "0"),
+                    new CollectionListInfo("~", 56, 0, getIndexFromCollectionNameStr("Half-Dollars"), 0, 1964, 2020, "2", "1"),
+                    new CollectionListInfo("Eisenhower", 2, 0, getIndexFromCollectionNameStr("Eisenhower Dollars"), 0, 1971, 1971, "7", "1"),
+                    new CollectionListInfo("Susan's \"Dollars!", 4, 0, getIndexFromCollectionNameStr("Susan B. Anthony Dollars"), 0, 1979, 1999, "2", "0"),
+                    new CollectionListInfo("; DROP TABLES;", 16, 0, getIndexFromCollectionNameStr("Sacagawea/Native American Dollars"), 0, 2002, 2009, "7", "1"),
+                    new CollectionListInfo("😁😁😁😁😁😍😄", 80, 0, getIndexFromCollectionNameStr("Presidential Dollars"), 0, 0, 0, "7", "0"),
+                    new CollectionListInfo("| | | | | ", 2, 0, getIndexFromCollectionNameStr("Indian Head Cents"), 0, 1859, 1909, "9", "0"),
+                    new CollectionListInfo(" ", 32, 0, getIndexFromCollectionNameStr("Liberty Head Nickels"), 0, 1883, 1912, "7", "1"),
+                    new CollectionListInfo("  ", 25, 0, getIndexFromCollectionNameStr("Barber Dimes"), 0, 1892, 1916, "2", "0"),
+                    new CollectionListInfo("Barb Quarts", 25, 0, getIndexFromCollectionNameStr("Barber Quarters"), 0, 1892, 1916, "2", "0"),
+                    new CollectionListInfo("_)(*&^%", 12, 0, getIndexFromCollectionNameStr("Standing Liberty Quarters"), 0, 1916, 1930, "9", "0"),
+                    new CollectionListInfo("Frankline", 19, 0, getIndexFromCollectionNameStr("Franklin Half Dollars"), 0, 1948, 1963, "13", "1"),
+                    new CollectionListInfo("✓✓✓✓✓™", 96, 0, getIndexFromCollectionNameStr("Morgan Dollars"), 0, 1878, 1921, "63", "0"),
+                    new CollectionListInfo("🐶✌️", 1, 0, getIndexFromCollectionNameStr("Peace Dollars"), 0, 1921, 1921, "2", "1"),
+                    new CollectionListInfo("Eagles", 39, 0, getIndexFromCollectionNameStr("American Eagle Silver Dollars"), 0, 1986, 2020, "0", "2"),
+                    new CollectionListInfo("()", 42, 0, getIndexFromCollectionNameStr("First Spouse Gold Coins"), 0, 0, 0, "0", "0"),
+                    new CollectionListInfo("S Pennies", 0, 0, getIndexFromCollectionNameStr("Pennies"), 0, 2000, 2020, "9", "1"),
+                    new CollectionListInfo("50-States", 50, 0, getIndexFromCollectionNameStr("State Quarters"), 0, 0, 0, "3", "0"),
+                    new CollectionListInfo("$PATH", 56, 0, getIndexFromCollectionNameStr("National Park Quarters"), 0, 0, 0, "5", "0"),
+                    new CollectionListInfo("CHAR(0x54)", 11, 0, getIndexFromCollectionNameStr("Sacagawea/Native American Dollars"), 0, 2010, 2020, "2", "1"),
+                    new CollectionListInfo("<a href=\"#\">Click Here</a>", 14, 0, getIndexFromCollectionNameStr("American Eagle Silver Dollars"), 0, 1986, 1999, "0", "1"),
+                    new CollectionListInfo("# comment", 18, 0, getIndexFromCollectionNameStr("Barber Quarters"), 0, 1892, 1916, "17", "0"),
+                    new CollectionListInfo("American_Women", 45, 0, getIndexFromCollectionNameStr("American Women Quarters"), 0, 0, 0, "15", "0"),
             };
 
     public static final CoinSlot[] COIN_SLOT_SCENARIOS =
@@ -136,8 +136,8 @@ public class SharedTest {
                 (base.getCoinImageIdentifier() == check.getCoinImageIdentifier()) &&
                 (base.getStartYear() == check.getStartYear()) &&
                 (base.getEndYear() == check.getEndYear()) &&
-                (base.getMintMarkFlags() == check.getMintMarkFlags()) &&
-                (base.getCheckboxFlags() == check.getCheckboxFlags()));
+                (base.getMintMarkFlags().equals(check.getMintMarkFlags())) &&
+                (base.getCheckboxFlags().equals(check.getCheckboxFlags())));
     }
 
     /**


### PR DESCRIPTION
The current implementation was capped at 32 mint marks / check boxes, so this PR expands it to an unlimited number in the database (by changing the storage to text) and increasing the code amount to 64 each (by switching from int to long). The code can be easily increased to more than 64, if needed later