### PR TITLE
ci: default Play tester track to internal instead of alpha

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: choice
         options:
-          - google_play_testers          # Closed testing (alpha) by default; see play_track
+          - google_play_testers          # Internal testing by default; see play_track
           - production_google_play_and_amazon
         default: 'google_play_testers'
       play_track:
@@ -16,10 +16,10 @@ on:
         required: true
         type: choice
         options:
+          - internal  # Internal testing (limited to ~100 named testers)
           - alpha     # Closed testing
           - beta      # Open testing
-          - internal  # Internal testing (limited to ~100 named testers)
-        default: 'alpha'
+        default: 'internal'
       release_tag:
         description: "Optional. GitHub Release tag to deploy (e.g. v3.2.0). Leave blank to use the version currently in main's AndroidManifest.xml."
         required: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,7 +180,7 @@ jobs:
             apk_path:"${{ github.workspace }}/app/build/outputs/apk/android/release/app-android-release-v${MVN}.apk" \
             version_name:"${MVN}" \
             version_code:"${{ steps.extract_versions.outputs.manifest_version_code }}" \
-            track:"alpha" \
+            track:"internal" \
             release_notes:"$RELEASE_NOTES"
 
       - name: Create GitHub Pre-release

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -82,9 +82,9 @@ platform :android do
       UI.user_error!("APK path must be provided via options[:apk_path] and exist.") unless options[:apk_path] && File.exist?(options[:apk_path])
 
       # Allow the caller to pick which Play tester track to deploy to.
-      # Defaults to 'alpha' (Closed testing). Other valid values: 'internal',
-      # 'beta'. The previous behavior used 'internal' unconditionally.
-      track = options[:track] && !options[:track].to_s.strip.empty? ? options[:track].to_s : 'alpha'
+      # Defaults to 'internal' (Internal testing). Other valid values: 'alpha'
+      # (Closed testing), 'beta' (Open testing).
+      track = options[:track] && !options[:track].to_s.strip.empty? ? options[:track].to_s : 'internal'
       UI.user_error!("Invalid track: #{track}") unless %w[internal alpha beta].include?(track)
 
       supply_params = {


### PR DESCRIPTION
## Summary

Switches the default Google Play **tester** track from `alpha` (Closed testing) to `internal` (Internal testing) across the deploy pipelines. Internal testing reaches our named testers faster with minimal review, which fits our day-to-day pre-release validation.

`alpha` and `beta` remain fully supported — they're still selectable via the `deploy.yml` dropdown or by passing `track:` to the Fastlane lane.

## Changes

- **fastlane/Fastfile** — `deploy_playstore_test` default track changed `alpha` → `internal` (comment updated).
- **.github/workflows/release.yml** — pre-release flow now pushes `track:"internal"`.
- **.github/workflows/deploy.yml** — `play_track` dropdown reordered with `internal` first and default set to `internal`; clarifying comment updated.

## Notes

- No change to production behavior — `deploy_playstore_production` is unaffected.
- Reminder for the next release: bump `versionCode` so it doesn't collide with the alpha build currently pending review.