### PR TITLE
Fix invalid workflow files (empty ${{ }} in comments)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,9 +139,10 @@ jobs:
         env:
           GOOGLE_PLAY_JSON_KEY_DATA: ${{ secrets.GOOGLE_PLAY_JSON_KEY_DATA }}
         run: |
-          # Use printf with the value coming from `env:` rather than direct ${{ }}
+          # Use printf with the value coming from `env:` rather than direct
+          # GitHub Actions expression
           # interpolation. The service-account JSON contains many " characters,
-          # which would break a `echo "${{ secrets.X }}"` style write.
+          # which would break a `echo "$SECRET"` style write.
           if [ -z "$GOOGLE_PLAY_JSON_KEY_DATA" ]; then
             echo "Error: GOOGLE_PLAY_JSON_KEY_DATA secret is not set."
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,8 @@ jobs:
             echo "Error: SIGNING_KEYSTORE_DATA secret is not set."
             exit 1
           fi
-          # Use printf + env-var (not direct ${{ }} interpolation) so the value never
+          # Use printf + env-var (not direct GitHub Actions expression
+          # interpolation) so the value never
           # has to survive shell-quoting at the YAML expansion layer.
           printf '%s' "$SIGNING_KEYSTORE_DATA" | base64 --decode > "${{ github.workspace }}/app/release.keystore"
           if [ ! -s "${{ github.workspace }}/app/release.keystore" ]; then


### PR DESCRIPTION
## Problem

Dispatching the release workflows failed with **Invalid workflow file: "An expression was expected"** (`release.yml` and `deploy.yml`).

GitHub Actions evaluates `${{ }}` interpolation **anywhere** in a `run:` block — including shell comments. Two explanatory comments contained a literal empty `${{ }}`, which parses as an empty expression and makes the whole workflow file invalid and un-runnable.

- `release.yml`: `# Use printf + env-var (not direct ${{ }} interpolation) ...`
- `deploy.yml`: `# Use printf with the value coming from env: rather than direct ${{ }} ...`

## Fix

Reworded both comments to drop the empty `${{ }}` (and simplified the `deploy.yml` `echo "${{ secrets.X }}"` comment example). No functional change to any step.

## Validation

- No empty `${{ }}` remain in any workflow (`grep` clean).
- `release.yml`, `promote.yml`, `deploy.yml` all parse as valid YAML.

This unblocks the v3.8.0 pre-release dispatch.