### PR TITLE
Fixing DB upgrades 2021-2024

### DIFF
--- a/app/src/main/java/com/spencerpages/collections/AmericanEagleSilverDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/AmericanEagleSilverDollars.java
@@ -152,22 +152,22 @@ public class AmericanEagleSilverDollars extends CollectionInfo {
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2020);
         }
 
-        if (oldVersion <= 16) {
+        if (oldVersion <= 15) {
             // Add in new 2021 coins if applicable
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2021);
         }
 
-        if (oldVersion <= 18) {
+        if (oldVersion <= 17) {
             // Add in new 2022 coins if applicable
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2022);
         }
 
-        if (oldVersion <= 19) {
+        if (oldVersion <= 18) {
             // Add in new 2023 coins if applicable
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2023);
         }
 
-        if (oldVersion <= 20) {
+        if (oldVersion <= 19) {
             // Add in new 2024 coins if applicable
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2024);
         }

--- a/app/src/main/java/com/spencerpages/collections/AmericanWomenQuarters.java
+++ b/app/src/main/java/com/spencerpages/collections/AmericanWomenQuarters.java
@@ -155,7 +155,7 @@ public class AmericanWomenQuarters extends CollectionInfo {
 
         int total = 0;
 
-        if (oldVersion <= 19) {
+        if (oldVersion <= 18) {
             // Add in new 2023 coins if applicable
             ArrayList<String> newCoinIdentifiers = new ArrayList<>();
             newCoinIdentifiers.add("Bessie Coleman");
@@ -168,7 +168,7 @@ public class AmericanWomenQuarters extends CollectionInfo {
             total += DatabaseHelper.addFromArrayList(db, collectionListInfo, newCoinIdentifiers);
         }
 
-        if (oldVersion <= 20) {
+        if (oldVersion <= 19) {
             // Add in new 2024 coins if applicable
             ArrayList<String> newCoinIdentifiers = new ArrayList<>();
             newCoinIdentifiers.add("Rev. Dr. Pauli Murray");

--- a/app/src/main/java/com/spencerpages/collections/BasicDimes.java
+++ b/app/src/main/java/com/spencerpages/collections/BasicDimes.java
@@ -181,22 +181,22 @@ public class BasicDimes extends CollectionInfo {
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2020);
         }
 
-        if (oldVersion <= 16) {
+        if (oldVersion <= 15) {
             // Add in new 2021 coins if applicable
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2021);
         }
 
-        if (oldVersion <= 18) {
+        if (oldVersion <= 17) {
             // Add in new 2022 coins if applicable
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2022);
         }
 
-        if (oldVersion <= 19) {
+        if (oldVersion <= 18) {
             // Add in new 2023 coins if applicable
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2023);
         }
 
-        if (oldVersion <= 20) {
+        if (oldVersion <= 19) {
             // Add in new 2024 coins if applicable
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2024);
         }

--- a/app/src/main/java/com/spencerpages/collections/BasicHalfDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/BasicHalfDollars.java
@@ -181,22 +181,22 @@ public class BasicHalfDollars extends CollectionInfo {
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2020);
         }
 
-        if (oldVersion <= 16) {
+        if (oldVersion <= 15) {
             // Add in new 2021 coins if applicable
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2021);
         }
 
-        if (oldVersion <= 18) {
+        if (oldVersion <= 17) {
             // Add in new 2022 coins if applicable
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2022);
         }
 
-        if (oldVersion <= 19) {
+        if (oldVersion <= 18) {
             // Add in new 2023 coins if applicable
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2023);
         }
 
-        if (oldVersion <= 20) {
+        if (oldVersion <= 19) {
             // Add in new 2024 coins if applicable
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2024);
         }

--- a/app/src/main/java/com/spencerpages/collections/BasicInnovationDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/BasicInnovationDollars.java
@@ -166,7 +166,7 @@ public class BasicInnovationDollars extends CollectionInfo {
             total += DatabaseHelper.addFromArrayList(db, collectionListInfo, newCoinIdentifiers);
         }
 
-        if (oldVersion <= 16) {
+        if (oldVersion <= 15) {
             // Add in new 2020 coins if applicable
             ArrayList<String> newCoinIdentifiers = new ArrayList<>();
             newCoinIdentifiers.add("Connecticut");
@@ -178,7 +178,7 @@ public class BasicInnovationDollars extends CollectionInfo {
             total += DatabaseHelper.addFromArrayList(db, collectionListInfo, newCoinIdentifiers);
         }
 
-        if (oldVersion <= 18) {
+        if (oldVersion <= 17) {
             // Add in new 2021 and 2022 coins if applicable
             ArrayList<String> newCoinIdentifiers = new ArrayList<>();
             newCoinIdentifiers.add("New Hampshire");
@@ -194,7 +194,7 @@ public class BasicInnovationDollars extends CollectionInfo {
             total += DatabaseHelper.addFromArrayList(db, collectionListInfo, newCoinIdentifiers);
         }
 
-        if (oldVersion <= 19) {
+        if (oldVersion <= 18) {
             // Add in new 2023 coins if applicable
             ArrayList<String> newCoinIdentifiers = new ArrayList<>();
             newCoinIdentifiers.add("Ohio");
@@ -206,7 +206,7 @@ public class BasicInnovationDollars extends CollectionInfo {
             total += DatabaseHelper.addFromArrayList(db, collectionListInfo, newCoinIdentifiers);
         }
 
-        if (oldVersion <= 20) {
+        if (oldVersion <= 19) {
             // Add in new 2024 coins if applicable
             ArrayList<String> newCoinIdentifiers = new ArrayList<>();
             newCoinIdentifiers.add("Illinois");

--- a/app/src/main/java/com/spencerpages/collections/BasicQuarters.java
+++ b/app/src/main/java/com/spencerpages/collections/BasicQuarters.java
@@ -175,7 +175,7 @@ public class BasicQuarters extends CollectionInfo {
             total -= runSqlDelete(db, tableName, COIN_SLOT_NAME_MINT_WHERE_CLAUSE, new String[]{"1967", "D"});
         }
 
-        if (oldVersion <= 16) {
+        if (oldVersion <= 15) {
             // Add in new 2021 coins if applicable
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 1998, 2021, "Crossing the Delaware");
         }

--- a/app/src/main/java/com/spencerpages/collections/FirstSpouseGoldCoins.java
+++ b/app/src/main/java/com/spencerpages/collections/FirstSpouseGoldCoins.java
@@ -232,7 +232,7 @@ public class FirstSpouseGoldCoins extends CollectionInfo {
             values.clear();
         }
 
-        if (oldVersion <= 16) {
+        if (oldVersion <= 15) {
             // Add in 2020 First Spouse Gold Coins
             ArrayList<String> newCoinIdentifiers = new ArrayList<>();
             newCoinIdentifiers.add("Barbara Bush");

--- a/app/src/main/java/com/spencerpages/collections/JeffersonNickels.java
+++ b/app/src/main/java/com/spencerpages/collections/JeffersonNickels.java
@@ -259,22 +259,22 @@ public class JeffersonNickels extends CollectionInfo {
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2020);
         }
 
-        if (oldVersion <= 16) {
+        if (oldVersion <= 15) {
             // Add in new 2021 coins if applicable
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2021);
         }
 
-        if (oldVersion <= 18) {
+        if (oldVersion <= 17) {
             // Add in new 2022 coins if applicable
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2022);
         }
 
-        if (oldVersion <= 19) {
+        if (oldVersion <= 18) {
             // Add in new 2023 coins if applicable
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2023);
         }
 
-        if (oldVersion <= 20) {
+        if (oldVersion <= 19) {
             // Add in new 2024 coins if applicable
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2024);
         }

--- a/app/src/main/java/com/spencerpages/collections/LincolnCents.java
+++ b/app/src/main/java/com/spencerpages/collections/LincolnCents.java
@@ -251,22 +251,22 @@ public class LincolnCents extends CollectionInfo {
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2020);
         }
 
-        if (oldVersion <= 16) {
+        if (oldVersion <= 15) {
             // Add in new 2021 coins if applicable
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2021);
         }
 
-        if (oldVersion <= 18) {
+        if (oldVersion <= 17) {
             // Add in new 2022 coins if applicable
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2022);
         }
 
-        if (oldVersion <= 19) {
+        if (oldVersion <= 18) {
             // Add in new 2023 coins if applicable
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2023);
         }
 
-        if (oldVersion <= 20) {
+        if (oldVersion <= 19) {
             // Add in new 2024 coins if applicable
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2024);
         }

--- a/app/src/main/java/com/spencerpages/collections/NationalParkQuarters.java
+++ b/app/src/main/java/com/spencerpages/collections/NationalParkQuarters.java
@@ -325,7 +325,7 @@ public class NationalParkQuarters extends CollectionInfo {
             total += DatabaseHelper.addFromArrayList(db, collectionListInfo, newCoinIdentifiers);
         }
 
-        if (oldVersion <= 16) {
+        if (oldVersion <= 15) {
             // Add in 2021 National Park Quarters
 
             ArrayList<String> newCoinIdentifiers = new ArrayList<>();

--- a/app/src/main/java/com/spencerpages/collections/NativeAmericanDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/NativeAmericanDollars.java
@@ -193,22 +193,22 @@ public class NativeAmericanDollars extends CollectionInfo {
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2020);
         }
 
-        if (oldVersion <= 16) {
+        if (oldVersion <= 15) {
             // Add in new 2021 coins if applicable
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2021);
         }
 
-        if (oldVersion <= 18) {
+        if (oldVersion <= 17) {
             // Add in new 2022 coins if applicable
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2022);
         }
 
-        if (oldVersion <= 19) {
+        if (oldVersion <= 18) {
             // Add in new 2023 coins if applicable
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2023);
         }
 
-        if (oldVersion <= 20) {
+        if (oldVersion <= 19) {
             // Add in new 2024 coins if applicable
             total += DatabaseHelper.addFromYear(db, collectionListInfo, 2024);
         }

--- a/app/src/main/java/com/spencerpages/collections/PresidentialDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/PresidentialDollars.java
@@ -242,7 +242,7 @@ public class PresidentialDollars extends CollectionInfo {
             total += DatabaseHelper.addFromArrayList(db, collectionListInfo, newCoinIdentifiers);
         }
 
-        if (oldVersion <= 16) {
+        if (oldVersion <= 15) {
             // Add in missing 2020 Presidential Dollars
 
             ArrayList<String> newCoinIdentifiers = new ArrayList<>();


### PR DESCRIPTION
Some users reported duplicates for American Women Quarters and a few others - I investigated and found that we were off by 1 in the upgrade code from 2021-2024. This meant that a duplicate set of coins from 2023 would get added during the 2024 upgrade, etc. The 2025 update was correct, however, the 2024 coin update was incorrect so those get duplicately added w/ the 2025 upgrade.