### PR TITLE
Bump to 3.8.2 (39); target SDK 35 for amazon flavor

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,6 +77,8 @@ android {
         amazon {
             dimension = "version"
             applicationIdSuffix = ".amazon"
+            // TODO - Up-rev once Amazon's SDK adds support
+            targetSdk = 35
         }
     }
     testOptions {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:versionCode="38"
-    android:versionName="3.8.1">
+    android:versionCode="39"
+    android:versionName="3.8.2">
 
     <!-- Reorder view, long press menu, and menu options require a touchscreen -->
     <uses-feature android:name="android.hardware.touchscreen"


### PR DESCRIPTION
Amazon rejected the 3.8.1 amazon APK at commit with error_apk_must_target_atleast1_device because it targeted API 37 (unreleased Android 17), which Amazon's device catalog can't map to any device. The Play build accepted the same versionCode fine.

Override targetSdk=35 on the amazon product flavor (proven on Amazon in 3.7.4) while the android flavor keeps 37; compileSdk stays 37 module-wide. Bump versionName 3.8.1 -> 3.8.2 and versionCode 38 -> 39 for the next release.

<!-- markdownlint-disable MD041 -- PR templates start with H2, not H1 -->

## Description

<!-- Brief description of the changes in this PR -->
