### PR TITLE
Fix pre-release APK output paths (app/build/outputs/apk)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,9 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '17' 
+          # AGP 9.x (com.android.tools.build:gradle 9.2.1) requires JDK 21 to
+          # run the build; the Android CI workflow (gradle.yml) also uses 21.
+          java-version: '21'
 
       - name: Decode and Place Keystore
         env:
@@ -117,10 +119,10 @@ jobs:
       - name: Verify Versioned APKs Exist
         run: |
           MVN="${{ steps.extract_versions.outputs.manifest_version_name }}" # Manifest Version Name
-          echo "Checking for app/android/release/app-android-release-v${MVN}.apk"
-          test -f "app/android/release/app-android-release-v${MVN}.apk"
-          echo "Checking for app/amazon/release/app-amazon-release-v${MVN}.apk"
-          test -f "app/amazon/release/app-amazon-release-v${MVN}.apk"
+          echo "Checking for app/build/outputs/apk/android/release/app-android-release-v${MVN}.apk"
+          test -f "app/build/outputs/apk/android/release/app-android-release-v${MVN}.apk"
+          echo "Checking for app/build/outputs/apk/amazon/release/app-amazon-release-v${MVN}.apk"
+          test -f "app/build/outputs/apk/amazon/release/app-amazon-release-v${MVN}.apk"
           echo "Versioned APKs verified."
 
       - name: Verify APKs are signed with the release key
@@ -136,8 +138,8 @@ jobs:
             exit 1
           fi
           for APK in \
-            "app/android/release/app-android-release-v${MVN}.apk" \
-            "app/amazon/release/app-amazon-release-v${MVN}.apk"; do
+            "app/build/outputs/apk/android/release/app-android-release-v${MVN}.apk" \
+            "app/build/outputs/apk/amazon/release/app-amazon-release-v${MVN}.apk"; do
             echo "Verifying signature: $APK"
             "$APKSIGNER" verify --verbose "$APK"
             # Reject debug-signed APKs: the AOSP debug cert's CN is
@@ -156,8 +158,8 @@ jobs:
           name: Pre-release ${{ steps.check_tag.outputs.rc_tag }}
           # body parameter is removed/empty to allow auto-generation
           files: |
-            app/android/release/app-android-release-v${{ steps.extract_versions.outputs.manifest_version_name }}.apk
-            app/amazon/release/app-amazon-release-v${{ steps.extract_versions.outputs.manifest_version_name }}.apk
+            app/build/outputs/apk/android/release/app-android-release-v${{ steps.extract_versions.outputs.manifest_version_name }}.apk
+            app/build/outputs/apk/amazon/release/app-amazon-release-v${{ steps.extract_versions.outputs.manifest_version_name }}.apk
           fail_on_unmatched_files: true # Ensures workflow fails if APKs are not found
           draft: false
           # Marked as pre-release. F-Droid watches git TAGS, not this flag, so the
@@ -193,7 +195,7 @@ jobs:
         run: |
           MVN="${{ steps.extract_versions.outputs.manifest_version_name }}"
           bundle exec fastlane deploy_playstore_test \
-            apk_path:"app/android/release/app-android-release-v${MVN}.apk" \
+            apk_path:"app/build/outputs/apk/android/release/app-android-release-v${MVN}.apk" \
             version_name:"${MVN}" \
             version_code:"${{ steps.extract_versions.outputs.manifest_version_code }}" \
             track:"alpha" \


### PR DESCRIPTION
## Problem

The first `v3.8.0` pre-release run failed at **Verify Versioned APKs Exist**:

```
Checking for app/android/release/app-android-release-v3.8.0.apk
Error: Process completed with exit code 1.
```

The Gradle build itself **succeeded** (`BUILD SUCCESSFUL`). The issue is the path: `release.yml` looked for the APKs under `app/<flavor>/release/`, but AGP outputs them to `app/build/outputs/apk/<flavor>/release/`. Reproduced locally:

```
app/build/outputs/apk/android/release/app-android-release-v3.8.0.apk
```

The filename was already correct (the `outputFileName` customization works) — only the directory prefix `build/outputs/apk/` was missing.

## Fix

Corrected all **9** references in `release.yml` to `app/build/outputs/apk/<flavor>/release/...`:
- "Verify Versioned APKs Exist" (4)
- "Verify APKs are signed with the release key" loop (2)
- "Create GitHub Pre-release" `files:` (2)
- "Deploy to Google Play (alpha)" `apk_path` (1)

`promote.yml` / `deploy.yml` are unaffected — they download APKs from the GitHub Release into `downloaded_apks/`, not from the build tree.

## Validation

- No `app/<flavor>/release/` references remain; 9 now use `app/build/outputs/apk/`.
- `release.yml` parses as valid YAML.
- Local `:app:assembleAndroidRelease` confirms the corrected path.

## Note

The failed run did **not** create the `v3.8.0-rc.1` tag/release (it died before that step), so after this merges, re-run **Build and Publish Pre-release** with `rc_number=1` — no cleanup needed.