### PR TITLE
Enhance GitHub issue templates for better usability

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request_template.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.yaml
@@ -18,5 +18,5 @@ body:
     validations:
       required: true
     attributes:
-      label: "💭 Feature Description"
-      description: "A clear and concise description of the feature you're interested in."
+      label: "🚀 Feature Proposal"
+      description: "Clearly describe the feature you're proposing. Explain the problem it solves and why it would be valuable. If you've considered alternative solutions or workarounds, please mention them too."

--- a/.github/ISSUE_TEMPLATE/issue_template.yaml
+++ b/.github/ISSUE_TEMPLATE/issue_template.yaml
@@ -5,7 +5,13 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for creating a new issue and contributing to our repository
+        Thank you for taking the time to create an issue! Your contribution helps us improve. Please provide as much detail as possible to help us understand and resolve the problem quickly. If you are reporting a bug, please include:
+
+        *   Clear steps to reproduce the issue.
+        *   What you expected to happen.
+        *   What actually happened.
+        *   Any error messages.
+        *   Your environment (e.g., app version, OS version).
   - type: textarea
     id: issue-description
     validations:
@@ -13,10 +19,3 @@ body:
     attributes:
       label: "💭 Description"
       description: "A clear and concise description of what the issue is."
-  - type: checkboxes
-    id: read-code-of-conduct
-    attributes:
-      label: "🏢 Have you read the Code of Conduct?"
-      options:
-        - label: "I have read the [Code of Conduct](https://github.com/anwilli5/coin-collection-android-US/blob/2d51333dd08c40c3fbc6a6897948209e1a6210c6/CODE_OF_CONDUCT.md)"
-          required: true


### PR DESCRIPTION
This commit updates the GitHub issue templates to be more user-friendly:

- For `issue_template.yaml`:
    - Removed the "Code of Conduct" checkbox.
    - Improved the introductory message to guide you in providing comprehensive issue details, such as steps to reproduce, expected vs. actual behavior, and environment information.

- For `feature_request_template.yaml`:
    - Updated the main textarea prompt to "🚀 Feature Proposal".
    - Enhanced the description to encourage you to explain the problem the feature solves, its value, and any alternative solutions considered.

These changes aim to streamline the issue reporting process and improve the quality of information received.