### PR TITLE
Bug Fix: Edit collection loses custom coin / image ids

### DIFF
--- a/app/src/androidTest/java/com/spencerpages/AndroidUITests.java
+++ b/app/src/androidTest/java/com/spencerpages/AndroidUITests.java
@@ -162,7 +162,7 @@ public class AndroidUITests extends TestCase {
             coinSlot.writeToParcel(testParcel, coinSlot.describeContents());
             testParcel.setDataPosition(0);
             CoinSlot checkInfo = CoinSlot.CREATOR.createFromParcel(testParcel);
-            assertTrue(SharedTest.compareCoinSlots(coinSlot, checkInfo, true));
+            assertTrue(SharedTest.compareCoinSlots(coinSlot, checkInfo, true, true));
         }
     }
 

--- a/app/src/main/java/com/coincollection/DatabaseHelper.java
+++ b/app/src/main/java/com/coincollection/DatabaseHelper.java
@@ -682,6 +682,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             values.put(COL_ADV_QUANTITY_INDEX, coinSlot.getAdvancedQuantities());
             values.put(COL_ADV_NOTES, coinSlot.getAdvancedNotes());
             values.put(COL_SORT_ORDER, coinSlot.getSortOrder());
+            values.put(COL_CUSTOM_COIN, coinSlot.isCustomCoin());
+            values.put(COL_IMAGE_ID, coinSlot.getImageId());
             coinSlot.setDatabaseId(runSqlInsert(db, tableName, values));
         }
 

--- a/app/src/test/java/com/spencerpages/BaseTestCase.java
+++ b/app/src/test/java/com/spencerpages/BaseTestCase.java
@@ -398,22 +398,24 @@ public class BaseTestCase {
     /**
      * Compare two lists of CoinSlot objects to ensure they're the same
      *
-     * @param base           ArrayList<CoinSlot>
-     * @param check          ArrayList<CoinSlot>
-     * @param compareAdvInfo if true, enables comparison of advanced details
+     * @param base             ArrayList<CoinSlot>
+     * @param check            ArrayList<CoinSlot>
+     * @param compareAdvInfo   if true, enables comparison of advanced details
+     * @param compareNewFields if true, enables comparison of new fields (e.g image IDs)
      */
-    void compareCoinSlotLists(ArrayList<CoinSlot> base, ArrayList<CoinSlot> check, boolean compareAdvInfo) {
-        assertTrue(SharedTest.compareCoinSlotLists(base, check, compareAdvInfo));
+    void compareCoinSlotLists(ArrayList<CoinSlot> base, ArrayList<CoinSlot> check, boolean compareAdvInfo, boolean compareNewFields) {
+        assertTrue(SharedTest.compareCoinSlotLists(base, check, compareAdvInfo, compareNewFields));
     }
 
     /**
      * Compare two lists of CoinSlot lists to ensure they're the same
      *
-     * @param base  list of CoinSlots lists
-     * @param check list of CoinSlots lists
+     * @param base             list of CoinSlots lists
+     * @param check            list of CoinSlots lists
+     * @param compareNewFields if true, enables comparison of new fields (e.g image IDs)
      */
-    void compareListOfCoinSlotLists(ArrayList<ArrayList<CoinSlot>> base, ArrayList<ArrayList<CoinSlot>> check) {
-        assertTrue(SharedTest.compareListOfCoinSlotLists(base, check, true));
+    void compareListOfCoinSlotLists(ArrayList<ArrayList<CoinSlot>> base, ArrayList<ArrayList<CoinSlot>> check, boolean compareNewFields) {
+        assertTrue(SharedTest.compareListOfCoinSlotLists(base, check, true, compareNewFields));
     }
 
     /**
@@ -488,7 +490,7 @@ public class BaseTestCase {
         if (coinList != null) {
             boolean populateAdvInfo = (collectionListInfo.getDisplayType() == ADVANCED_DISPLAY);
             ArrayList<CoinSlot> checkCoinList = activity.mDbAdapter.getCoinList(tableName, populateAdvInfo, false);
-            compareCoinSlotLists(coinList, checkCoinList, populateAdvInfo);
+            compareCoinSlotLists(coinList, checkCoinList, populateAdvInfo, true);
 
             // Test coin slot database methods
             for (CoinSlot coinSlot : coinList) {

--- a/app/src/test/java/com/spencerpages/CollectionPageActivityTests.java
+++ b/app/src/test/java/com/spencerpages/CollectionPageActivityTests.java
@@ -123,7 +123,7 @@ public class CollectionPageActivityTests extends BaseTestCase {
 
                     // Check that the copied collection was made correctly in the database
                     ArrayList<CoinSlot> checkCoinList = activity.mDbAdapter.getCoinList(collectionName, true);
-                    compareCoinSlotLists(activity.mCoinList, checkCoinList, true);
+                    compareCoinSlotLists(activity.mCoinList, checkCoinList, true, true);
                     checkCoinSortOrdersUnique(activity.mCoinList);
                     assertEquals(getSortOrderList(activity.mCoinList), getSortOrderList(checkCoinList));
                 });

--- a/app/src/test/java/com/spencerpages/ExportImportTests.java
+++ b/app/src/test/java/com/spencerpages/ExportImportTests.java
@@ -145,7 +145,7 @@ public class ExportImportTests extends BaseTestCase {
                 ArrayList<ArrayList<CoinSlot>> afterCoinLists = getCoinSlotListsFromCollectionNames(activity.mDbAdapter, afterCollectionNames);
                 assertEquals(afterCollectionNames.size(), COLLECTION_TYPES.length);
                 assertEquals(beforeCollectionNames, afterCollectionNames);
-                compareListOfCoinSlotLists(beforeCoinLists, afterCoinLists);
+                compareListOfCoinSlotLists(beforeCoinLists, afterCoinLists, false);
             });
         }
     }
@@ -190,7 +190,7 @@ public class ExportImportTests extends BaseTestCase {
                 ArrayList<ArrayList<CoinSlot>> afterCoinLists = getCoinSlotListsFromCollectionNames(activity.mDbAdapter, afterCollectionNames);
                 assertEquals(afterCollectionNames.size(), COLLECTION_TYPES.length);
                 assertEquals(beforeCollectionNames, afterCollectionNames);
-                compareListOfCoinSlotLists(beforeCoinLists, afterCoinLists);
+                compareListOfCoinSlotLists(beforeCoinLists, afterCoinLists, true);
                 closeStream(inputStream);
             });
         }
@@ -236,7 +236,7 @@ public class ExportImportTests extends BaseTestCase {
                 ArrayList<ArrayList<CoinSlot>> afterCoinLists = getCoinSlotListsFromCollectionNames(activity.mDbAdapter, afterCollectionNames);
                 assertEquals(afterCollectionNames.size(), COLLECTION_TYPES.length);
                 assertEquals(beforeCollectionNames, afterCollectionNames);
-                compareListOfCoinSlotLists(beforeCoinLists, afterCoinLists);
+                compareListOfCoinSlotLists(beforeCoinLists, afterCoinLists, true);
                 closeStream(inputStream);
             });
         }

--- a/shared-test/src/main/java/com/spencerpages/SharedTest.java
+++ b/shared-test/src/main/java/com/spencerpages/SharedTest.java
@@ -213,35 +213,40 @@ public class SharedTest {
     /**
      * Compare two CoinSlot objects to ensure they're the same
      *
-     * @param base           CoinSlot
-     * @param check          CoinSlot
-     * @param compareAdvInfo if true, enables comparison of advanced details
+     * @param base             CoinSlot
+     * @param check            CoinSlot
+     * @param compareAdvInfo   if true, enables comparison of advanced details
+     * @param compareNewFields if true, enables comparison of new fields (e.g., imageId)
      * @return true if they have the same contents, false otherwise
      */
-    public static boolean compareCoinSlots(CoinSlot base, CoinSlot check, boolean compareAdvInfo) {
-        // TODO - Not sure how to add assertions here
+    public static boolean compareCoinSlots(CoinSlot base, CoinSlot check,
+                                           boolean compareAdvInfo, boolean compareNewFields) {
         return (base.getIdentifier().equals(check.getIdentifier()) &&
                 (base.getMint().equals(check.getMint())) &&
                 (base.isInCollection() == check.isInCollection()) &&
                 (!compareAdvInfo || (base.getAdvancedGrades().equals(check.getAdvancedGrades()))) &&
                 (!compareAdvInfo || (base.getAdvancedQuantities().equals(check.getAdvancedQuantities()))) &&
-                (!compareAdvInfo || (base.getAdvancedNotes().equals(check.getAdvancedNotes()))));
+                (!compareAdvInfo || (base.getAdvancedNotes().equals(check.getAdvancedNotes()))) &&
+                (!compareNewFields || (base.isCustomCoin() == check.isCustomCoin())) &&
+                (!compareNewFields || (base.getImageId() == check.getImageId())));
     }
 
     /**
      * Compare two lists of CoinSlot objects
      *
-     * @param base           list of CoinSlots
-     * @param check          list of CoinSlots
-     * @param compareAdvInfo if true, enables comparison of advanced details
+     * @param base             list of CoinSlots
+     * @param check            list of CoinSlots
+     * @param compareAdvInfo   if true, enables comparison of advanced details
+     * @param compareNewFields if true, enables comparison of new fields (e.g., imageId)
      * @return true if they have the same contents, false otherwise
      */
-    public static boolean compareCoinSlotLists(ArrayList<CoinSlot> base, ArrayList<CoinSlot> check, boolean compareAdvInfo) {
+    public static boolean compareCoinSlotLists(ArrayList<CoinSlot> base, ArrayList<CoinSlot> check,
+                                               boolean compareAdvInfo, boolean compareNewFields) {
         if (base.size() != check.size()) {
             return false;
         }
         for (int i = 0; i < base.size(); i++) {
-            if (!compareCoinSlots(base.get(i), check.get(i), compareAdvInfo)) {
+            if (!compareCoinSlots(base.get(i), check.get(i), compareAdvInfo, compareNewFields)) {
                 return false;
             }
         }
@@ -272,17 +277,19 @@ public class SharedTest {
     /**
      * Compare two lists of CoinSlot lists
      *
-     * @param base           list of CoinSlots lists
-     * @param check          list of CoinSlots lists
-     * @param compareAdvInfo if true, enables comparison of advanced details
+     * @param base             list of CoinSlots lists
+     * @param check            list of CoinSlots lists
+     * @param compareAdvInfo   if true, enables comparison of advanced details
+     * @param compareNewFields if true, enables comparison of new fields (e.g., imageId)
      * @return true if they have the same contents, false otherwise
      */
-    public static boolean compareListOfCoinSlotLists(ArrayList<ArrayList<CoinSlot>> base, ArrayList<ArrayList<CoinSlot>> check, boolean compareAdvInfo) {
+    public static boolean compareListOfCoinSlotLists(ArrayList<ArrayList<CoinSlot>> base, ArrayList<ArrayList<CoinSlot>> check,
+                                                     boolean compareAdvInfo, boolean compareNewFields) {
         if (base.size() != check.size()) {
             return false;
         }
         for (int i = 0; i < base.size(); i++) {
-            if (!compareCoinSlotLists(base.get(i), check.get(i), compareAdvInfo)) {
+            if (!compareCoinSlotLists(base.get(i), check.get(i), compareAdvInfo, compareNewFields)) {
                 return false;
             }
         }


### PR DESCRIPTION
Address an issue where editing a collection resulted in the loss of custom coin indication and image IDs. The changes ensure that these fields are properly handled and compared during collection operations.