### PR TITLE
Adding path-ignore/paths to workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,9 +14,17 @@ name: "CodeQL"
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'images/**'
+      - 'fastlane/metadata/**'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'images/**'
+      - 'fastlane/metadata/**'
   schedule:
     - cron: '24 13 * * 5'
 

--- a/.github/workflows/devskim-analysis.yml
+++ b/.github/workflows/devskim-analysis.yml
@@ -8,8 +8,16 @@ name: DevSkim
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'images/**'
+      - 'fastlane/metadata/**'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'images/**'
+      - 'fastlane/metadata/**'
   schedule:
     - cron: '43 9 * * 3'
 

--- a/.github/workflows/fastlane-analysis.yml
+++ b/.github/workflows/fastlane-analysis.yml
@@ -5,8 +5,12 @@ name: Fastlane Metadata
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'fastlane/metadata/**'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'fastlane/metadata/**'
 
 jobs:
   validate:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -6,8 +6,16 @@ name: Android CI
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'images/**'
+      - 'fastlane/metadata/**'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'images/**'
+      - 'fastlane/metadata/**'
 
 jobs:
   test:

--- a/.github/workflows/ossar-analysis.yml
+++ b/.github/workflows/ossar-analysis.yml
@@ -11,9 +11,17 @@ name: OSSAR
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'images/**'
+      - 'fastlane/metadata/**'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'images/**'
+      - 'fastlane/metadata/**'
   schedule:
     - cron: '33 4 * * 2'
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR templates start with H2, not H1 -->

## Description
This pull request updates several GitHub Actions workflow files to optimize when CI and analysis jobs run. The main change is to exclude documentation files, images, and Fastlane metadata from triggering most workflows, while ensuring the Fastlane-specific workflow only runs when relevant files change. This helps reduce unnecessary workflow runs and improves CI efficiency.

Workflow trigger optimizations:

* Added `paths-ignore` to the `push` and `pull_request` triggers in the following workflows to prevent them from running when only documentation (`*.md`), images, or Fastlane metadata are changed:
  - `codeql-analysis.yml`
  - `devskim-analysis.yml`
  - `gradle.yml`
  - `ossar-analysis.yml`

Fastlane workflow targeting:

* Updated `fastlane-analysis.yml` to only run on changes to files in `fastlane/metadata/**` by adding `paths` to the `push` and `pull_request` triggers.

<!-- Brief description of the changes in this PR -->
