### PR TITLE
Fix Play deploy: absolute fastlane metadata path + robust release ordering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,24 +151,6 @@ jobs:
           done
           echo "All APKs verified as signed with a non-debug key."
 
-      - name: Create GitHub Pre-release
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ steps.check_tag.outputs.rc_tag }}
-          name: Pre-release ${{ steps.check_tag.outputs.rc_tag }}
-          # body parameter is removed/empty to allow auto-generation
-          files: |
-            app/build/outputs/apk/android/release/app-android-release-v${{ steps.extract_versions.outputs.manifest_version_name }}.apk
-            app/build/outputs/apk/amazon/release/app-amazon-release-v${{ steps.extract_versions.outputs.manifest_version_name }}.apk
-          fail_on_unmatched_files: true # Ensures workflow fails if APKs are not found
-          draft: false
-          # Marked as pre-release. F-Droid watches git TAGS, not this flag, so the
-          # RC tag (vX.Y.Z-rc.N) must be excluded by fdroiddata UpdateCheckMode.
-          # The final vX.Y.Z release/tag is created later by promote.yml.
-          prerelease: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Set up Ruby for Fastlane
         uses: ruby/setup-ruby@v1
         with:
@@ -200,3 +182,17 @@ jobs:
             version_code:"${{ steps.extract_versions.outputs.manifest_version_code }}" \
             track:"alpha" \
             release_notes:"$RELEASE_NOTES"
+
+      - name: Create GitHub Pre-release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ steps.check_tag.outputs.rc_tag }}
+          name: Pre-release ${{ steps.check_tag.outputs.rc_tag }}
+          files: |
+            app/build/outputs/apk/android/release/app-android-release-v${{ steps.extract_versions.outputs.manifest_version_name }}.apk
+            app/build/outputs/apk/amazon/release/app-amazon-release-v${{ steps.extract_versions.outputs.manifest_version_name }}.apk
+          fail_on_unmatched_files: true
+          draft: false
+          prerelease: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,6 +17,34 @@
 
 default_platform(:android)
 
+# Absolute path to fastlane/metadata/android, anchored to this Fastfile's own
+# directory (__dir__ is the fastlane/ folder, evaluated lexically regardless of
+# the process working directory). Using an absolute path avoids a CWD-resolution
+# mismatch: fastlane runs plain-Ruby blocks (FileUtils/File.write) and the
+# supply / amazon actions with different effective working directories, so a
+# relative "metadata/android" can be created in one place and looked up in
+# another — which surfaced as "Could not find folder metadata/android".
+def android_metadata_path
+  File.expand_path("metadata/android", __dir__)
+end
+
+# Write the "what's new" changelog file for the given versionCode and return
+# true when a file was actually written. supply (and the Amazon plugin) read
+# release notes from <metadata_path>/en-US/changelogs/<versionCode>.txt.
+# Writes nothing and returns false when the notes are blank or version_code <= 0
+# (0 is the deploy.yml sentinel meaning "don't trust the manifest versionCode").
+def write_changelog_file(version_code, release_notes)
+  vc = version_code.to_i
+  return false if release_notes.nil? || release_notes.to_s.strip.empty? || vc <= 0
+
+  changelog_dir = File.join(android_metadata_path, "en-US", "changelogs")
+  FileUtils.mkdir_p(changelog_dir)
+  changelog_path = File.join(changelog_dir, "#{vc}.txt")
+  File.write(changelog_path, release_notes)
+  UI.message("Wrote release notes to #{changelog_path} for version code #{vc}")
+  true
+end
+
 platform :android do
   desc "Runs all the tests"
   lane :test_and_lint do
@@ -66,9 +94,8 @@ platform :android do
         # Upload only the APK (and the changelog handled below) — never the
         # store listing text, images, or screenshots — so a build/track deploy
         # can't overwrite the live Play listing.
-        # NOTE: paths are relative to fastlane's working directory (the
-        # fastlane/ folder), so this resolves to fastlane/metadata/android.
-        metadata_path: "metadata/android",
+        # android_metadata_path is absolute (see helper) to avoid CWD ambiguity.
+        metadata_path: android_metadata_path,
         skip_upload_metadata: true,
         skip_upload_images: true,
         skip_upload_screenshots: true,
@@ -76,16 +103,9 @@ platform :android do
       }
 
       # supply has no inline "changelogs" option; the "what's new" text is read
-      # from a versionCode-named file under the metadata path. Write it and
-      # enable changelog upload only when we have release notes and a real
-      # version code (version_code 0 is the deploy.yml sentinel).
-      vc = options[:version_code].to_i
-      if options[:release_notes] && vc > 0
-        changelog_dir = "metadata/android/en-US/changelogs"
-        FileUtils.mkdir_p(changelog_dir)
-        File.write(File.join(changelog_dir, "#{vc}.txt"), options[:release_notes])
-        supply_params[:skip_upload_changelogs] = false
-      end
+      # from a versionCode-named file under the metadata path. Enable changelog
+      # upload only when a changelog file was actually written.
+      supply_params[:skip_upload_changelogs] = false if write_changelog_file(options[:version_code], options[:release_notes])
 
       supply(supply_params)
       UI.success("Successfully deployed to Google Play Store (#{track} track)!")
@@ -108,8 +128,8 @@ platform :android do
         apk: options[:apk_path], # Use passed APK path
         # Upload only the APK (and the changelog handled below) — never the
         # store listing text, images, or screenshots.
-        # Paths are relative to fastlane's working directory (the fastlane/ folder).
-        metadata_path: "metadata/android",
+        # android_metadata_path is absolute (see helper) to avoid CWD ambiguity.
+        metadata_path: android_metadata_path,
         skip_upload_metadata: true,
         skip_upload_images: true,
         skip_upload_screenshots: true,
@@ -117,15 +137,9 @@ platform :android do
       }
 
       # supply has no inline "changelogs" option; write the "what's new" text to
-      # a versionCode-named file and enable changelog upload only when we have
-      # release notes and a real version code (0 is the deploy.yml sentinel).
-      vc = options[:version_code].to_i
-      if options[:release_notes] && vc > 0
-        changelog_dir = "metadata/android/en-US/changelogs"
-        FileUtils.mkdir_p(changelog_dir)
-        File.write(File.join(changelog_dir, "#{vc}.txt"), options[:release_notes])
-        supply_params[:skip_upload_changelogs] = false
-      end
+      # a versionCode-named file and enable changelog upload only when one was
+      # actually written.
+      supply_params[:skip_upload_changelogs] = false if write_changelog_file(options[:version_code], options[:release_notes])
 
       supply(supply_params)
       UI.success("Successfully deployed to Google Play Store (Production Track)!")
@@ -146,14 +160,8 @@ platform :android do
       # Handle changelogs by writing to file. The deploy workflow passes
       # version_code="0" as a sentinel when the operator supplied an explicit
       # release_tag (in which case the workflow can't trust main's manifest).
-      # Skip the changelog file in that case rather than writing "0.txt".
-      if options[:release_notes] && options[:version_code] && options[:version_code].to_i > 0
-        changelog_dir = "metadata/android/en-US/changelogs"
-        FileUtils.mkdir_p(changelog_dir) # Ensure directory exists
-        changelog_path = File.join(changelog_dir, "#{options[:version_code]}.txt")
-        File.open(changelog_path, 'w') { |file| file.write(options[:release_notes]) }
-        UI.message("Wrote release notes to #{changelog_path} for version code #{options[:version_code]}")
-      else
+      # write_changelog_file skips the file in that case rather than writing "0.txt".
+      unless write_changelog_file(options[:version_code], options[:release_notes])
         UI.important("No release notes or valid version code provided for Amazon changelog generation; relying on existing changelog files (if any).")
       end
 
@@ -164,7 +172,7 @@ platform :android do
         apk: options[:apk_path], # Use passed APK path
         client_id: ENV['AMAZON_CLIENT_ID'],
         client_secret: ENV['AMAZON_CLIENT_SECRET'],
-        metadata_path: "metadata/android", # Relative to fastlane/ working dir
+        metadata_path: android_metadata_path, # Absolute (see helper) to avoid CWD ambiguity
         skip_upload_changelogs: false # Ensure plugin tries to read changelog files
         # package_name: options[:package_name] # Optional: if needed and passed
         # version_name: options[:version_name] # Optional: if plugin uses it for metadata

--- a/fastlane/metadata/android/en-US/changelogs/.gitkeep
+++ b/fastlane/metadata/android/en-US/changelogs/.gitkeep
@@ -1,0 +1,1 @@
+# Release pipeline uses this directory for release notes


### PR DESCRIPTION
## Problem

The "Build and Publish Pre-release" pipeline (rc.4, on `main`@419ca9d) failed at the Play alpha deploy:

```
Error deploying to Google Play Store (tester track): Could not find folder metadata/android
```

This happened **even though** PR #392 had already switched `metadata_path` to the relative `metadata/android`. The relative path is unreliable: `supply` resolves `metadata_path` against a different effective working directory than the plain-Ruby `FileUtils.mkdir_p` / `File.write` calls in the Fastfile, so the changelog folder is created in one place and looked up in another.

## Fix

**Absolute metadata path (root cause)** — `fastlane/Fastfile`
- Add `android_metadata_path` helper returning `File.expand_path("metadata/android", __dir__)` (anchored to the `fastlane/` folder, evaluated lexically regardless of CWD).
- Add shared `write_changelog_file(version_code, release_notes)` helper that writes `<abs>/en-US/changelogs/<versionCode>.txt` and returns whether a file was written.
- All three deploy lanes (`deploy_playstore_test`, `deploy_playstore_production`, `deploy_amazon_appstore`) now use the absolute `metadata_path` and the shared helper, so the folder created and the folder read are guaranteed identical.

**Robustness**
- `.github/workflows/release.yml`: the Play alpha deploy now runs **before** creating the GitHub pre-release/tag. The deploy uses the locally-built APK (independent of the GitHub release), so a deploy failure no longer leaves behind an RC tag/release — the same `rc_number` can simply be re-run.
- Track `fastlane/metadata/android/en-US/changelogs/` via `.gitkeep` so the metadata tree is always complete.
- De-duplicated the changelog logic into one helper so the Play and Amazon lanes can't drift.

## Verification

- `ruby -c fastlane/Fastfile` → Syntax OK
- Helper resolves to `…/fastlane/metadata/android` (asserted locally)
- No stale relative `metadata_path` assignments remain
- `release.yml` parses as valid YAML; step order confirmed (deploy → pre-release)

**To validate end-to-end:** run "Build and Publish Pre-release" with `rc_number=5` (rc.4 already exists) and confirm the deploy reaches "Updating track 'alpha'..." and succeeds, with the "what's new" text appearing in the Play Console alpha track.

## Notes
- Store listing text/images/screenshots remain protected via `skip_upload_*` on the Play lanes.
- No changes to signing, secrets, or F-Droid handling.