### PR TITLE
Bump version to 3.8.0 (versionCode 37)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:versionCode="36"
-    android:versionName="3.7.4">
+    android:versionCode="37"
+    android:versionName="3.8.0">
 
     <!-- Reorder view, long press menu, and menu options require a touchscreen -->
     <uses-feature android:name="android.hardware.touchscreen"


### PR DESCRIPTION
## Summary

Bumps the app version ahead of the v3.8.0 release.

- `android:versionName`: `3.7.4` → `3.8.0`
- `android:versionCode`: `36` → `37`

The previous `v3.7.4` tag (versionCode 36) is already released on all stores, so the new release requires a strictly increasing `versionCode`.

## Merge order

Merge **after** #383 (release pipelines). Once both are on `main`, the **Build and Publish Pre-release** workflow can be run to produce `v3.8.0-rc.1`.