### PR TITLE
Add GitHub Actions release pipelines (pre-release + promote)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -155,31 +155,36 @@ jobs:
 
       - name: Deploy to Google Play (Testers)
         if: github.event.inputs.deployment_target == 'google_play_testers'
+        env:
+          RELEASE_NOTES: ${{ github.event.inputs.releaseNotes }}
         run: |
           bundle exec fastlane deploy_playstore_test \
             apk_path:"downloaded_apks/app-android-release-v${{ steps.resolve_version.outputs.version_name }}.apk" \
             version_name:"${{ steps.resolve_version.outputs.version_name }}" \
             version_code:"${{ steps.resolve_version.outputs.version_code }}" \
             track:"${{ github.event.inputs.play_track }}" \
-            release_notes:"${{ github.event.inputs.releaseNotes }}"
+            release_notes:"$RELEASE_NOTES"
 
       - name: Deploy to Google Play (Production)
         if: github.event.inputs.deployment_target == 'production_google_play_and_amazon'
+        env:
+          RELEASE_NOTES: ${{ github.event.inputs.releaseNotes }}
         run: |
           bundle exec fastlane deploy_playstore_production \
             apk_path:"downloaded_apks/app-android-release-v${{ steps.resolve_version.outputs.version_name }}.apk" \
             version_name:"${{ steps.resolve_version.outputs.version_name }}" \
             version_code:"${{ steps.resolve_version.outputs.version_code }}" \
-            release_notes:"${{ github.event.inputs.releaseNotes }}"
+            release_notes:"$RELEASE_NOTES"
 
       - name: Deploy to Amazon Appstore
         if: github.event.inputs.deployment_target == 'production_google_play_and_amazon'
         env:
           AMAZON_CLIENT_ID: ${{ secrets.AMAZON_CLIENT_ID }}
           AMAZON_CLIENT_SECRET: ${{ secrets.AMAZON_CLIENT_SECRET }}
+          RELEASE_NOTES: ${{ github.event.inputs.releaseNotes }}
         run: |
           bundle exec fastlane deploy_amazon_appstore \
             apk_path:"downloaded_apks/app-amazon-release-v${{ steps.resolve_version.outputs.version_name }}.apk" \
             version_name:"${{ steps.resolve_version.outputs.version_name }}" \
             version_code:"${{ steps.resolve_version.outputs.version_code }}" \
-            release_notes:"${{ github.event.inputs.releaseNotes }}"
+            release_notes:"$RELEASE_NOTES"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,17 +3,30 @@ name: Deploy Release to App Stores
 on:
   workflow_dispatch:
     inputs:
-      # Versioning information is derived from the main branch's manifest and the corresponding GitHub Release.
       deployment_target:
-        description: 'Select the deployment target'
+        description: 'Which audience to deploy to'
         required: true
         type: choice
         options:
-          - google_play_internal_test_track
+          - google_play_testers          # Closed testing (alpha) by default; see play_track
           - production_google_play_and_amazon
-        default: 'google_play_internal_test_track'
-      releaseNotes: 
-        description: 'Release notes for the app store listings. Can be same or different from GitHub Release notes.'
+        default: 'google_play_testers'
+      play_track:
+        description: 'Google Play track (used only when deployment_target is google_play_testers)'
+        required: true
+        type: choice
+        options:
+          - alpha     # Closed testing
+          - beta      # Open testing
+          - internal  # Internal testing (limited to ~100 named testers)
+        default: 'alpha'
+      release_tag:
+        description: "Optional. GitHub Release tag to deploy (e.g. v3.2.0). Leave blank to use the version currently in main's AndroidManifest.xml."
+        required: false
+        type: string
+        default: ''
+      releaseNotes:
+        description: 'Release notes for the app store listings. Can match or differ from the GitHub Release notes.'
         required: true
         type: string
 
@@ -21,56 +34,73 @@ jobs:
   download_and_deploy:
     name: 'Download Release APKs and Deploy'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read   # Only need to read the GitHub Release to download attached APKs.
     steps:
       - name: Checkout main branch
         uses: actions/checkout@v7
         with:
-          ref: 'main' # Explicitly checkout main to get the latest manifest for version info
+          ref: 'main' # main carries the latest manifest; used as default version source.
 
-      - name: Extract versionName and versionCode from Manifest
-        id: extract_versions
+      - name: Resolve target version and tag
+        id: resolve_version
+        env:
+          INPUT_RELEASE_TAG: ${{ github.event.inputs.release_tag }}
         run: |
-          MANIFEST_PATH="app/src/main/AndroidManifest.xml"
-          if [ ! -f "$MANIFEST_PATH" ]; then
-            echo "AndroidManifest.xml not found"
-            exit 1
+          set -euo pipefail
+          if [ -n "$INPUT_RELEASE_TAG" ]; then
+            # Explicit tag provided by the operator. Strip a leading "v" if present
+            # to compute the versionName, but keep the tag value verbatim for gh.
+            TAG="$INPUT_RELEASE_TAG"
+            VERSION_NAME="${TAG#v}"
+            echo "Using operator-supplied tag: $TAG (versionName=$VERSION_NAME)"
+          else
+            MANIFEST_PATH="app/src/main/AndroidManifest.xml"
+            if [ ! -f "$MANIFEST_PATH" ]; then
+              echo "AndroidManifest.xml not found at $MANIFEST_PATH"
+              exit 1
+            fi
+            VERSION_NAME=$(grep 'android:versionName=' "$MANIFEST_PATH" | sed -n 's/.*android:versionName="\([^"]*\)".*/\1/p')
+            if [ -z "$VERSION_NAME" ]; then
+              echo "Could not extract versionName from $MANIFEST_PATH"
+              exit 1
+            fi
+            TAG="v$VERSION_NAME"
+            echo "Derived tag from main's manifest: $TAG"
           fi
-          
-          VERSION_NAME=$(grep 'android:versionName=' "$MANIFEST_PATH" | sed -n 's/.*android:versionName="\([^"]*\)".*/\1/p')
-          VERSION_CODE=$(grep 'android:versionCode=' "$MANIFEST_PATH" | sed -n 's/.*android:versionCode="\([0-9]*\)".*/\1/p')
-          
-          if [ -z "$VERSION_NAME" ] || [ -z "$VERSION_CODE" ]; then
-            echo "Could not extract versionName or versionCode from $MANIFEST_PATH"
-            exit 1
+
+          # versionCode is only used to name the Amazon changelog file. When an
+          # explicit tag is supplied, we cannot trust main's manifest (the tag
+          # may predate it), so use 0 as a sentinel and the Fastfile will skip
+          # writing the Amazon changelog file. Fastlane's `supply` derives the
+          # Play versionCode from the APK directly.
+          if [ -z "$INPUT_RELEASE_TAG" ]; then
+            VERSION_CODE=$(grep 'android:versionCode=' "app/src/main/AndroidManifest.xml" | sed -n 's/.*android:versionCode="\([0-9]*\)".*/\1/p')
+          else
+            VERSION_CODE="0"
           fi
-          echo "Extracted from main's manifest - versionName: $VERSION_NAME, versionCode: $VERSION_CODE"
-          echo "manifest_version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
-          echo "manifest_version_code=$VERSION_CODE" >> $GITHUB_OUTPUT
-      
-      - name: Verify Release Exists for Manifest Version and Set Tag
-        id: check_release
+
+          echo "Resolved: tag=$TAG versionName=$VERSION_NAME versionCode=$VERSION_CODE"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version_name=$VERSION_NAME" >> "$GITHUB_OUTPUT"
+          echo "version_code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
+
+      - name: Verify GitHub Release exists for tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          EXPECTED_TAG="v${{ steps.extract_versions.outputs.manifest_version_name }}"
-          echo "Verifying if GitHub Release for tag $EXPECTED_TAG exists (based on main branch's AndroidManifest.xml)..."
-          if ! command -v gh &> /dev/null; then
-              echo "GitHub CLI (gh) not found. It is required to verify the release."
-              exit 1
-          fi
-          # Check if a release associated with the expected tag exists
-          gh release view "$EXPECTED_TAG" --repo "$GITHUB_REPOSITORY"
-          if [ $? -ne 0 ]; then
-            echo "Error: Release for tag $EXPECTED_TAG not found. Please ensure 'release.yml' has been run successfully for version ${{ steps.extract_versions.outputs.manifest_version_name }} (currently in main's AndroidManifest.xml)."
+          TAG="${{ steps.resolve_version.outputs.tag }}"
+          echo "Verifying GitHub Release exists for $TAG..."
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null; then
+            echo "Error: GitHub Release for tag $TAG not found. Run the 'Build and Create GitHub Release' workflow first, or supply an existing release_tag input."
             exit 1
           fi
-          echo "Release for tag $EXPECTED_TAG found."
-          echo "tag_value=$EXPECTED_TAG" >> $GITHUB_OUTPUT # Sets the output for this step
+          echo "Release $TAG found."
 
       - name: Set up Ruby for Fastlane
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1' 
+          ruby-version: '3.1'
           bundler-cache: true
 
       - name: Download Release APKs from GitHub Release
@@ -78,65 +108,68 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Create download directory
+          set -euo pipefail
           mkdir -p downloaded_apks
-          
-          # Download Android APK
-          ANDROID_APK_NAME="app-android-release-v${{ steps.extract_versions.outputs.manifest_version_name }}.apk"
-          AMAZON_APK_NAME="app-amazon-release-v${{ steps.extract_versions.outputs.manifest_version_name }}.apk"
-          TAG="${{ steps.check_release.outputs.tag_value }}"
-          
+          VERSION_NAME="${{ steps.resolve_version.outputs.version_name }}"
+          TAG="${{ steps.resolve_version.outputs.tag }}"
+          ANDROID_APK_NAME="app-android-release-v${VERSION_NAME}.apk"
+          AMAZON_APK_NAME="app-amazon-release-v${VERSION_NAME}.apk"
+
           echo "Downloading APKs from release $TAG..."
-          
-          # Download Android APK
-          echo "Downloading $ANDROID_APK_NAME..."
           gh release download "$TAG" \
             --pattern "$ANDROID_APK_NAME" \
             --dir downloaded_apks \
             --repo "$GITHUB_REPOSITORY"
-          
-          # Download Amazon APK
-          echo "Downloading $AMAZON_APK_NAME..."
           gh release download "$TAG" \
             --pattern "$AMAZON_APK_NAME" \
             --dir downloaded_apks \
             --repo "$GITHUB_REPOSITORY"
-          
-          # Verify downloads
+
           if [ ! -f "downloaded_apks/$ANDROID_APK_NAME" ]; then
-            echo "Error: Failed to download $ANDROID_APK_NAME"
+            echo "Error: failed to download $ANDROID_APK_NAME"
             exit 1
           fi
-          
           if [ ! -f "downloaded_apks/$AMAZON_APK_NAME" ]; then
-            echo "Error: Failed to download $AMAZON_APK_NAME"
+            echo "Error: failed to download $AMAZON_APK_NAME"
             exit 1
           fi
-          
-          echo "Successfully downloaded both APKs"
           ls -la downloaded_apks/
 
       - name: Create Google Play Key File
-        run: echo "${{ secrets.GOOGLE_PLAY_JSON_KEY_DATA }}" > /tmp/google_play_key.json
         env:
           GOOGLE_PLAY_JSON_KEY_DATA: ${{ secrets.GOOGLE_PLAY_JSON_KEY_DATA }}
+        run: |
+          # Use printf with the value coming from `env:` rather than direct ${{ }}
+          # interpolation. The service-account JSON contains many " characters,
+          # which would break a `echo "${{ secrets.X }}"` style write.
+          if [ -z "$GOOGLE_PLAY_JSON_KEY_DATA" ]; then
+            echo "Error: GOOGLE_PLAY_JSON_KEY_DATA secret is not set."
+            exit 1
+          fi
+          printf '%s' "$GOOGLE_PLAY_JSON_KEY_DATA" > /tmp/google_play_key.json
+          # Sanity-check it parses as JSON before invoking fastlane.
+          python3 -c 'import json,sys; json.load(open("/tmp/google_play_key.json"))' || {
+            echo "Error: GOOGLE_PLAY_JSON_KEY_DATA did not parse as JSON.";
+            exit 1;
+          }
 
-      - name: Deploy to Google Play (Internal Test Track)
-        if: github.event.inputs.deployment_target == 'google_play_internal_test_track'
+      - name: Deploy to Google Play (Testers)
+        if: github.event.inputs.deployment_target == 'google_play_testers'
         run: |
           bundle exec fastlane deploy_playstore_test \
-            apk_path:"downloaded_apks/app-android-release-v${{ steps.extract_versions.outputs.manifest_version_name }}.apk" \
-            version_name:"${{ steps.extract_versions.outputs.manifest_version_name }}" \
-            version_code:"${{ steps.extract_versions.outputs.manifest_version_code }}" \
+            apk_path:"downloaded_apks/app-android-release-v${{ steps.resolve_version.outputs.version_name }}.apk" \
+            version_name:"${{ steps.resolve_version.outputs.version_name }}" \
+            version_code:"${{ steps.resolve_version.outputs.version_code }}" \
+            track:"${{ github.event.inputs.play_track }}" \
             release_notes:"${{ github.event.inputs.releaseNotes }}"
 
       - name: Deploy to Google Play (Production)
         if: github.event.inputs.deployment_target == 'production_google_play_and_amazon'
         run: |
           bundle exec fastlane deploy_playstore_production \
-            apk_path:"downloaded_apks/app-android-release-v${{ steps.extract_versions.outputs.manifest_version_name }}.apk" \
-            version_name:"${{ steps.extract_versions.outputs.manifest_version_name }}" \
-            version_code:"${{ steps.extract_versions.outputs.manifest_version_code }}" \
+            apk_path:"downloaded_apks/app-android-release-v${{ steps.resolve_version.outputs.version_name }}.apk" \
+            version_name:"${{ steps.resolve_version.outputs.version_name }}" \
+            version_code:"${{ steps.resolve_version.outputs.version_code }}" \
             release_notes:"${{ github.event.inputs.releaseNotes }}"
 
       - name: Deploy to Amazon Appstore
@@ -146,7 +179,7 @@ jobs:
           AMAZON_CLIENT_SECRET: ${{ secrets.AMAZON_CLIENT_SECRET }}
         run: |
           bundle exec fastlane deploy_amazon_appstore \
-            apk_path:"downloaded_apks/app-amazon-release-v${{ steps.extract_versions.outputs.manifest_version_name }}.apk" \
-            version_name:"${{ steps.extract_versions.outputs.manifest_version_name }}" \
-            version_code:"${{ steps.extract_versions.outputs.manifest_version_code }}" \
+            apk_path:"downloaded_apks/app-amazon-release-v${{ steps.resolve_version.outputs.version_name }}.apk" \
+            version_name:"${{ steps.resolve_version.outputs.version_name }}" \
+            version_code:"${{ steps.resolve_version.outputs.version_code }}" \
             release_notes:"${{ github.event.inputs.releaseNotes }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,7 +92,7 @@ jobs:
           TAG="${{ steps.resolve_version.outputs.tag }}"
           echo "Verifying GitHub Release exists for $TAG..."
           if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null; then
-            echo "Error: GitHub Release for tag $TAG not found. Run the 'Build and Create GitHub Release' workflow first, or supply an existing release_tag input."
+            echo "Error: GitHub Release for tag $TAG not found. Run the 'Build and Publish Pre-release' and 'Promote Pre-release to Release' workflows first, or supply an existing release_tag input."
             exit 1
           fi
           echo "Release $TAG found."

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -147,22 +147,25 @@ jobs:
           }
 
       - name: Deploy to Google Play (Production)
+        env:
+          RELEASE_NOTES: ${{ github.event.inputs.releaseNotes }}
         run: |
           VERSION_NAME="${{ steps.parse.outputs.version_name }}"
           bundle exec fastlane deploy_playstore_production \
             apk_path:"downloaded_apks/app-android-release-v${VERSION_NAME}.apk" \
             version_name:"${VERSION_NAME}" \
             version_code:"${{ steps.resolve.outputs.version_code }}" \
-            release_notes:"${{ github.event.inputs.releaseNotes }}"
+            release_notes:"$RELEASE_NOTES"
 
       - name: Deploy to Amazon Appstore
         env:
           AMAZON_CLIENT_ID: ${{ secrets.AMAZON_CLIENT_ID }}
           AMAZON_CLIENT_SECRET: ${{ secrets.AMAZON_CLIENT_SECRET }}
+          RELEASE_NOTES: ${{ github.event.inputs.releaseNotes }}
         run: |
           VERSION_NAME="${{ steps.parse.outputs.version_name }}"
           bundle exec fastlane deploy_amazon_appstore \
             apk_path:"downloaded_apks/app-amazon-release-v${VERSION_NAME}.apk" \
             version_name:"${VERSION_NAME}" \
             version_code:"${{ steps.resolve.outputs.version_code }}" \
-            release_notes:"${{ github.event.inputs.releaseNotes }}"
+            release_notes:"$RELEASE_NOTES"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,168 @@
+name: Promote Pre-release to Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      rc_tag:
+        description: 'Pre-release tag to promote (e.g. v3.7.4-rc.1).'
+        required: true
+        type: string
+      releaseNotes:
+        description: "What's-new text for Google Play production and the Amazon Appstore."
+        required: true
+        type: string
+
+jobs:
+  promote:
+    name: 'Promote pre-release to production + Amazon (+ F-Droid tag)'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the final release and tag
+    steps:
+      - name: Validate and parse RC tag
+        id: parse
+        env:
+          INPUT_RC_TAG: ${{ github.event.inputs.rc_tag }}
+        run: |
+          set -euo pipefail
+          RC_TAG="$INPUT_RC_TAG"
+          # Only accept a proper pre-release tag: vMAJOR[.MINOR...]-rc.N
+          if ! printf '%s' "$RC_TAG" | grep -Eq '^v[0-9]+(\.[0-9]+)*-rc\.[0-9]+$'; then
+            echo "Error: rc_tag '$RC_TAG' is not of the form vX.Y.Z-rc.N."
+            exit 1
+          fi
+          VERSION_NAME="$(printf '%s' "$RC_TAG" | sed -E 's/^v//; s/-rc\.[0-9]+$//')"
+          FINAL_TAG="v${VERSION_NAME}"
+          echo "rc_tag=$RC_TAG" >> "$GITHUB_OUTPUT"
+          echo "version_name=$VERSION_NAME" >> "$GITHUB_OUTPUT"
+          echo "final_tag=$FINAL_TAG" >> "$GITHUB_OUTPUT"
+          echo "Parsed: rc_tag=$RC_TAG versionName=$VERSION_NAME final_tag=$FINAL_TAG"
+
+      - name: Checkout RC tag commit
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.parse.outputs.rc_tag }}
+          fetch-depth: 0
+
+      - name: Resolve commit and versionCode
+        id: resolve
+        run: |
+          set -euo pipefail
+          COMMIT_SHA="$(git rev-parse HEAD)"
+          MANIFEST_PATH="app/src/main/AndroidManifest.xml"
+          VERSION_CODE=$(grep 'android:versionCode=' "$MANIFEST_PATH" | sed -n 's/.*android:versionCode="\([0-9]*\)".*/\1/p')
+          if [ -z "$VERSION_CODE" ]; then
+            echo "Could not extract versionCode from $MANIFEST_PATH at ${{ steps.parse.outputs.rc_tag }}"
+            exit 1
+          fi
+          echo "commit_sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
+          echo "version_code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
+          echo "Commit: $COMMIT_SHA versionCode: $VERSION_CODE"
+
+      - name: Verify pre-release exists and final release does not
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          RC_TAG="${{ steps.parse.outputs.rc_tag }}"
+          FINAL_TAG="${{ steps.parse.outputs.final_tag }}"
+          if ! gh release view "$RC_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null; then
+            echo "Error: pre-release $RC_TAG not found. Run the 'Build and Publish Pre-release' workflow first."
+            exit 1
+          fi
+          if gh release view "$FINAL_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Error: final release $FINAL_TAG already exists. This pre-release was already promoted."
+            exit 1
+          fi
+          echo "Pre-release $RC_TAG present; final release $FINAL_TAG not yet created."
+
+      - name: Download APKs from pre-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p downloaded_apks
+          RC_TAG="${{ steps.parse.outputs.rc_tag }}"
+          VERSION_NAME="${{ steps.parse.outputs.version_name }}"
+          ANDROID_APK_NAME="app-android-release-v${VERSION_NAME}.apk"
+          AMAZON_APK_NAME="app-amazon-release-v${VERSION_NAME}.apk"
+
+          echo "Downloading APKs from pre-release $RC_TAG..."
+          gh release download "$RC_TAG" \
+            --pattern "$ANDROID_APK_NAME" \
+            --dir downloaded_apks \
+            --repo "$GITHUB_REPOSITORY"
+          gh release download "$RC_TAG" \
+            --pattern "$AMAZON_APK_NAME" \
+            --dir downloaded_apks \
+            --repo "$GITHUB_REPOSITORY"
+
+          if [ ! -f "downloaded_apks/$ANDROID_APK_NAME" ]; then
+            echo "Error: failed to download $ANDROID_APK_NAME"
+            exit 1
+          fi
+          if [ ! -f "downloaded_apks/$AMAZON_APK_NAME" ]; then
+            echo "Error: failed to download $AMAZON_APK_NAME"
+            exit 1
+          fi
+          ls -la downloaded_apks/
+
+      - name: Create final GitHub Release (F-Droid picks up this tag)
+        uses: softprops/action-gh-release@v3
+        with:
+          # The bare vX.Y.Z tag is what F-Droid's UpdateCheckMode watches. It is
+          # created here (not at pre-release time) and points at the exact commit
+          # the verified pre-release APKs were built from.
+          tag_name: ${{ steps.parse.outputs.final_tag }}
+          target_commitish: ${{ steps.resolve.outputs.commit_sha }}
+          name: Release ${{ steps.parse.outputs.final_tag }}
+          # Re-attach the exact same APKs that alpha testers verified.
+          files: |
+            downloaded_apks/app-android-release-v${{ steps.parse.outputs.version_name }}.apk
+            downloaded_apks/app-amazon-release-v${{ steps.parse.outputs.version_name }}.apk
+          fail_on_unmatched_files: true
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Ruby for Fastlane
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+
+      - name: Create Google Play Key File
+        env:
+          GOOGLE_PLAY_JSON_KEY_DATA: ${{ secrets.GOOGLE_PLAY_JSON_KEY_DATA }}
+        run: |
+          if [ -z "$GOOGLE_PLAY_JSON_KEY_DATA" ]; then
+            echo "Error: GOOGLE_PLAY_JSON_KEY_DATA secret is not set."
+            exit 1
+          fi
+          printf '%s' "$GOOGLE_PLAY_JSON_KEY_DATA" > /tmp/google_play_key.json
+          python3 -c 'import json,sys; json.load(open("/tmp/google_play_key.json"))' || {
+            echo "Error: GOOGLE_PLAY_JSON_KEY_DATA did not parse as JSON.";
+            exit 1;
+          }
+
+      - name: Deploy to Google Play (Production)
+        run: |
+          VERSION_NAME="${{ steps.parse.outputs.version_name }}"
+          bundle exec fastlane deploy_playstore_production \
+            apk_path:"downloaded_apks/app-android-release-v${VERSION_NAME}.apk" \
+            version_name:"${VERSION_NAME}" \
+            version_code:"${{ steps.resolve.outputs.version_code }}" \
+            release_notes:"${{ github.event.inputs.releaseNotes }}"
+
+      - name: Deploy to Amazon Appstore
+        env:
+          AMAZON_CLIENT_ID: ${{ secrets.AMAZON_CLIENT_ID }}
+          AMAZON_CLIENT_SECRET: ${{ secrets.AMAZON_CLIENT_SECRET }}
+        run: |
+          VERSION_NAME="${{ steps.parse.outputs.version_name }}"
+          bundle exec fastlane deploy_amazon_appstore \
+            apk_path:"downloaded_apks/app-amazon-release-v${VERSION_NAME}.apk" \
+            version_name:"${VERSION_NAME}" \
+            version_code:"${{ steps.resolve.outputs.version_code }}" \
+            release_notes:"${{ github.event.inputs.releaseNotes }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,10 +54,12 @@ jobs:
         run: |
           set -euo pipefail
           VERSION_NAME="${{ steps.extract_versions.outputs.manifest_version_name }}"
-          # Sanitize the RC number to digits only.
-          RC_NUMBER="$(printf '%s' "$INPUT_RC_NUMBER" | tr -cd '0-9')"
+          # Sanitize the RC number to digits only, then strip leading zeros so
+          # e.g. "007" -> "7" (and "0" / "000" -> ""). This rejects 0, which would
+          # otherwise produce a meaningless "-rc.0" tag.
+          RC_NUMBER="$(printf '%s' "$INPUT_RC_NUMBER" | tr -cd '0-9' | sed 's/^0*//')"
           if [ -z "$RC_NUMBER" ]; then
-            echo "Error: rc_number must be a positive integer."
+            echo "Error: rc_number must be a positive integer (>= 1)."
             exit 1
           fi
           FINAL_TAG="v${VERSION_NAME}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,8 @@ jobs:
           }
 
       - name: Deploy to Google Play (alpha / closed testing)
+        env:
+          RELEASE_NOTES: ${{ github.event.inputs.releaseNotes }}
         run: |
           MVN="${{ steps.extract_versions.outputs.manifest_version_name }}"
           bundle exec fastlane deploy_playstore_test \
@@ -194,4 +196,4 @@ jobs:
             version_name:"${MVN}" \
             version_code:"${{ steps.extract_versions.outputs.manifest_version_code }}" \
             track:"alpha" \
-            release_notes:"${{ github.event.inputs.releaseNotes }}"
+            release_notes:"$RELEASE_NOTES"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,24 @@
-name: Build and Create GitHub Release
+name: Build and Publish Pre-release
 
 on:
-  workflow_dispatch: {} # No inputs from user at trigger time
+  workflow_dispatch:
+    inputs:
+      rc_number:
+        description: 'Release candidate number for this pre-release (e.g. 1 produces tag vX.Y.Z-rc.1).'
+        required: true
+        type: string
+        default: '1'
+      releaseNotes:
+        description: "What's-new text for the Google Play closed testing (alpha) track."
+        required: true
+        type: string
 
 jobs:
-  build_and_create_release:
-    name: 'Build APKs and Create GitHub Release'
+  build_and_prerelease:
+    name: 'Build APKs, Publish Pre-release, Deploy to Play alpha'
     runs-on: ubuntu-latest
-    permissions: # Needed by softprops/action-gh-release to create releases
-      contents: write 
-    outputs: # Output extracted versions for potential use in other workflows if chained via API
-      tag_created: v${{ steps.extract_versions.outputs.manifest_version_name }}
-      version_name_extracted: ${{ steps.extract_versions.outputs.manifest_version_name }}
-      version_code_extracted: ${{ steps.extract_versions.outputs.manifest_version_code }}
+    permissions: # contents:write to create the pre-release; deploy uses Play creds via secrets
+      contents: write
     steps:
       - name: Checkout code (full history for release notes)
         uses: actions/checkout@v7
@@ -41,26 +47,36 @@ jobs:
           echo "manifest_version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
           echo "manifest_version_code=$VERSION_CODE" >> $GITHUB_OUTPUT
 
-      - name: Check if Git Tag Exists
+      - name: Compose RC tag and check tags do not exist
         id: check_tag
+        env:
+          INPUT_RC_NUMBER: ${{ github.event.inputs.rc_number }}
         run: |
-          TAG_NAME="v${{ steps.extract_versions.outputs.manifest_version_name }}"
-          echo "Checking for existing tag: $TAG_NAME"
-          # Fetch all tags from remote to ensure local git knows about them
-          git fetch --tags --force # --force to overwrite local tags with remote, ensuring up-to-date check
-          # Check if tag exists locally (which implies it would have been fetched if remote)
-          if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
-            echo "Error: Tag $TAG_NAME already exists. Halting workflow to prevent duplicate release."
+          set -euo pipefail
+          VERSION_NAME="${{ steps.extract_versions.outputs.manifest_version_name }}"
+          # Sanitize the RC number to digits only.
+          RC_NUMBER="$(printf '%s' "$INPUT_RC_NUMBER" | tr -cd '0-9')"
+          if [ -z "$RC_NUMBER" ]; then
+            echo "Error: rc_number must be a positive integer."
             exit 1
           fi
-          # As an additional safeguard, explicitly check remote. 
-          # git ls-remote --tags origin refs/tags/$TAG_NAME will output the tag if it exists on remote.
-          # If it outputs something, the tag exists.
-          if git ls-remote --tags origin | grep -q "refs/tags/$TAG_NAME$"; then
-             echo "Error: Tag $TAG_NAME confirmed to exist on remote 'origin'."
-             exit 1
+          FINAL_TAG="v${VERSION_NAME}"
+          RC_TAG="v${VERSION_NAME}-rc.${RC_NUMBER}"
+          echo "Final release tag (reserved for promotion): $FINAL_TAG"
+          echo "Pre-release tag: $RC_TAG"
+          # Fetch all tags from remote so local git is authoritative.
+          git fetch --tags --force
+          if git rev-parse "$FINAL_TAG" >/dev/null 2>&1; then
+            echo "Error: Final tag $FINAL_TAG already exists; this version was already released. Bump android:versionName before pre-releasing."
+            exit 1
           fi
-          echo "Tag $TAG_NAME does not appear to exist locally or on remote 'origin'. Proceeding."
+          if git rev-parse "$RC_TAG" >/dev/null 2>&1; then
+            echo "Error: Pre-release tag $RC_TAG already exists. Use a higher rc_number."
+            exit 1
+          fi
+          echo "Neither $FINAL_TAG nor $RC_TAG exists. Proceeding."
+          echo "rc_tag=$RC_TAG" >> "$GITHUB_OUTPUT"
+          echo "final_tag=$FINAL_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Set up Java (for Gradle)
         uses: actions/setup-java@v5
@@ -69,10 +85,20 @@ jobs:
           java-version: '17' 
 
       - name: Decode and Place Keystore
-        run: |
-          echo "${{ secrets.SIGNING_KEYSTORE_DATA }}" | base64 --decode > ${{ github.workspace }}/app/release.keystore
         env:
           SIGNING_KEYSTORE_DATA: ${{ secrets.SIGNING_KEYSTORE_DATA }}
+        run: |
+          if [ -z "$SIGNING_KEYSTORE_DATA" ]; then
+            echo "Error: SIGNING_KEYSTORE_DATA secret is not set."
+            exit 1
+          fi
+          # Use printf + env-var (not direct ${{ }} interpolation) so the value never
+          # has to survive shell-quoting at the YAML expansion layer.
+          printf '%s' "$SIGNING_KEYSTORE_DATA" | base64 --decode > "${{ github.workspace }}/app/release.keystore"
+          if [ ! -s "${{ github.workspace }}/app/release.keystore" ]; then
+            echo "Error: decoded keystore is empty. SIGNING_KEYSTORE_DATA may be malformed."
+            exit 1
+          fi
 
       - name: Build Release APKs (Android and Amazon)
         env:
@@ -94,17 +120,76 @@ jobs:
           test -f "app/amazon/release/app-amazon-release-v${MVN}.apk"
           echo "Versioned APKs verified."
 
-      - name: Create GitHub Release
+      - name: Verify APKs are signed with the release key
+        # Fails the workflow early if signing wiring is broken (e.g. missing secrets,
+        # or signingConfig not applied to the release buildType). Without this check,
+        # an unsigned/debug-signed APK could be uploaded to a GitHub Release and only
+        # rejected later by the Play/Amazon stores.
+        run: |
+          MVN="${{ steps.extract_versions.outputs.manifest_version_name }}"
+          APKSIGNER=$(find "$ANDROID_HOME/build-tools" -name apksigner -type f | sort -V | tail -n 1)
+          if [ -z "$APKSIGNER" ]; then
+            echo "apksigner not found in \$ANDROID_HOME/build-tools"
+            exit 1
+          fi
+          for APK in \
+            "app/android/release/app-android-release-v${MVN}.apk" \
+            "app/amazon/release/app-amazon-release-v${MVN}.apk"; do
+            echo "Verifying signature: $APK"
+            "$APKSIGNER" verify --verbose "$APK"
+            # Reject debug-signed APKs: the AOSP debug cert's CN is
+            # "CN=Android Debug,O=Android,C=US". Refuse to publish those.
+            if "$APKSIGNER" verify --print-certs "$APK" | grep -q "CN=Android Debug"; then
+              echo "Error: $APK is signed with the Android debug key. Check SIGNING_* secrets."
+              exit 1
+            fi
+          done
+          echo "All APKs verified as signed with a non-debug key."
+
+      - name: Create GitHub Pre-release
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: v${{ steps.extract_versions.outputs.manifest_version_name }}
-          name: Release v${{ steps.extract_versions.outputs.manifest_version_name }}
+          tag_name: ${{ steps.check_tag.outputs.rc_tag }}
+          name: Pre-release ${{ steps.check_tag.outputs.rc_tag }}
           # body parameter is removed/empty to allow auto-generation
           files: |
             app/android/release/app-android-release-v${{ steps.extract_versions.outputs.manifest_version_name }}.apk
             app/amazon/release/app-amazon-release-v${{ steps.extract_versions.outputs.manifest_version_name }}.apk
           fail_on_unmatched_files: true # Ensures workflow fails if APKs are not found
           draft: false
-          prerelease: false
+          # Marked as pre-release. F-Droid watches git TAGS, not this flag, so the
+          # RC tag (vX.Y.Z-rc.N) must be excluded by fdroiddata UpdateCheckMode.
+          # The final vX.Y.Z release/tag is created later by promote.yml.
+          prerelease: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Ruby for Fastlane
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+
+      - name: Create Google Play Key File
+        env:
+          GOOGLE_PLAY_JSON_KEY_DATA: ${{ secrets.GOOGLE_PLAY_JSON_KEY_DATA }}
+        run: |
+          if [ -z "$GOOGLE_PLAY_JSON_KEY_DATA" ]; then
+            echo "Error: GOOGLE_PLAY_JSON_KEY_DATA secret is not set."
+            exit 1
+          fi
+          printf '%s' "$GOOGLE_PLAY_JSON_KEY_DATA" > /tmp/google_play_key.json
+          python3 -c 'import json,sys; json.load(open("/tmp/google_play_key.json"))' || {
+            echo "Error: GOOGLE_PLAY_JSON_KEY_DATA did not parse as JSON.";
+            exit 1;
+          }
+
+      - name: Deploy to Google Play (alpha / closed testing)
+        run: |
+          MVN="${{ steps.extract_versions.outputs.manifest_version_name }}"
+          bundle exec fastlane deploy_playstore_test \
+            apk_path:"app/android/release/app-android-release-v${MVN}.apk" \
+            version_name:"${MVN}" \
+            version_code:"${{ steps.extract_versions.outputs.manifest_version_code }}" \
+            track:"alpha" \
+            release_notes:"${{ github.event.inputs.releaseNotes }}"

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -192,9 +192,10 @@ compare its SHA-1 to **Play Console → Setup → App integrity →
 App signing → Upload certificate**. They must match exactly.
 
 **Release workflow fails decoding the keystore (`decoded keystore is empty`).**
-`SIGNING_KEYSTORE_DATA` value is not valid base64. Recreate it with
-`base64 -i upload-keystore.jks -o keystore.b64` and paste the entire file
-contents into the secret.
+`SIGNING_KEYSTORE_DATA` value is not valid base64. Recreate it and paste the
+entire file contents into the secret. On macOS/BSD use
+`base64 -i upload-keystore.jks -o keystore.b64`; on Linux/GNU use
+`base64 -w0 upload-keystore.jks > keystore.b64`.
 
 **Promote workflow fails with `pre-release ... not found`.**
 The pre-release workflow has not been run for that `rc_tag`, or the tag is

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,115 +1,458 @@
 # Deployment Process
 
-This document outlines the process for building, releasing, and deploying the Coin Collection Android application. This is managed by two distinct GitHub Actions workflows:
+This document covers two things:
 
-1. **Build and Create GitHub Release** (`.github/workflows/release.yml`): Builds and signs the APK, then creates a formal GitHub Release with the APK as an attachment. GitHub Releases are picked up automatically by the F-Droid App Repository.
-2. **Deploy Release to App Stores** (`.github/workflows/deploy.yml`): Takes an existing GitHub Release (and its attached APKs), downloads the APKs, and deploys them to the specified app store tracks (Google Play Internal, Google Play Production, Amazon Appstore).
+1. **One-time setup** — registering signing keys, store credentials, and GitHub
+   secrets so the CI workflows can build and publish.
+2. **Cutting a release** — the runbook for shipping a new version to alpha
+   testers first, and then to production (Google Play, Amazon Appstore, and
+   F-Droid).
 
-## CI/CD Pipeline Overview
+> **Context.** This app has been published to Google Play, the Amazon
+> Appstore, and F-Droid for years; releases have historically been built and
+> uploaded manually from a developer machine using the original legacy
+> upload keystore (created ~2014). The workflows below shift that work into
+> GitHub Actions while continuing to sign with the **same** legacy keystore
+> — do not generate a new one. Google Play and Amazon will reject any APK
+> signed with a different upload key.
 
-- **`.github/workflows/release.yml` (Build and Create GitHub Release)**:
-  - **Purpose**: To create an official, signed build of the application and a corresponding GitHub Release. This release includes the android and amazon APKs.
-  - **Trigger**: Manual (`workflow_dispatch`).
+The release flow is a **two-stage pipeline**: first a pre-release that only
+reaches alpha testers, then a promotion that ships the *exact same* artifact
+everywhere.
 
-- **`.github/workflows/deploy.yml` (Deploy Release to App Stores)**:
-  - **Purpose**: To deploy pre-built APKs (from GitHub Release) to various app store tracks.
-  - **Trigger**: Manual (`workflow_dispatch`).
-  - **Targets**: Select between the following deployment targets:
-    - `google_play_internal_test_track` Select this first to test the release version of the app via the Google Play test track.
-    - `production_google_play_and_amazon` Select this to release to all Google Play / Amazon App Store users.
+- **Build and Publish Pre-release** ([`.github/workflows/release.yml`](.github/workflows/release.yml))
+  builds and signs both flavor APKs (`android` and `amazon`), publishes a
+  GitHub **pre-release** tagged `vX.Y.Z-rc.N`, and deploys the `android` APK
+  to the Google Play **alpha** (closed testing) track. It deliberately does
+  **not** touch Play production, Amazon, or F-Droid.
+- **Promote Pre-release to Release** ([`.github/workflows/promote.yml`](.github/workflows/promote.yml))
+  takes a verified pre-release, re-attaches its exact APKs to a final
+  GitHub Release tagged `vX.Y.Z`, and deploys to Google Play **production**
+  and the **Amazon Appstore**. Creating the bare `vX.Y.Z` tag is what
+  releases the build to **F-Droid**.
+- **Deploy Release to App Stores** ([`.github/workflows/deploy.yml`](.github/workflows/deploy.yml))
+  is an optional manual fallback for ad-hoc deploys of an existing GitHub
+  Release to a chosen track. The standard flow uses the two workflows above.
 
-## Recommended Deployment Flow
+> **Why two stages and an RC tag?** F-Droid's build server watches this
+> repo's git **tags** — not GitHub's "pre-release" flag. To keep a build out
+> of F-Droid (and Play production / Amazon) while alpha testing, the
+> pre-release uses a distinct `vX.Y.Z-rc.N` tag and the bare `vX.Y.Z` tag is
+> created only at promotion. For this to work, F-Droid's metadata must be
+> told to ignore RC tags — see
+> [Step 1.9](#19-restrict-f-droid-to-final-release-tags).
 
-This flow ensures a consistent artifact is built, released, tested, and deployed.
+---
 
-### Step 1: Build and Create GitHub Release
+## 1. One-time setup
 
-1. Navigate to `Actions > Build and Create GitHub Release`.
-2. Click **"Run workflow"**.
-    - **Outcome**:
-        - The `release.yml` workflow runs.
-        - Signed APKs are built using the provided version information in AndroidManifest.xml.
-        - A GitHub Release and release tag are created.
+You only need to do this once per repository. Skip ahead to
+[Cutting a release](#2-cutting-a-release) if everything below is already
+configured.
 
-### Step 2: Deploy to Google Play Internal Test Track for Verification
+### 1.1 Locate the existing legacy upload keystore
 
-1. Navigate to `Actions > Deploy Release to App Stores`.
-2. Click **"Run workflow"**.
-    - **Deployment target**: Select `google_play_internal_test_track`.
-    - **Outcome**:
-        - The `deploy.yml` workflow runs.
-        - It downloads APKs from the GitHub Release created in Step 1 (e.g., from tag `v1.0.5`).
-        - The downloaded Android APK is deployed to the Google Play Store's Internal test track using the `deploy_playstore_test` Fastlane lane.
+The app has been published for years, so a working upload keystore already
+exists on the maintainer's development machine — typically the same
+`signing.properties` + `.jks`/`.keystore` pair used for manual builds. **Use
+that exact keystore.** Do not generate a new one: Google Play (and Amazon)
+bind your package to the certificate that signed earlier uploads, and an
+APK signed with a different key is rejected on upload.
 
-### Step 3: Test Thoroughly on Google Play Internal Track
+1. On the machine where releases have historically been built, find the
+   keystore. Common locations:
+   - The `storeFilePath` value referenced by the repo's local
+     `signing.properties` (gitignored).
+   - Older paths used pre-CI such as `~/keystores/coin-collection.jks` or
+     similar.
+2. Record four values — all needed as GitHub Secrets:
+   - The keystore file itself (the `.jks` / `.keystore`).
+   - The keystore (store) password.
+   - The key alias.
+   - The key password.
+3. Confirm the keystore's certificate matches what Google Play has on
+   record. In **Google Play Console → Setup → App integrity → App signing**,
+   note the **Upload certificate** SHA-1 fingerprint. Then locally:
+   ```bash
+   keytool -list -v -keystore /path/to/your.keystore -alias <alias>
+   ```
+   The `SHA1:` line under "Certificate fingerprints" must match the SHA-1
+   shown in Play Console. If it doesn't, you have the wrong keystore (or
+   the wrong alias — try `keytool -list -keystore /path/to/your.keystore`
+   with no alias to list all entries).
 
-1. Access your Google Play Console.
-2. Distribute the internal test build to your testers.
-3. Conduct comprehensive testing of the application.
+> **Legacy-key compatibility notes.**
+>
+> - A ~2014-era keystore is almost certainly **1024-bit RSA / SHA1withRSA**.
+>   That's fine for *uploading* to Google Play: Play App Signing handles
+>   re-signing distributed APKs with a modern key. The upload key only has
+>   to match what Play has on record — it does **not** need to satisfy
+>   modern strength requirements.
+> - For **Amazon Appstore**, which historically does *not* re-sign, the
+>   same legacy key continues to work because the listing is already bound
+>   to it. Continuing to sign with the same key preserves update
+>   compatibility for existing installs.
+> - For **F-Droid**, signing is irrelevant — F-Droid rebuilds from source
+>   and re-signs with its own key.
+> - **Do not** "upgrade" the upload key by replacing the keystore. If you
+>   want to rotate to a stronger upload key in the future, that's a
+>   separate Play Console workflow (**App signing → Request upload key
+>   reset**); do it deliberately, not as a side effect of CI work.
+>
+> **Back up the keystore before doing anything else.** Losing this file
+> means you can no longer publish updates to existing installs on Google
+> Play (without a Play-side key reset) or Amazon (no recovery). Make at
+> least one encrypted offline backup before proceeding.
 
-### Step 4: Deploy to Production Stores (Google Play Production & Amazon Appstore)
+### 1.2 Base64-encode the keystore
 
-1. Once the build from Step 2 has been successfully tested and approved:
-2. Navigate to `Actions > Deploy Release to App Stores` again.
-3. Click **"Run workflow"**.
-    - **Deployment target**: Select `production_google_play_and_amazon`.
-    - **Outcome**:
-        - The `deploy.yml` workflow runs again.
-        - It downloads the android and amazon APKs from the GitHub Release (e.g., from tag `v1.0.5`).
-        - The Android APK is deployed to the Google Play Store's Production track via the `deploy_playstore_production` Fastlane lane.
-        - The Amazon APK is deployed to the Amazon Appstore via the `deploy_amazon_appstore` Fastlane lane.
+GitHub Secrets can't hold binary data, so the keystore is stored as base64.
+Run this on the same machine where the legacy keystore lives.
 
-This process ensures that the exact artifact built and attached to the GitHub Release is the one tested and subsequently deployed to production environments.
+- macOS / Linux:
+  ```bash
+  base64 -i /path/to/your.keystore -o keystore.b64
+  ```
+- Windows PowerShell:
+  ```powershell
+  [Convert]::ToBase64String([IO.File]::ReadAllBytes("C:\path\to\your.keystore")) | Out-File keystore.b64 -Encoding ASCII
+  ```
 
-## Fastlane Lanes
+The contents of `keystore.b64` go into the `SIGNING_KEYSTORE_DATA` secret in
+[Step 1.6](#16-register-github-secrets). Delete `keystore.b64` after pasting
+it into GitHub — it is the keystore in plaintext-recoverable form.
 
-The Fastlane lanes defined in `fastlane/Fastfile` are now designed to deploy pre-built APKs. They expect an `apk_path` parameter pointing to the APK to be deployed.
+### 1.3 Create (or reuse) a Google Play service account
 
-- `deploy_playstore_test`:
-  - Deploys the APK (specified by `options[:apk_path]`) to the Google Play Store's **internal** test track.
-  - Uses `options[:release_notes]` for the changelog on this track.
-- `deploy_playstore_production`:
-  - Deploys the APK (specified by `options[:apk_path]`) to the Google Play Store's **production** track.
-  - Uses `options[:release_notes]` for the changelog on this track.
-- `deploy_amazon_appstore`:
-  - Deploys the APK (specified by `options[:apk_path]`) to the Amazon Appstore.
-  - If `options[:release_notes]` and `options[:version_code]` are provided, writes release notes to `fastlane/metadata/android/en-US/changelogs/#{options[:version_code]}.txt` for the plugin to pick up.
+Fastlane authenticates to the Play Developer API with a service-account JSON
+key. If the maintainer has been using Fastlane locally for manual uploads,
+this service account likely already exists — reuse the same JSON file. Skip
+to Step 1.4 in that case.
 
-## Prerequisites: GitHub Secrets Setup
+If there's no existing service account:
 
-The following GitHub Secrets must be configured in the repository settings (`Settings > Secrets and variables > Actions`):
+1. Open **Google Play Console → Setup → API access**.
+2. **Link** your Google Cloud project (or create one) if you haven't already.
+   The **Service accounts** section on this page stays hidden until a Google
+   Cloud project is linked — if you don't see it, complete this step first
+   and scroll down past the linked-project panel.
+3. Under **Service accounts**, click **Create new service account**. This does
+   not create it inline — it opens **Google Cloud Console → IAM & Admin →
+   Service Accounts**. There, click **Create service account**, finish the
+   wizard, then open the new account's **Keys → Add key → Create new key →
+   JSON** and download the JSON file (keep it safe; it's the secret).
+4. Back in Play Console → API access, refresh so the new account appears,
+   then click **Grant access** next to it and give it at minimum:
+   - **Release manager** role (or **Admin**), scoped to this app.
+   - Permissions: `Release to production`, `Release to testing tracks`,
+     `Manage testing track access`.
+5. The full JSON file's contents go into the `GOOGLE_PLAY_JSON_KEY_DATA`
+   secret in [Step 1.6](#16-register-github-secrets).
 
-1. **`GOOGLE_PLAY_JSON_KEY_DATA`**:
-    - **Description**: JSON key for Google Play Console service account. Allows Fastlane to authenticate with Google Play Developer API.
-    - **Used by**: `deploy.yml` (for Fastlane `supply` action).
-    - **How to obtain**: Google Play Console > Setup > API access.
+### 1.4 Enable the Google Play Closed testing (alpha) track
 
-2. **`SIGNING_KEYSTORE_DATA`**:
-    - **Description**: Base64 encoded Android signing keystore file (`.jks` or `.keystore`).
-    - **Used by**: `release.yml` (for signing the APK during the Gradle build).
-    - **How to obtain**: Convert your keystore file to base64.
-        - macOS/Linux: `base64 -i your_keystore_file.jks -o keystore_base64.txt`
-        - Windows (PowerShell): `[Convert]::ToBase64String([IO.File]::ReadAllBytes("your_keystore_file.jks")) | Out-File keystore_base64.txt -Encoding ASCII`
-        - Copy the content of `keystore_base64.txt` into the secret.
+The first deploy will fail if the Closed testing track doesn't exist yet.
 
-3. **`SIGNING_KEYSTORE_PASSWORD`**:
-    - **Description**: Password for the Android signing keystore.
-    - **Used by**: `release.yml`.
+1. **Google Play Console → Testing → Closed testing**.
+2. Click **Create track** (or use the default "Alpha" track).
+3. Add at least one tester (email list or Google group). You'll need this to
+   verify the test deploy in [Step 2.3](#23-verify-on-the-alpha-track).
+4. Save. You do not need to create a release here — Fastlane will.
 
-4. **`SIGNING_KEY_ALIAS`**:
-    - **Description**: Alias for the signing key within the keystore.
-    - **Used by**: `release.yml`.
+The track ID Fastlane uses is `alpha` (default), `beta`, or `internal`. Make
+sure the track you intend to target actually exists in Play Console.
 
-5. **`SIGNING_KEY_PASSWORD`**:
-    - **Description**: Password for the specific key alias.
-    - **Used by**: `release.yml`.
+### 1.5 Reuse or create Amazon Appstore API credentials
 
-6. **`AMAZON_CLIENT_ID`**:
-    - **Description**: Client ID for Amazon App Submission API.
-    - **Used by**: `deploy.yml` (for Fastlane `amazon_appstore` plugin).
-    - **How to obtain**: Amazon Developer Console documentation.
+The app already has an Amazon Appstore listing. If the maintainer has been
+uploading to Amazon via Fastlane locally, the API credentials likely already
+exist on that machine — reuse them. Otherwise:
 
-7. **`AMAZON_CLIENT_SECRET`**:
-    - **Description**: Client Secret for Amazon App Submission API.
-    - **Used by**: `deploy.yml`.
-    - **How to obtain**: Amazon Developer Console documentation.
+1. Open the [Amazon Developer Console](https://developer.amazon.com/) and
+   sign in with the account that owns the existing Appstore listing.
+2. Go to **Settings → Security Profile → API access**. Create a new security
+   profile if needed (existing profiles can be reused).
+3. Generate a **Client ID** and **Client Secret** with the **App Submission
+   API** scope enabled. Authorize this profile for your Appstore app.
+4. These values go into `AMAZON_CLIENT_ID` and `AMAZON_CLIENT_SECRET` in
+   [Step 1.6](#16-register-github-secrets).
+
+### 1.6 Register GitHub Secrets
+
+In the repository, go to **Settings → Secrets and variables → Actions →
+New repository secret** and add all of the following. Names must match
+exactly.
+
+| Secret | Source | Used by |
+| --- | --- | --- |
+| `SIGNING_KEYSTORE_DATA` | base64 of the keystore from Step 1.2 | `release.yml` |
+| `SIGNING_KEYSTORE_PASSWORD` | keystore password from Step 1.1 | `release.yml` |
+| `SIGNING_KEY_ALIAS` | key alias from Step 1.1 | `release.yml` |
+| `SIGNING_KEY_PASSWORD` | key password from Step 1.1 | `release.yml` |
+| `GOOGLE_PLAY_JSON_KEY_DATA` | full JSON file from Step 1.3 | `deploy.yml` |
+| `AMAZON_CLIENT_ID` | from Step 1.5 | `deploy.yml` |
+| `AMAZON_CLIENT_SECRET` | from Step 1.5 | `deploy.yml` |
+
+> `GITHUB_TOKEN` is provided automatically by Actions — do not create it.
+
+### 1.7 Verify signing locally (recommended)
+
+If manual builds already work on the maintainer's machine, the local
+`signing.properties` is already correct and this step can be skipped — but
+it's still worth running once to confirm the certificate fingerprint matches
+what's in Play Console (from Step 1.1).
+
+```bash
+./gradlew :app:assembleAndroidRelease
+$ANDROID_HOME/build-tools/*/apksigner verify --print-certs \
+  app/android/release/app-android-release-v*.apk
+```
+
+Check two things in the output:
+
+- The certificate **must not** show `CN=Android Debug`. If it does, the
+  signing config is not being applied — re-check `signing.properties`
+  paths.
+- The `SHA-1 digest` (or `SHA1` fingerprint) shown must match the **Upload
+  certificate** SHA-1 from Play Console (Step 1.1). If they differ, the
+  APK will be rejected on upload.
+
+> CI uses the `SIGNING_*` environment variables (sourced from the secrets
+> above), not `signing.properties`. The Gradle build prefers env vars when
+> they're set; see [`app/build.gradle`](app/build.gradle).
+
+### 1.8 (Optional) Protect the workflows
+
+These workflows can publish releases and ship to stores. Consider:
+
+- **Branch protection on `main`**: require PR review and a green
+  [Android CI](.github/workflows/gradle.yml) check before merge. Releases
+  are cut from `main`, so a broken `main` blocks bad releases.
+- **Environment with required reviewers** for `deploy.yml` — add an
+  `environment: production` block and configure required reviewers in
+  **Settings → Environments**. (Not enabled by default; left to operator.)
+
+### 1.9 Restrict F-Droid to final release tags
+
+F-Droid's build server tracks this repo through its metadata recipe at
+[`metadata/com.spencerpages.yml`](https://gitlab.com/fdroid/fdroiddata/-/blob/master/metadata/com.spencerpages.yml)
+in the `fdroiddata` project. That recipe currently uses:
+
+```yaml
+AutoUpdateMode: Version
+UpdateCheckMode: Tags
+```
+
+`UpdateCheckMode: Tags` with **no filter** makes F-Droid consider *every*
+tag — including the `vX.Y.Z-rc.N` pre-release tags. Because an RC tag carries
+the new `versionCode` (it has to, to upload to Play alpha), F-Droid would
+detect it and try to build the pre-release. To prevent that, restrict the
+check to final tags by opening a merge request against `fdroiddata` that
+changes the line to:
+
+```yaml
+UpdateCheckMode: Tags ^v[0-9.]+$
+```
+
+The `^v[0-9.]+$` regex matches `v3.7.4` but **not** `v3.7.4-rc.1` (the hyphen
+and letters are excluded). After this change, F-Droid only builds the bare
+`vX.Y.Z` tag created at promotion time. This is a **one-time** change; you do
+not need to touch it for future releases.
+
+> The app's APK naming already matches F-Droid's `Binaries:` template
+> (`app-android-release-v%v.apk`, where `%v` is the `versionName` with no RC
+> suffix), so no other `fdroiddata` change is required.
+
+---
+
+## 2. Cutting a release
+
+The pipeline has two operator-driven stages.
+
+- **Stage 1 — Pre-release** ([Step 2.1](#21-build-and-publish-the-pre-release))
+  builds the signed APKs, publishes them as a GitHub **pre-release** tagged
+  `vX.Y.Z-rc.N`, and ships the `android` APK to Google Play **alpha**. The
+  bare `vX.Y.Z` tag is *not* created, so F-Droid, Play production, and Amazon
+  are untouched. Alpha testers verify ([Step 2.2](#22-verify-on-the-alpha-track)).
+- **Stage 2 — Promote** ([Step 2.3](#23-promote-the-pre-release-to-a-release))
+  re-attaches the *exact same* APKs to a final GitHub Release tagged
+  `vX.Y.Z` and ships to Google Play **production** and **Amazon**. Creating
+  the `vX.Y.Z` tag releases the build to **F-Droid** automatically.
+
+
+```
+  bump version in          release.yml                    promote.yml
+  AndroidManifest.xml ─►   (Stage 1, Step 2.1)       ─►   (Stage 2, Step 2.3)
+  + merge to main          tag vX.Y.Z-rc.N                tag vX.Y.Z
+                           GitHub pre-release             final GitHub Release
+                           + Play alpha                   + Play production + Amazon
+                                  │                               │
+                                  └─► Alpha testers verify        ├─► Google Play production
+                                      (Step 2.2)                  ├─► Amazon Appstore
+                                                                  └─► F-Droid scans vX.Y.Z tag
+                                                                      (1–3 day lag)
+```
+
+### 2.1 Build and publish the pre-release
+
+1. Bump `android:versionName` **and** `android:versionCode` in
+   [`app/src/main/AndroidManifest.xml`](app/src/main/AndroidManifest.xml).
+   `versionCode` must strictly increase from the last published value on
+   every store. Because the app has been published for years, the current
+   value is already well into the dozens — just `+1` from whatever's on
+   `main` (and confirm it exceeds the latest Play / Amazon production
+   versionCode).
+2. Merge the version bump to `main`.
+3. In GitHub, go to **Actions → Build and Publish Pre-release → Run
+   workflow** and fill in the inputs:
+   - `rc_number`: the release-candidate number for this attempt (`1` the
+     first time; bump to `2`, `3`, … if you need another pre-release of the
+     same version). This produces the tag `vX.Y.Z-rc.N`.
+   - `releaseNotes`: the "what's new" text shown to Play alpha testers.
+4. The workflow:
+   - Refuses to run if the final tag `vX.Y.Z` **or** the chosen
+     `vX.Y.Z-rc.N` tag already exists.
+   - Builds `:app:assembleAndroidRelease` and `:app:assembleAmazonRelease`.
+   - Verifies the APKs are signed with the release key (fails on
+     debug-signed APKs).
+   - Creates a GitHub **pre-release** tagged `vX.Y.Z-rc.N` with both APKs
+     attached.
+   - Uploads the `android` APK to the Google Play **alpha** track.
+5. F-Droid does **not** build at this stage: the `vX.Y.Z-rc.N` tag is
+   excluded by the `UpdateCheckMode` regex from
+   [Step 1.9](#19-restrict-f-droid-to-final-release-tags), and the bare
+   `vX.Y.Z` tag does not exist yet. Amazon and Play production are untouched.
+
+### 2.2 Verify on the alpha track
+
+1. Open Google Play Console → **Testing → Closed testing → Alpha**. Confirm
+   a new release exists with the expected `versionCode`.
+2. On a test device opted into the closed-test program, install the build
+   from the Play Store and exercise the changed flows.
+3. Watch the Play Console pre-launch report for crashes / policy issues
+   before promoting.
+4. If a problem is found, fix it, bump `versionCode`/`versionName` as
+   needed, and run [Step 2.1](#21-build-and-publish-the-pre-release) again
+   with the next `rc_number` (or new version). Only promote once a
+   pre-release is green.
+
+### 2.3 Promote the pre-release to a release
+
+Once alpha testing is green:
+
+1. **Actions → Promote Pre-release to Release → Run workflow**.
+2. Inputs:
+   - `rc_tag`: the pre-release tag you verified, e.g. `v3.7.4-rc.1`.
+   - `releaseNotes`: production "what's new" text for Google Play and Amazon.
+     May match or differ from the alpha notes.
+3. The workflow:
+   - Verifies the pre-release exists and the final `vX.Y.Z` release does not.
+   - Downloads the exact APKs from the pre-release (no rebuild — guaranteeing
+     production gets the same bytes alpha testers verified).
+   - Creates the final GitHub Release tagged `vX.Y.Z`, pointing at the same
+     commit as the RC tag, with both APKs re-attached.
+   - Uploads the `android` APK to Google Play **production** and the
+     `amazon` APK to the **Amazon Appstore**.
+4. Both stores review independently. Google Play production reviews
+   typically take a few hours to a couple of days; Amazon Appstore reviews
+   take longer.
+5. F-Droid's build server picks up the new `vX.Y.Z` tag at its next scan,
+   rebuilds from source, and publishes. Expect F-Droid availability to lag
+   the GitHub Release by 1–3 days. No action required.
+
+> The `vX.Y.Z-rc.N` pre-release is kept after promotion as an audit trail.
+> You can delete it manually from the GitHub Releases page if you prefer.
+
+---
+
+## 3. Fastlane lanes (reference)
+
+Defined in [`fastlane/Fastfile`](fastlane/Fastfile). Each workflow passes a
+pre-built APK to the relevant lane via `apk_path` — the pre-release workflow
+builds it fresh, the promote workflow downloads it from the pre-release.
+
+- `deploy_playstore_test`
+  - Uploads to a Google Play tester track (`alpha`, `beta`, or `internal`).
+    The pre-release workflow always uses `alpha`.
+  - Inputs: `apk_path`, `track`, `release_notes`, optional
+    `version_name`, `version_code`.
+- `deploy_playstore_production`
+  - Uploads to the Google Play production track. Used by the promote workflow.
+  - Inputs: `apk_path`, `release_notes`.
+- `deploy_amazon_appstore`
+  - Uploads to the Amazon Appstore via `fastlane-plugin-amazon_appstore`.
+    Used by the promote workflow.
+  - Inputs: `apk_path`, `release_notes`, `version_code`. The promote workflow
+    passes the real `version_code` (read from the manifest at the RC tag),
+    so the Amazon changelog file is written from `release_notes`. A
+    `version_code` of `0` (the sentinel used by the optional `deploy.yml`
+    fallback) skips the changelog rewrite and reuses existing metadata.
+
+---
+
+## 4. Troubleshooting
+
+**Pre-release workflow fails with `Tag vX.Y.Z already exists` (or
+`vX.Y.Z-rc.N already exists`).**
+The final tag exists because this version was already released — bump
+`android:versionName` in
+[`app/src/main/AndroidManifest.xml`](app/src/main/AndroidManifest.xml) and
+merge to `main`. If only the RC tag exists, just pick a higher `rc_number`
+and re-run.
+
+**Release workflow fails with `... is signed with the Android debug key`.**
+One of the four `SIGNING_*` secrets is missing or wrong. Confirm all four
+exist in repo settings and that `SIGNING_KEYSTORE_DATA` is the base64 of the
+actual legacy upload keystore (not the debug keystore from `~/.android`,
+and not a freshly generated one).
+
+**Google Play upload rejected with `... your APK is not signed with the
+upload certificate`.**
+The SHA-1 of the signing certificate in the uploaded APK doesn't match the
+upload certificate Google Play has on record. Almost always this means CI
+is signing with the wrong key. Re-verify per [Step 1.1](#11-locate-the-existing-legacy-upload-keystore):
+run `keytool -list -v -keystore ... -alias ...` against the keystore being
+used, and compare its SHA-1 to **Play Console → Setup → App integrity →
+App signing → Upload certificate**. They must match exactly.
+
+**Release workflow fails decoding the keystore (`decoded keystore is empty`).**
+`SIGNING_KEYSTORE_DATA` value is not valid base64. Recreate it with
+`base64 -i upload-keystore.jks -o keystore.b64` and paste the entire file
+contents into the secret.
+
+**Promote workflow fails with `pre-release ... not found`.**
+The pre-release workflow has not been run for that `rc_tag`, or the tag is
+mistyped. Run **Build and Publish Pre-release** first, then promote the
+`vX.Y.Z-rc.N` tag it created.
+
+**Promote workflow fails with `final release vX.Y.Z already exists`.**
+This pre-release was already promoted. If you need to re-ship, bump the
+version and start a new pre-release.
+
+**Deploy fails: `Google Api Error: ... versionCode N has already been used`.**
+The `versionCode` in the APK has been uploaded to Play before. You cannot
+re-use a versionCode on Google Play. Bump `android:versionCode` and run the
+pre-release workflow again.
+
+**Deploy fails: `... GOOGLE_PLAY_JSON_KEY_DATA did not parse as JSON`.**
+The secret was pasted with surrounding quotes or had characters stripped.
+Re-download the service-account JSON and paste the complete file contents
+(starts with `{`, ends with `}`).
+
+**Deploy fails: `track 'alpha' is not a valid track`.**
+The Closed testing track is not set up in Play Console. Complete
+[Step 1.4](#14-enable-the-google-play-closed-testing-alpha-track).
+
+**Amazon Appstore deploy fails: `version_code already submitted`.**
+Same issue as Google Play — Amazon also enforces strictly increasing
+versionCodes. Bump and re-release.
+
+**F-Droid built a pre-release / RC tag.**
+The `fdroiddata` `UpdateCheckMode` is still unfiltered `Tags`. Apply the
+regex from [Step 1.9](#19-restrict-f-droid-to-final-release-tags) so RC tags
+are ignored.
+
+**F-Droid hasn't picked up the new release.**
+F-Droid scans on its own schedule and rebuilds from source. Expect a
+1–3 day lag after the final `vX.Y.Z` GitHub tag is created. Track build
+status at the F-Droid build logs / your package's metadata repo.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,20 +1,18 @@
 # Deployment Process
 
-This document covers two things:
+This document is the runbook for **cutting a release** — shipping a new
+version to alpha testers first, then to production (Google Play, Amazon
+Appstore, and F-Droid).
 
-1. **One-time setup** — registering signing keys, store credentials, and GitHub
-   secrets so the CI workflows can build and publish.
-2. **Cutting a release** — the runbook for shipping a new version to alpha
-   testers first, and then to production (Google Play, Amazon Appstore, and
-   F-Droid).
-
-> **Context.** This app has been published to Google Play, the Amazon
-> Appstore, and F-Droid for years; releases have historically been built and
-> uploaded manually from a developer machine using the original legacy
-> upload keystore (created ~2014). The workflows below shift that work into
-> GitHub Actions while continuing to sign with the **same** legacy keystore
-> — do not generate a new one. Google Play and Amazon will reject any APK
-> signed with a different upload key.
+> **Prerequisite.** The one-time setup (signing secrets, store credentials,
+> the Google Play closed-testing track, and the F-Droid tag filter) is
+> already configured for this repository. The steps below assume those
+> secrets and credentials are in place.
+>
+> **Context.** This app is signed with the original legacy upload keystore
+> (created ~2014). Google Play and Amazon will reject any APK signed with a
+> different upload key, so CI continues to sign with that **same** keystore
+> via the `SIGNING_*` secrets — never generate a new one.
 
 The release flow is a **two-stage pipeline**: first a pre-release that only
 reaches alpha testers, then a promotion that ships the *exact same* artifact
@@ -38,262 +36,40 @@ everywhere.
 > repo's git **tags** — not GitHub's "pre-release" flag. To keep a build out
 > of F-Droid (and Play production / Amazon) while alpha testing, the
 > pre-release uses a distinct `vX.Y.Z-rc.N` tag and the bare `vX.Y.Z` tag is
-> created only at promotion. For this to work, F-Droid's metadata must be
-> told to ignore RC tags — see
-> [Step 1.9](#19-restrict-f-droid-to-final-release-tags).
+> created only at promotion. F-Droid's metadata is already configured to
+> ignore RC tags (`UpdateCheckMode: Tags ^v[0-9.]+$`), so only the final
+> `vX.Y.Z` tag triggers an F-Droid build.
 
 ---
 
-## 1. One-time setup
-
-You only need to do this once per repository. Skip ahead to
-[Cutting a release](#2-cutting-a-release) if everything below is already
-configured.
-
-### 1.1 Locate the existing legacy upload keystore
-
-The app has been published for years, so a working upload keystore already
-exists on the maintainer's development machine — typically the same
-`signing.properties` + `.jks`/`.keystore` pair used for manual builds. **Use
-that exact keystore.** Do not generate a new one: Google Play (and Amazon)
-bind your package to the certificate that signed earlier uploads, and an
-APK signed with a different key is rejected on upload.
-
-1. On the machine where releases have historically been built, find the
-   keystore. Common locations:
-   - The `storeFilePath` value referenced by the repo's local
-     `signing.properties` (gitignored).
-   - Older paths used pre-CI such as `~/keystores/coin-collection.jks` or
-     similar.
-2. Record four values — all needed as GitHub Secrets:
-   - The keystore file itself (the `.jks` / `.keystore`).
-   - The keystore (store) password.
-   - The key alias.
-   - The key password.
-3. Confirm the keystore's certificate matches what Google Play has on
-   record. In **Google Play Console → Setup → App integrity → App signing**,
-   note the **Upload certificate** SHA-1 fingerprint. Then locally:
-   ```bash
-   keytool -list -v -keystore /path/to/your.keystore -alias <alias>
-   ```
-   The `SHA1:` line under "Certificate fingerprints" must match the SHA-1
-   shown in Play Console. If it doesn't, you have the wrong keystore (or
-   the wrong alias — try `keytool -list -keystore /path/to/your.keystore`
-   with no alias to list all entries).
-
-> **Legacy-key compatibility notes.**
->
-> - A ~2014-era keystore is almost certainly **1024-bit RSA / SHA1withRSA**.
->   That's fine for *uploading* to Google Play: Play App Signing handles
->   re-signing distributed APKs with a modern key. The upload key only has
->   to match what Play has on record — it does **not** need to satisfy
->   modern strength requirements.
-> - For **Amazon Appstore**, which historically does *not* re-sign, the
->   same legacy key continues to work because the listing is already bound
->   to it. Continuing to sign with the same key preserves update
->   compatibility for existing installs.
-> - For **F-Droid**, signing is irrelevant — F-Droid rebuilds from source
->   and re-signs with its own key.
-> - **Do not** "upgrade" the upload key by replacing the keystore. If you
->   want to rotate to a stronger upload key in the future, that's a
->   separate Play Console workflow (**App signing → Request upload key
->   reset**); do it deliberately, not as a side effect of CI work.
->
-> **Back up the keystore before doing anything else.** Losing this file
-> means you can no longer publish updates to existing installs on Google
-> Play (without a Play-side key reset) or Amazon (no recovery). Make at
-> least one encrypted offline backup before proceeding.
-
-### 1.2 Base64-encode the keystore
-
-GitHub Secrets can't hold binary data, so the keystore is stored as base64.
-Run this on the same machine where the legacy keystore lives.
-
-- macOS / Linux:
-  ```bash
-  base64 -i /path/to/your.keystore -o keystore.b64
-  ```
-- Windows PowerShell:
-  ```powershell
-  [Convert]::ToBase64String([IO.File]::ReadAllBytes("C:\path\to\your.keystore")) | Out-File keystore.b64 -Encoding ASCII
-  ```
-
-The contents of `keystore.b64` go into the `SIGNING_KEYSTORE_DATA` secret in
-[Step 1.6](#16-register-github-secrets). Delete `keystore.b64` after pasting
-it into GitHub — it is the keystore in plaintext-recoverable form.
-
-### 1.3 Create (or reuse) a Google Play service account
-
-Fastlane authenticates to the Play Developer API with a service-account JSON
-key. If the maintainer has been using Fastlane locally for manual uploads,
-this service account likely already exists — reuse the same JSON file. Skip
-to Step 1.4 in that case.
-
-If there's no existing service account:
-
-1. Open **Google Play Console → Setup → API access**.
-2. **Link** your Google Cloud project (or create one) if you haven't already.
-   The **Service accounts** section on this page stays hidden until a Google
-   Cloud project is linked — if you don't see it, complete this step first
-   and scroll down past the linked-project panel.
-3. Under **Service accounts**, click **Create new service account**. This does
-   not create it inline — it opens **Google Cloud Console → IAM & Admin →
-   Service Accounts**. There, click **Create service account**, finish the
-   wizard, then open the new account's **Keys → Add key → Create new key →
-   JSON** and download the JSON file (keep it safe; it's the secret).
-4. Back in Play Console → API access, refresh so the new account appears,
-   then click **Grant access** next to it and give it at minimum:
-   - **Release manager** role (or **Admin**), scoped to this app.
-   - Permissions: `Release to production`, `Release to testing tracks`,
-     `Manage testing track access`.
-5. The full JSON file's contents go into the `GOOGLE_PLAY_JSON_KEY_DATA`
-   secret in [Step 1.6](#16-register-github-secrets).
-
-### 1.4 Enable the Google Play Closed testing (alpha) track
-
-The first deploy will fail if the Closed testing track doesn't exist yet.
-
-1. **Google Play Console → Testing → Closed testing**.
-2. Click **Create track** (or use the default "Alpha" track).
-3. Add at least one tester (email list or Google group). You'll need this to
-   verify the test deploy in [Step 2.3](#23-verify-on-the-alpha-track).
-4. Save. You do not need to create a release here — Fastlane will.
-
-The track ID Fastlane uses is `alpha` (default), `beta`, or `internal`. Make
-sure the track you intend to target actually exists in Play Console.
-
-### 1.5 Reuse or create Amazon Appstore API credentials
-
-The app already has an Amazon Appstore listing. If the maintainer has been
-uploading to Amazon via Fastlane locally, the API credentials likely already
-exist on that machine — reuse them. Otherwise:
-
-1. Open the [Amazon Developer Console](https://developer.amazon.com/) and
-   sign in with the account that owns the existing Appstore listing.
-2. Go to **Settings → Security Profile → API access**. Create a new security
-   profile if needed (existing profiles can be reused).
-3. Generate a **Client ID** and **Client Secret** with the **App Submission
-   API** scope enabled. Authorize this profile for your Appstore app.
-4. These values go into `AMAZON_CLIENT_ID` and `AMAZON_CLIENT_SECRET` in
-   [Step 1.6](#16-register-github-secrets).
-
-### 1.6 Register GitHub Secrets
-
-In the repository, go to **Settings → Secrets and variables → Actions →
-New repository secret** and add all of the following. Names must match
-exactly.
-
-| Secret | Source | Used by |
-| --- | --- | --- |
-| `SIGNING_KEYSTORE_DATA` | base64 of the keystore from Step 1.2 | `release.yml` |
-| `SIGNING_KEYSTORE_PASSWORD` | keystore password from Step 1.1 | `release.yml` |
-| `SIGNING_KEY_ALIAS` | key alias from Step 1.1 | `release.yml` |
-| `SIGNING_KEY_PASSWORD` | key password from Step 1.1 | `release.yml` |
-| `GOOGLE_PLAY_JSON_KEY_DATA` | full JSON file from Step 1.3 | `deploy.yml` |
-| `AMAZON_CLIENT_ID` | from Step 1.5 | `deploy.yml` |
-| `AMAZON_CLIENT_SECRET` | from Step 1.5 | `deploy.yml` |
-
-> `GITHUB_TOKEN` is provided automatically by Actions — do not create it.
-
-### 1.7 Verify signing locally (recommended)
-
-If manual builds already work on the maintainer's machine, the local
-`signing.properties` is already correct and this step can be skipped — but
-it's still worth running once to confirm the certificate fingerprint matches
-what's in Play Console (from Step 1.1).
-
-```bash
-./gradlew :app:assembleAndroidRelease
-$ANDROID_HOME/build-tools/*/apksigner verify --print-certs \
-  app/android/release/app-android-release-v*.apk
-```
-
-Check two things in the output:
-
-- The certificate **must not** show `CN=Android Debug`. If it does, the
-  signing config is not being applied — re-check `signing.properties`
-  paths.
-- The `SHA-1 digest` (or `SHA1` fingerprint) shown must match the **Upload
-  certificate** SHA-1 from Play Console (Step 1.1). If they differ, the
-  APK will be rejected on upload.
-
-> CI uses the `SIGNING_*` environment variables (sourced from the secrets
-> above), not `signing.properties`. The Gradle build prefers env vars when
-> they're set; see [`app/build.gradle`](app/build.gradle).
-
-### 1.8 (Optional) Protect the workflows
-
-These workflows can publish releases and ship to stores. Consider:
-
-- **Branch protection on `main`**: require PR review and a green
-  [Android CI](.github/workflows/gradle.yml) check before merge. Releases
-  are cut from `main`, so a broken `main` blocks bad releases.
-- **Environment with required reviewers** for `deploy.yml` — add an
-  `environment: production` block and configure required reviewers in
-  **Settings → Environments**. (Not enabled by default; left to operator.)
-
-### 1.9 Restrict F-Droid to final release tags
-
-F-Droid's build server tracks this repo through its metadata recipe at
-[`metadata/com.spencerpages.yml`](https://gitlab.com/fdroid/fdroiddata/-/blob/master/metadata/com.spencerpages.yml)
-in the `fdroiddata` project. That recipe currently uses:
-
-```yaml
-AutoUpdateMode: Version
-UpdateCheckMode: Tags
-```
-
-`UpdateCheckMode: Tags` with **no filter** makes F-Droid consider *every*
-tag — including the `vX.Y.Z-rc.N` pre-release tags. Because an RC tag carries
-the new `versionCode` (it has to, to upload to Play alpha), F-Droid would
-detect it and try to build the pre-release. To prevent that, restrict the
-check to final tags by opening a merge request against `fdroiddata` that
-changes the line to:
-
-```yaml
-UpdateCheckMode: Tags ^v[0-9.]+$
-```
-
-The `^v[0-9.]+$` regex matches `v3.7.4` but **not** `v3.7.4-rc.1` (the hyphen
-and letters are excluded). After this change, F-Droid only builds the bare
-`vX.Y.Z` tag created at promotion time. This is a **one-time** change; you do
-not need to touch it for future releases.
-
-> The app's APK naming already matches F-Droid's `Binaries:` template
-> (`app-android-release-v%v.apk`, where `%v` is the `versionName` with no RC
-> suffix), so no other `fdroiddata` change is required.
-
----
-
-## 2. Cutting a release
+## 1. Cutting a release
 
 The pipeline has two operator-driven stages.
 
-- **Stage 1 — Pre-release** ([Step 2.1](#21-build-and-publish-the-pre-release))
+- **Stage 1 — Pre-release** ([Step 1.1](#11-build-and-publish-the-pre-release))
   builds the signed APKs, publishes them as a GitHub **pre-release** tagged
   `vX.Y.Z-rc.N`, and ships the `android` APK to Google Play **alpha**. The
   bare `vX.Y.Z` tag is *not* created, so F-Droid, Play production, and Amazon
-  are untouched. Alpha testers verify ([Step 2.2](#22-verify-on-the-alpha-track)).
-- **Stage 2 — Promote** ([Step 2.3](#23-promote-the-pre-release-to-a-release))
+  are untouched. Alpha testers verify ([Step 1.2](#12-verify-on-the-alpha-track)).
+- **Stage 2 — Promote** ([Step 1.3](#13-promote-the-pre-release-to-a-release))
   re-attaches the *exact same* APKs to a final GitHub Release tagged
   `vX.Y.Z` and ships to Google Play **production** and **Amazon**. Creating
   the `vX.Y.Z` tag releases the build to **F-Droid** automatically.
 
-
-```
+```text
   bump version in          release.yml                    promote.yml
-  AndroidManifest.xml ─►   (Stage 1, Step 2.1)       ─►   (Stage 2, Step 2.3)
+  AndroidManifest.xml ─►   (Stage 1, Step 1.1)       ─►   (Stage 2, Step 1.3)
   + merge to main          tag vX.Y.Z-rc.N                tag vX.Y.Z
                            GitHub pre-release             final GitHub Release
                            + Play alpha                   + Play production + Amazon
                                   │                               │
                                   └─► Alpha testers verify        ├─► Google Play production
-                                      (Step 2.2)                  ├─► Amazon Appstore
+                                      (Step 1.2)                  ├─► Amazon Appstore
                                                                   └─► F-Droid scans vX.Y.Z tag
                                                                       (1–3 day lag)
 ```
 
-### 2.1 Build and publish the pre-release
+### 1.1 Build and publish the pre-release
 
 1. Bump `android:versionName` **and** `android:versionCode` in
    [`app/src/main/AndroidManifest.xml`](app/src/main/AndroidManifest.xml).
@@ -319,11 +95,11 @@ The pipeline has two operator-driven stages.
      attached.
    - Uploads the `android` APK to the Google Play **alpha** track.
 5. F-Droid does **not** build at this stage: the `vX.Y.Z-rc.N` tag is
-   excluded by the `UpdateCheckMode` regex from
-   [Step 1.9](#19-restrict-f-droid-to-final-release-tags), and the bare
-   `vX.Y.Z` tag does not exist yet. Amazon and Play production are untouched.
+   excluded by the `fdroiddata` `UpdateCheckMode` regex
+   (`Tags ^v[0-9.]+$`), and the bare `vX.Y.Z` tag does not exist yet.
+   Amazon and Play production are untouched.
 
-### 2.2 Verify on the alpha track
+### 1.2 Verify on the alpha track
 
 1. Open Google Play Console → **Testing → Closed testing → Alpha**. Confirm
    a new release exists with the expected `versionCode`.
@@ -332,11 +108,11 @@ The pipeline has two operator-driven stages.
 3. Watch the Play Console pre-launch report for crashes / policy issues
    before promoting.
 4. If a problem is found, fix it, bump `versionCode`/`versionName` as
-   needed, and run [Step 2.1](#21-build-and-publish-the-pre-release) again
+   needed, and run [Step 1.1](#11-build-and-publish-the-pre-release) again
    with the next `rc_number` (or new version). Only promote once a
    pre-release is green.
 
-### 2.3 Promote the pre-release to a release
+### 1.3 Promote the pre-release to a release
 
 Once alpha testing is green:
 
@@ -365,7 +141,7 @@ Once alpha testing is green:
 
 ---
 
-## 3. Fastlane lanes (reference)
+## 2. Fastlane lanes (reference)
 
 Defined in [`fastlane/Fastfile`](fastlane/Fastfile). Each workflow passes a
 pre-built APK to the relevant lane via `apk_path` — the pre-release workflow
@@ -390,7 +166,7 @@ builds it fresh, the promote workflow downloads it from the pre-release.
 
 ---
 
-## 4. Troubleshooting
+## 3. Troubleshooting
 
 **Pre-release workflow fails with `Tag vX.Y.Z already exists` (or
 `vX.Y.Z-rc.N already exists`).**
@@ -410,9 +186,9 @@ and not a freshly generated one).
 upload certificate`.**
 The SHA-1 of the signing certificate in the uploaded APK doesn't match the
 upload certificate Google Play has on record. Almost always this means CI
-is signing with the wrong key. Re-verify per [Step 1.1](#11-locate-the-existing-legacy-upload-keystore):
-run `keytool -list -v -keystore ... -alias ...` against the keystore being
-used, and compare its SHA-1 to **Play Console → Setup → App integrity →
+is signing with the wrong key. Re-verify the keystore behind the `SIGNING_*`
+secrets: run `keytool -list -v -keystore ... -alias ...` against it and
+compare its SHA-1 to **Play Console → Setup → App integrity →
 App signing → Upload certificate**. They must match exactly.
 
 **Release workflow fails decoding the keystore (`decoded keystore is empty`).**
@@ -440,17 +216,17 @@ Re-download the service-account JSON and paste the complete file contents
 (starts with `{`, ends with `}`).
 
 **Deploy fails: `track 'alpha' is not a valid track`.**
-The Closed testing track is not set up in Play Console. Complete
-[Step 1.4](#14-enable-the-google-play-closed-testing-alpha-track).
+The Closed testing track is not set up in Play Console. Create it under
+**Testing → Closed testing** and add at least one tester.
 
 **Amazon Appstore deploy fails: `version_code already submitted`.**
 Same issue as Google Play — Amazon also enforces strictly increasing
 versionCodes. Bump and re-release.
 
 **F-Droid built a pre-release / RC tag.**
-The `fdroiddata` `UpdateCheckMode` is still unfiltered `Tags`. Apply the
-regex from [Step 1.9](#19-restrict-f-droid-to-final-release-tags) so RC tags
-are ignored.
+The `fdroiddata` `UpdateCheckMode` is no longer filtering RC tags. Confirm
+the recipe still uses `UpdateCheckMode: Tags ^v[0-9.]+$` so RC tags are
+ignored.
 
 **F-Droid hasn't picked up the new release.**
 F-Droid scans on its own schedule and rebuilds from source. Expect a

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,8 +52,9 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.txt'
             // Apply the release signing config only when it was actually populated
             // (either via env vars in CI or signing.properties locally). Without this
-            // guard, unsigned release builds would fail; with it, devs can still
-            // produce debug-signed release builds for local testing.
+            // guard, Gradle would fail evaluating a signingConfig with a null
+            // storeFile. With it, a local build with no keystore configured simply
+            // produces an unsigned release APK (CI always provides the keystore).
             if (signingConfigs.Android.storeFile != null) {
                 signingConfig signingConfigs.Android
             }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,8 +5,20 @@ plugins {
 android {
     signingConfigs {
         Android {
+            // Local development: read from signing.properties (gitignored) when present.
             def signingPropsFile = new File('../signing.properties')
-            if (signingPropsFile.canRead()) {
+            // CI: when SIGNING_* env vars are set (see .github/workflows/release.yml),
+            // use them instead. Env vars take precedence over signing.properties.
+            def envKeystorePath = System.getenv('SIGNING_KEYSTORE_PATH')
+            def envKeystorePassword = System.getenv('SIGNING_KEYSTORE_PASSWORD')
+            def envKeyAlias = System.getenv('SIGNING_KEY_ALIAS')
+            def envKeyPassword = System.getenv('SIGNING_KEY_PASSWORD')
+            if (envKeystorePath && envKeystorePassword && envKeyAlias && envKeyPassword) {
+                storeFile = file(envKeystorePath)
+                storePassword = envKeystorePassword
+                keyAlias = envKeyAlias
+                keyPassword = envKeyPassword
+            } else if (signingPropsFile.canRead()) {
                 def props = new Properties()
                 def fileInputStream = new FileInputStream(signingPropsFile)
                 props.load(fileInputStream)
@@ -38,6 +50,13 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.txt'
+            // Apply the release signing config only when it was actually populated
+            // (either via env vars in CI or signing.properties locally). Without this
+            // guard, unsigned release builds would fail; with it, devs can still
+            // produce debug-signed release builds for local testing.
+            if (signingConfigs.Android.storeFile != null) {
+                signingConfig signingConfigs.Android
+            }
             android.applicationVariants.all { variant ->
                 variant.outputs.all {
                     outputFileName = "app-${variant.flavorName}-${variant.buildType.name}-v${variant.versionName}.apk"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,8 +10,10 @@
 #     https://docs.fastlane.tools/plugins/available-plugins
 #
 
-# Uncomment the line if you want fastlane to automatically update itself
-update_fastlane
+# Note: `update_fastlane` is intentionally NOT called here.
+# Fastlane versions are pinned in the repo's Gemfile/Gemfile.lock; allowing the
+# tool to self-update mid-run on CI has historically caused flaky failures.
+# Run `bundle update fastlane` locally when you need a new version.
 
 default_platform(:android)
 
@@ -45,30 +47,30 @@ platform :android do
     sh("cp metadata/android/en-US/images/phoneScreenshots/*.png ../images/screenshots/")
   end
 
-  desc "Deploy the app to Google Play Store (Internal Test Track) using a pre-built APK."
+  desc "Deploy the app to Google Play Store (tester track) using a pre-built APK."
   lane :deploy_playstore_test do |options|
     begin
-      UI.message("Deploying to Internal Test Track with options: #{options.inspect}")
+      UI.message("Deploying to Play tester track with options: #{options.inspect}")
       UI.user_error!("APK path must be provided via options[:apk_path] and exist.") unless options[:apk_path] && File.exist?(options[:apk_path])
 
-      # Gradle build steps are removed. APK is provided via options[:apk_path].
+      # Allow the caller to pick which Play tester track to deploy to.
+      # Defaults to 'alpha' (Closed testing). Other valid values: 'internal',
+      # 'beta'. The previous behavior used 'internal' unconditionally.
+      track = options[:track] && !options[:track].to_s.strip.empty? ? options[:track].to_s : 'alpha'
+      UI.user_error!("Invalid track: #{track}") unless %w[internal alpha beta].include?(track)
 
       supply_params = {
-        track: 'internal',
-        apk: options[:apk_path] # Use passed APK path
+        track: track,
+        apk: options[:apk_path]
         # json_key_file is already set in Appfile
       }
-      supply_params[:changelogs] = { 'en-US' => options[:release_notes] || 'Default changelog for internal track.' } if options[:release_notes]
-      # Optional: Pass version name and code if your supply setup needs them for metadata,
-      # though this is usually derived from the APK or managed in Play Console.
-      # supply_params[:version_name] = options[:version_name] if options[:version_name]
-      # supply_params[:version_code] = options[:version_code].to_i if options[:version_code]
+      supply_params[:changelogs] = { 'en-US' => options[:release_notes] || "Default changelog for #{track} track." } if options[:release_notes]
 
       supply(supply_params)
-      UI.success("Successfully deployed to Google Play Store (Internal Test Track)!")
+      UI.success("Successfully deployed to Google Play Store (#{track} track)!")
     rescue => ex
-      UI.error("Error deploying to Google Play Store (Internal): #{ex}")
-      raise ex # Re-raise the exception to fail the lane
+      UI.error("Error deploying to Google Play Store (tester track): #{ex}")
+      raise ex
     end
   end
 
@@ -106,15 +108,18 @@ platform :android do
 
       # Gradle build steps are removed. APK is provided via options[:apk_path].
 
-      # Handle changelogs by writing to file
-      if options[:release_notes] && options[:version_code]
+      # Handle changelogs by writing to file. The deploy workflow passes
+      # version_code="0" as a sentinel when the operator supplied an explicit
+      # release_tag (in which case the workflow can't trust main's manifest).
+      # Skip the changelog file in that case rather than writing "0.txt".
+      if options[:release_notes] && options[:version_code] && options[:version_code].to_i > 0
         changelog_dir = "./fastlane/metadata/android/en-US/changelogs"
         FileUtils.mkdir_p(changelog_dir) # Ensure directory exists
         changelog_path = File.join(changelog_dir, "#{options[:version_code]}.txt")
         File.open(changelog_path, 'w') { |file| file.write(options[:release_notes]) }
         UI.message("Wrote release notes to #{changelog_path} for version code #{options[:version_code]}")
       else
-        UI.important("No release notes or version code provided for Amazon changelog generation.")
+        UI.important("No release notes or valid version code provided for Amazon changelog generation; relying on existing changelog files (if any).")
       end
 
       # Check to ensure ENV variables are set

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -64,7 +64,7 @@ platform :android do
         apk: options[:apk_path]
         # json_key_file is already set in Appfile
       }
-      supply_params[:changelogs] = { 'en-US' => options[:release_notes] || "Default changelog for #{track} track." } if options[:release_notes]
+      supply_params[:changelogs] = { 'en-US' => options[:release_notes] } if options[:release_notes]
 
       supply(supply_params)
       UI.success("Successfully deployed to Google Play Store (#{track} track)!")
@@ -86,7 +86,7 @@ platform :android do
         track: 'production',
         apk: options[:apk_path] # Use passed APK path
       }
-      supply_params[:changelogs] = { 'en-US' => options[:release_notes] || 'Production release.' } if options[:release_notes]
+      supply_params[:changelogs] = { 'en-US' => options[:release_notes] } if options[:release_notes]
       # supply_params[:release_status] = 'completed' # Optional: to automatically submit for review
       # Optional: Pass version name and code if your supply setup needs them for metadata.
       # supply_params[:version_name] = options[:version_name] if options[:version_name]


### PR DESCRIPTION
## Summary

Introduces a two-stage, GitHub Actions–driven release pipeline so releases can be built, signed, and published without a developer machine.

- **`release.yml` (Stage 1 — Build & Publish Pre-release)**: builds + signs both flavor APKs (`android`, `amazon`), publishes a GitHub **pre-release** tagged `vX.Y.Z-rc.N`, and deploys the `android` APK to Google Play **alpha** (closed testing). Does not touch Play production, Amazon, or F-Droid.
- **`promote.yml` (Stage 2 — Promote Pre-release to Release)** *(new)*: re-attaches the *exact same* APKs from a verified pre-release to a final GitHub Release tagged `vX.Y.Z`, then deploys to Google Play **production** and the **Amazon Appstore**. Creating the bare `vX.Y.Z` tag is what releases to **F-Droid**.
- **`deploy.yml`**: reworked into an optional manual fallback for ad-hoc deploys.
- **`fastlane/Fastfile`**: updated lanes (`deploy_playstore_test`, `deploy_playstore_production`, `deploy_amazon_appstore`).
- **`app/build.gradle`**: signing config now prefers `SIGNING_*` env vars (CI) over `signing.properties` (local), and safely skips release signing when neither is present.
- **`DEPLOYMENT.md`**: rewritten as the authoritative two-stage runbook (one-time setup + cut-a-release).

## F-Droid

`fdroiddata` metadata already updated to `UpdateCheckMode: Tags ^v[0-9.]+$`, so RC tags (`vX.Y.Z-rc.N`) are ignored and only final `vX.Y.Z` tags trigger an F-Droid build.

## Notes

- Requires repo secrets to be configured before running (see `DEPLOYMENT.md` Step 1.6): `SIGNING_KEYSTORE_DATA`, `SIGNING_KEYSTORE_PASSWORD`, `SIGNING_KEY_ALIAS`, `SIGNING_KEY_PASSWORD`, `GOOGLE_PLAY_JSON_KEY_DATA`, `AMAZON_CLIENT_ID`, `AMAZON_CLIENT_SECRET`.
- Continues signing with the existing legacy upload keystore — no new key.
- Gradle config validated locally (`./gradlew help` configures cleanly).