### PR TITLE
Fix Fastlane deploy: pass absolute apk_path (github.workspace)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -160,7 +160,7 @@ jobs:
           RELEASE_NOTES: ${{ github.event.inputs.releaseNotes }}
         run: |
           bundle exec fastlane deploy_playstore_test \
-            apk_path:"downloaded_apks/app-android-release-v${{ steps.resolve_version.outputs.version_name }}.apk" \
+            apk_path:"${{ github.workspace }}/downloaded_apks/app-android-release-v${{ steps.resolve_version.outputs.version_name }}.apk" \
             version_name:"${{ steps.resolve_version.outputs.version_name }}" \
             version_code:"${{ steps.resolve_version.outputs.version_code }}" \
             track:"${{ github.event.inputs.play_track }}" \
@@ -172,7 +172,7 @@ jobs:
           RELEASE_NOTES: ${{ github.event.inputs.releaseNotes }}
         run: |
           bundle exec fastlane deploy_playstore_production \
-            apk_path:"downloaded_apks/app-android-release-v${{ steps.resolve_version.outputs.version_name }}.apk" \
+            apk_path:"${{ github.workspace }}/downloaded_apks/app-android-release-v${{ steps.resolve_version.outputs.version_name }}.apk" \
             version_name:"${{ steps.resolve_version.outputs.version_name }}" \
             version_code:"${{ steps.resolve_version.outputs.version_code }}" \
             release_notes:"$RELEASE_NOTES"
@@ -185,7 +185,7 @@ jobs:
           RELEASE_NOTES: ${{ github.event.inputs.releaseNotes }}
         run: |
           bundle exec fastlane deploy_amazon_appstore \
-            apk_path:"downloaded_apks/app-amazon-release-v${{ steps.resolve_version.outputs.version_name }}.apk" \
+            apk_path:"${{ github.workspace }}/downloaded_apks/app-amazon-release-v${{ steps.resolve_version.outputs.version_name }}.apk" \
             version_name:"${{ steps.resolve_version.outputs.version_name }}" \
             version_code:"${{ steps.resolve_version.outputs.version_code }}" \
             release_notes:"$RELEASE_NOTES"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -152,7 +152,7 @@ jobs:
         run: |
           VERSION_NAME="${{ steps.parse.outputs.version_name }}"
           bundle exec fastlane deploy_playstore_production \
-            apk_path:"downloaded_apks/app-android-release-v${VERSION_NAME}.apk" \
+            apk_path:"${{ github.workspace }}/downloaded_apks/app-android-release-v${VERSION_NAME}.apk" \
             version_name:"${VERSION_NAME}" \
             version_code:"${{ steps.resolve.outputs.version_code }}" \
             release_notes:"$RELEASE_NOTES"
@@ -165,7 +165,7 @@ jobs:
         run: |
           VERSION_NAME="${{ steps.parse.outputs.version_name }}"
           bundle exec fastlane deploy_amazon_appstore \
-            apk_path:"downloaded_apks/app-amazon-release-v${VERSION_NAME}.apk" \
+            apk_path:"${{ github.workspace }}/downloaded_apks/app-amazon-release-v${VERSION_NAME}.apk" \
             version_name:"${VERSION_NAME}" \
             version_code:"${{ steps.resolve.outputs.version_code }}" \
             release_notes:"$RELEASE_NOTES"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,7 +195,7 @@ jobs:
         run: |
           MVN="${{ steps.extract_versions.outputs.manifest_version_name }}"
           bundle exec fastlane deploy_playstore_test \
-            apk_path:"app/build/outputs/apk/android/release/app-android-release-v${MVN}.apk" \
+            apk_path:"${{ github.workspace }}/app/build/outputs/apk/android/release/app-android-release-v${MVN}.apk" \
             version_name:"${MVN}" \
             version_code:"${{ steps.extract_versions.outputs.manifest_version_code }}" \
             track:"alpha" \


### PR DESCRIPTION
## Problem

With everything else fixed, the run reached **Deploy to Google Play (alpha)** and failed:

```
apk_path=>"app/build/outputs/apk/android/release/app-android-release-v3.8.0.apk"
Error: APK path must be provided via options[:apk_path] and exist.
```

The `apk_path` string was correct and the bash **Verify Versioned APKs Exist** step found that exact file — but the Fastlane lane's `File.exist?(options[:apk_path])` returned `false`. Fastlane resolves a **relative** path from a different working directory than the repo root, so the relative `apk_path` didn't resolve.

## Fix

Prefix every `apk_path` with `${{ github.workspace }}` so it's **absolute** and independent of Fastlane's CWD. Applied to all 6 deploy invocations:
- `release.yml` — alpha (`deploy_playstore_test`)
- `deploy.yml` — testers, production, Amazon
- `promote.yml` — production, Amazon

## Validation

- No relative `apk_path` remains; all 6 use `${{ github.workspace }}/…`.
- `release.yml`, `promote.yml`, `deploy.yml` parse as valid YAML.

## Re-run note

The failed run **created `v3.8.0-rc.2`** (it failed at the deploy, after the pre-release step). After this merges, either:
- **Retry without rebuilding** — run **Deploy Release to App Stores** with `deployment_target=google_play_testers`, `play_track=alpha`, `release_tag=v3.8.0-rc.2` (pushes the already-built rc.2 APKs to alpha), **or**
- Re-run **Build and Publish Pre-release** with `rc_number=3`.

`versionCode 37` is still unused on Play, so no version bump is needed.