### PR TITLE
Fix Play deploy: file-based changelog + correct fastlane-relative paths

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -61,10 +61,31 @@ platform :android do
 
       supply_params = {
         track: track,
-        apk: options[:apk_path]
-        # json_key_file is already set in Appfile
+        apk: options[:apk_path],
+        # json_key_file is already set in Appfile.
+        # Upload only the APK (and the changelog handled below) — never the
+        # store listing text, images, or screenshots — so a build/track deploy
+        # can't overwrite the live Play listing.
+        # NOTE: paths are relative to fastlane's working directory (the
+        # fastlane/ folder), so this resolves to fastlane/metadata/android.
+        metadata_path: "metadata/android",
+        skip_upload_metadata: true,
+        skip_upload_images: true,
+        skip_upload_screenshots: true,
+        skip_upload_changelogs: true
       }
-      supply_params[:changelogs] = { 'en-US' => options[:release_notes] } if options[:release_notes]
+
+      # supply has no inline "changelogs" option; the "what's new" text is read
+      # from a versionCode-named file under the metadata path. Write it and
+      # enable changelog upload only when we have release notes and a real
+      # version code (version_code 0 is the deploy.yml sentinel).
+      vc = options[:version_code].to_i
+      if options[:release_notes] && vc > 0
+        changelog_dir = "metadata/android/en-US/changelogs"
+        FileUtils.mkdir_p(changelog_dir)
+        File.write(File.join(changelog_dir, "#{vc}.txt"), options[:release_notes])
+        supply_params[:skip_upload_changelogs] = false
+      end
 
       supply(supply_params)
       UI.success("Successfully deployed to Google Play Store (#{track} track)!")
@@ -84,13 +105,27 @@ platform :android do
       
       supply_params = {
         track: 'production',
-        apk: options[:apk_path] # Use passed APK path
+        apk: options[:apk_path], # Use passed APK path
+        # Upload only the APK (and the changelog handled below) — never the
+        # store listing text, images, or screenshots.
+        # Paths are relative to fastlane's working directory (the fastlane/ folder).
+        metadata_path: "metadata/android",
+        skip_upload_metadata: true,
+        skip_upload_images: true,
+        skip_upload_screenshots: true,
+        skip_upload_changelogs: true
       }
-      supply_params[:changelogs] = { 'en-US' => options[:release_notes] } if options[:release_notes]
-      # supply_params[:release_status] = 'completed' # Optional: to automatically submit for review
-      # Optional: Pass version name and code if your supply setup needs them for metadata.
-      # supply_params[:version_name] = options[:version_name] if options[:version_name]
-      # supply_params[:version_code] = options[:version_code].to_i if options[:version_code]
+
+      # supply has no inline "changelogs" option; write the "what's new" text to
+      # a versionCode-named file and enable changelog upload only when we have
+      # release notes and a real version code (0 is the deploy.yml sentinel).
+      vc = options[:version_code].to_i
+      if options[:release_notes] && vc > 0
+        changelog_dir = "metadata/android/en-US/changelogs"
+        FileUtils.mkdir_p(changelog_dir)
+        File.write(File.join(changelog_dir, "#{vc}.txt"), options[:release_notes])
+        supply_params[:skip_upload_changelogs] = false
+      end
 
       supply(supply_params)
       UI.success("Successfully deployed to Google Play Store (Production Track)!")
@@ -113,7 +148,7 @@ platform :android do
       # release_tag (in which case the workflow can't trust main's manifest).
       # Skip the changelog file in that case rather than writing "0.txt".
       if options[:release_notes] && options[:version_code] && options[:version_code].to_i > 0
-        changelog_dir = "./fastlane/metadata/android/en-US/changelogs"
+        changelog_dir = "metadata/android/en-US/changelogs"
         FileUtils.mkdir_p(changelog_dir) # Ensure directory exists
         changelog_path = File.join(changelog_dir, "#{options[:version_code]}.txt")
         File.open(changelog_path, 'w') { |file| file.write(options[:release_notes]) }
@@ -129,7 +164,7 @@ platform :android do
         apk: options[:apk_path], # Use passed APK path
         client_id: ENV['AMAZON_CLIENT_ID'],
         client_secret: ENV['AMAZON_CLIENT_SECRET'],
-        metadata_path: "./fastlane/metadata/android", # Explicitly set, though it's the default
+        metadata_path: "metadata/android", # Relative to fastlane/ working dir
         skip_upload_changelogs: false # Ensure plugin tries to read changelog files
         # package_name: options[:package_name] # Optional: if needed and passed
         # version_name: options[:version_name] # Optional: if plugin uses it for metadata


### PR DESCRIPTION
## Problem

After the absolute-`apk_path` fix (#391), the alpha deploy reached `supply` and failed:

```
You passed invalid parameters to 'supply'.
Could not find option 'changelogs' in the list of available options
```

Two distinct bugs in the Play deploy lanes:

1. **No inline `changelogs` option.** Confirmed against the official [`upload_to_play_store` parameter list](https://docs.fastlane.tools/actions/upload_to_play_store/) — `supply` reads the "What's new" text from a **file** named `<versionCode>.txt` under `metadata_path/<locale>/changelogs/`, not an inline hash.
2. **Wrong relative paths.** The lanes wrote `./fastlane/metadata/...`, but fastlane runs lane code with its working directory set to the **`fastlane/` folder** (verified locally: `Dir.pwd` ends in `/fastlane`, and `File.directory?('./fastlane/metadata/android')` is `false` while `'metadata/android'` is `true`). So `./fastlane/metadata/...` resolved to `fastlane/fastlane/metadata/...`. This is the same working-directory gotcha behind the earlier `apk_path` failure.

## Fix

- Write `release_notes` to `metadata/android/en-US/changelogs/<versionCode>.txt` (path relative to fastlane's CWD, matching the existing `build_and_screengrab` lane) and set `skip_upload_changelogs: false`.
- Upload **only the APK + changelog**: `skip_upload_metadata/images/screenshots: true`, so a build/track deploy never overwrites the live Play listing (all `skip_upload_*` default to `false`).
- Keep the `version_code > 0` guard (the `deploy.yml` sentinel) — mirrors the Amazon lane.
- Fix the **same latent path bug in the Amazon lane** (`./fastlane/metadata/android` → `metadata/android`).

## Validation

- `ruby -c fastlane/Fastfile` → Syntax OK.
- No `./fastlane/metadata` references remain.
- Verified the corrected paths resolve from fastlane's `fastlane/` working directory.

## Scope note

This deliberately does **not** upload store listing text/screenshots — that's a separate, production-listing decision (a follow-up `update_play_listing` lane could do that on demand).

## Re-run

Depends on #391 (absolute `apk_path`). With both merged, retry via **Deploy Release to App Stores** (`google_play_testers`, `alpha`, `release_tag=v3.8.0-rc.2`) to push the existing rc.2 APKs, or re-run the pre-release with `rc_number=3`.