### PR TITLE
Fixing issue selecting Penny collections

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    android:versionCode="35"
-    android:versionName="3.7.3">
+    android:versionCode="36"
+    android:versionName="3.7.4">
 
     <uses-feature android:name="android.hardware.touchscreen" />
 

--- a/app/src/main/java/com/coincollection/CoinPageCreator.java
+++ b/app/src/main/java/com/coincollection/CoinPageCreator.java
@@ -325,11 +325,6 @@ public class CoinPageCreator extends BaseActivity {
                     return;
                 }
 
-                // If the users selects a non-coin option, keep index in range
-                if (newCoinTypeIndex == -1) {
-                    newCoinTypeIndex = 0;
-                }
-
                 // When an item is selected, switch our internal state based on the collection type
                 setInternalStateFromCollectionIndex(newCoinTypeIndex, position, null);
 
@@ -731,21 +726,20 @@ public class CoinPageCreator extends BaseActivity {
         mCoinTypeIndex = index;
         mCoinTypeListPos = position;
 
-        mCollectionObj = MainApplication.COLLECTION_TYPES[mCoinTypeIndex];
-
         // Get the defaults for the parameters that this new collection type cares about
         mDefaults = new HashMap<>();
-        mCollectionObj.getCreationParameters(mDefaults);
+        mParameters = new ParcelableHashMap();
 
-        if (parameters == null) {
-            mParameters = new ParcelableHashMap();
-            mCollectionObj.getCreationParameters(mParameters);
-        } else {
-            // Allow the parameters to be passed in for things like testing and on screen rotation
-            mParameters = parameters;
+        if (mCoinTypeIndex != -1) {
+            mCollectionObj = MainApplication.COLLECTION_TYPES[mCoinTypeIndex];
+            mCollectionObj.getCreationParameters(mDefaults);
+            if (parameters == null) {
+                mCollectionObj.getCreationParameters(mParameters);
+            } else {
+                // Allow the parameters to be passed in for things like testing and on screen rotation
+                mParameters = parameters;
+            }
         }
-
-        // TODO Validate mParameters
     }
 
     @Override


### PR DESCRIPTION
@aDesertRat noticed this and I was able to recreate locally. There was an issue with the default list index/pos causing pennies from not being able to be selected. This PR fixes that