### PR TITLE
Fix Play production promote; add deploy store selector + bypass gate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,22 +3,29 @@ name: Deploy Release to App Stores
 on:
   workflow_dispatch:
     inputs:
-      deployment_target:
-        description: 'Which audience to deploy to'
+      acknowledge_bypass:
+        description: 'I understand this BYPASSES the recommended release + internal testing + promote flow and pushes an APK directly to a live store/track.'
+        required: true
+        type: boolean
+        default: false
+      stores:
+        description: 'Which app store(s) to deploy to'
         required: true
         type: choice
         options:
-          - google_play_testers          # Internal testing by default; see play_track
-          - production_google_play_and_amazon
-        default: 'google_play_testers'
+          - android   # Google Play only
+          - amazon    # Amazon Appstore only
+          - both      # Google Play and Amazon Appstore
+        default: 'both'
       play_track:
-        description: 'Google Play track (used only when deployment_target is google_play_testers)'
+        description: 'Google Play track (used only when stores is android or both; Amazon has no track concept)'
         required: true
         type: choice
         options:
-          - internal  # Internal testing (limited to ~100 named testers)
-          - alpha     # Closed testing
-          - beta      # Open testing
+          - internal    # Internal testing (limited to ~100 named testers)
+          - alpha       # Closed testing
+          - beta        # Open testing
+          - production  # Public production track
         default: 'internal'
       release_tag:
         description: "Optional. GitHub Release tag to deploy (e.g. v3.2.0). Leave blank to use the version currently in main's AndroidManifest.xml."
@@ -37,6 +44,17 @@ jobs:
     permissions:
       contents: read   # Only need to read the GitHub Release to download attached APKs.
     steps:
+      - name: Confirm intentional bypass of the release + test + promote flow
+        # This workflow is a break-glass tool that pushes an APK straight to a
+        # live store/track, skipping the normal pre-release + internal testing +
+        # promote pipeline. Force the operator to explicitly acknowledge that
+        # before anything is deployed; fail fast otherwise.
+        if: github.event.inputs.acknowledge_bypass != 'true'
+        run: |
+          echo "::error::Deploy aborted: this workflow bypasses the recommended release + internal testing + promote pipeline."
+          echo "Re-run and enable the 'acknowledge_bypass' checkbox to confirm you intend a direct store/track deploy."
+          exit 1
+
       - name: Checkout main branch
         uses: actions/checkout@v7
         with:
@@ -136,6 +154,7 @@ jobs:
           ls -la downloaded_apks/
 
       - name: Create Google Play Key File
+        if: github.event.inputs.stores == 'android' || github.event.inputs.stores == 'both'
         env:
           GOOGLE_PLAY_JSON_KEY_DATA: ${{ secrets.GOOGLE_PLAY_JSON_KEY_DATA }}
         run: |
@@ -155,7 +174,7 @@ jobs:
           }
 
       - name: Deploy to Google Play (Testers)
-        if: github.event.inputs.deployment_target == 'google_play_testers'
+        if: (github.event.inputs.stores == 'android' || github.event.inputs.stores == 'both') && github.event.inputs.play_track != 'production'
         env:
           RELEASE_NOTES: ${{ github.event.inputs.releaseNotes }}
         run: |
@@ -167,7 +186,7 @@ jobs:
             release_notes:"$RELEASE_NOTES"
 
       - name: Deploy to Google Play (Production)
-        if: github.event.inputs.deployment_target == 'production_google_play_and_amazon'
+        if: (github.event.inputs.stores == 'android' || github.event.inputs.stores == 'both') && github.event.inputs.play_track == 'production'
         env:
           RELEASE_NOTES: ${{ github.event.inputs.releaseNotes }}
         run: |
@@ -178,7 +197,7 @@ jobs:
             release_notes:"$RELEASE_NOTES"
 
       - name: Deploy to Amazon Appstore
-        if: github.event.inputs.deployment_target == 'production_google_play_and_amazon'
+        if: github.event.inputs.stores == 'amazon' || github.event.inputs.stores == 'both'
         env:
           AMAZON_CLIENT_ID: ${{ secrets.AMAZON_CLIENT_ID }}
           AMAZON_CLIENT_SECRET: ${{ secrets.AMAZON_CLIENT_SECRET }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -151,8 +151,10 @@ jobs:
           RELEASE_NOTES: ${{ github.event.inputs.releaseNotes }}
         run: |
           VERSION_NAME="${{ steps.parse.outputs.version_name }}"
+          # Promote the release already uploaded to the internal track by the
+          # pre-release workflow (keyed off versionCode) — Google Play forbids
+          # re-uploading an already-published APK, so no apk_path is passed.
           bundle exec fastlane deploy_playstore_production \
-            apk_path:"${{ github.workspace }}/downloaded_apks/app-android-release-v${VERSION_NAME}.apk" \
             version_name:"${VERSION_NAME}" \
             version_code:"${{ steps.resolve.outputs.version_code }}" \
             release_notes:"$RELEASE_NOTES"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -115,19 +115,26 @@ platform :android do
     end
   end
 
-  desc "Deploy the app to Google Play Store (Production Track) using a pre-built APK."
+  desc "Release to the Google Play Store Production track.\n" \
+       "Promotes an already-uploaded release by versionCode (default), or uploads " \
+       "a pre-built APK when options[:apk_path] is provided."
   lane :deploy_playstore_production do |options|
     begin
       UI.message("Deploying to Production Track with options: #{options.inspect}")
-      UI.user_error!("APK path must be provided via options[:apk_path] and exist.") unless options[:apk_path] && File.exist?(options[:apk_path])
 
-      # Gradle build steps are removed. APK is provided via options[:apk_path].
-      
+      # Two modes:
+      #   * Promote (default): the APK was already uploaded (and published) to a
+      #     tester track by the pre-release workflow. Google Play rejects
+      #     re-uploading an already-published APK ("Cannot update a published
+      #     APK"), so promote the existing release to production by versionCode.
+      #   * Upload: when a caller passes options[:apk_path] for a versionCode that
+      #     was never uploaded to any track, upload the binary straight to
+      #     production.
+      upload_mode = options[:apk_path] && !options[:apk_path].to_s.strip.empty?
+
       supply_params = {
-        track: 'production',
-        apk: options[:apk_path], # Use passed APK path
-        # Upload only the APK (and the changelog handled below) — never the
-        # store listing text, images, or screenshots.
+        # Upload only the APK/changelog — never the store listing text, images,
+        # or screenshots.
         # android_metadata_path is absolute (see helper) to avoid CWD ambiguity.
         metadata_path: android_metadata_path,
         skip_upload_metadata: true,
@@ -136,13 +143,35 @@ platform :android do
         skip_upload_changelogs: true
       }
 
+      if upload_mode
+        UI.user_error!("apk_path was provided but does not exist: #{options[:apk_path]}") unless File.exist?(options[:apk_path])
+        supply_params[:track] = 'production'
+        supply_params[:apk] = options[:apk_path]
+      else
+        # Promotion is keyed off the versionCode, so it is required in this mode.
+        version_code = options[:version_code].to_i
+        UI.user_error!("Provide options[:apk_path] to upload, or a positive version_code to promote to production.") unless version_code > 0
+
+        # Track the pre-release build was uploaded to (see deploy_playstore_test /
+        # release.yml, which uses 'internal'). Overridable for flexibility.
+        from_track = options[:from_track] && !options[:from_track].to_s.strip.empty? ? options[:from_track].to_s : 'internal'
+        UI.user_error!("Invalid from_track: #{from_track}") unless %w[internal alpha beta].include?(from_track)
+
+        supply_params[:track] = from_track
+        supply_params[:track_promote_to] = 'production'
+        supply_params[:version_code] = version_code
+        # Promote the existing artifact — do not (re-)upload any binary.
+        supply_params[:skip_upload_apk] = true
+        supply_params[:skip_upload_aab] = true
+      end
+
       # supply has no inline "changelogs" option; write the "what's new" text to
       # a versionCode-named file and enable changelog upload only when one was
       # actually written.
       supply_params[:skip_upload_changelogs] = false if write_changelog_file(options[:version_code], options[:release_notes])
 
       supply(supply_params)
-      UI.success("Successfully deployed to Google Play Store (Production Track)!")
+      UI.success("Successfully released to Google Play Store (Production Track)!")
     rescue => ex
       UI.error("Error deploying to Google Play Store (Production): #{ex}")
       raise ex


### PR DESCRIPTION
- Fastfile deploy_playstore_production: promote the existing internal-track release by versionCode instead of re-uploading the APK (fixes Google Play 'Cannot update a published APK'). Still supports direct upload when apk_path is provided, so deploy.yml's break-glass path keeps working.
- promote.yml: call the production lane without apk_path (promote mode).
- deploy.yml: add 'stores' input (android/amazon/both), fold production into play_track, gate each store's steps accordingly, and require an acknowledge_bypass confirmation before any direct deploy.

<!-- markdownlint-disable MD041 -- PR templates start with H2, not H1 -->

## Description

<!-- Brief description of the changes in this PR -->
