### PR TITLE
Add AI agent customization files (skills and CLAUDE.md guides)

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.github/skills

--- a/.github/skills/add-yearly-coins/SKILL.md
+++ b/.github/skills/add-yearly-coins/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: add-yearly-coins
+description: >
+  Add a new year's coins to all active (ongoing) collection types and bump
+  the database version — the annual maintenance workflow performed when the
+  U.S. Mint issues new coins. Use when asked to add this year's coins, do
+  the annual coin update, or extend ongoing series to a new year. NOT for
+  adding entirely new collection types — use the add-coin-collection skill
+  for that.
+---
+
+# Add Yearly Coins
+
+Add a new year's coins to all active (ongoing) collection types. This is an
+annual maintenance task performed when the U.S. Mint issues new coins.
+
+## Scope
+
+This workflow covers adding coins for a new year to **existing** collection
+types that have ongoing series. It does NOT cover adding entirely new
+collection types — use the `add-coin-collection` skill for that.
+
+For the detailed migration rules (version guards, `fromImport` handling,
+constant-value pitfalls, image IDs, checkbox flags), defer to the
+`database-migration` skill — it is the source of truth for how migrations
+must be written.
+
+## Prerequisites
+
+- Know which collections need new coins for the target year
+- Have any new coin images (drawables) ready if specific designs are needed
+- Understand whether the series uses year-based or named-identifier coins
+
+## Workflow
+
+### Step 1: Identify affected collections
+
+Active U.S. Mint series that get yearly additions typically include:
+
+- Lincoln Cents, Jefferson Nickels (year-based)
+- American Women Quarters (named-identifier, 5 per year)
+- American Innovation Dollars (named-identifier, 4-5 per year)
+- Native American / Sacagawea Dollars (named-identifier, 1 per year)
+- Kennedy Half Dollars (year-based)
+- American Eagle Silver Dollars (year-based)
+
+Confirm with the user which series have new coins.
+
+### Step 2: Add drawable resources
+
+For named-identifier collections with unique coin designs, add images to
+`app/src/main/res/drawable/`. Follow naming conventions from existing images
+in the same series.
+
+### Step 3: Bump DATABASE_VERSION
+
+In `app/src/main/java/com/spencerpages/MainApplication.java`:
+
+1. Increment `DATABASE_VERSION` (check current value first)
+2. Add version history comment
+
+### Step 4: Update each collection class
+
+For each affected collection in `app/src/main/java/com/spencerpages/collections/`:
+
+**For named-identifier collections** (e.g., AmericanWomenQuarters):
+
+1. Add new entries to `COIN_IDENTIFIERS[]` array with name and drawable
+2. Update `COIN_MAP` if used (static initializer handles this automatically
+   when COIN_IDENTIFIERS is updated)
+3. Add `onCollectionDatabaseUpgrade()` block:
+
+   ```java
+   if (oldVersion <= PREVIOUS_DB_VERSION) {
+       ArrayList<String> newCoinIdentifiers = new ArrayList<>();
+       newCoinIdentifiers.add("New Coin Name");
+       total += DatabaseHelper.addFromArrayList(db, collectionListInfo, newCoinIdentifiers);
+   }
+   ```
+
+**For year-based collections** (e.g., LincolnCents):
+
+1. Update `OPT_STOP_YEAR` default if the new year extends past it
+2. Add `onCollectionDatabaseUpgrade()` block:
+
+   ```java
+   if (oldVersion <= PREVIOUS_DB_VERSION) {
+       total += DatabaseHelper.addFromYear(db, collectionListInfo, NEW_YEAR);
+   }
+   ```
+
+### Step 5: Update tests
+
+1. **CollectionCreationTests**: Update expected coin counts for each modified
+   collection's test method.
+2. **CollectionUpgradeTests**: Verify upgrade test coverage includes the new
+   database version.
+
+### Step 6: Build and verify
+
+```bash
+./gradlew assembleDebug
+./gradlew testAndroidDebugUnitTest
+```
+
+Fix any test failures (usually expected count mismatches) and re-run.
+
+### Step 7: Summary
+
+Report a table of changes made:
+
+| Collection | Coins Added | DB Version Check |
+| --- | --- | --- |
+| ... | ... | `oldVersion <= N` |
+
+## Tips
+
+- Check the previous year's changes for examples of the exact pattern used
+  in each collection's `onCollectionDatabaseUpgrade()`.
+- Named-identifier collections must have `COIN_IDENTIFIERS[]` updated **and**
+  the upgrade method updated — the former is for new collections, the latter
+  is for existing user databases.
+- Always use `oldVersion <= N` where N is the version **before** your bump.

--- a/.github/skills/capture-debug-screenshot/SKILL.md
+++ b/.github/skills/capture-debug-screenshot/SKILL.md
@@ -29,13 +29,13 @@ with the emulator and capture what is currently on screen.
 
 ### 1. Confirm a device is available
 
-Call `mcp_mobile-mcp_mobile_list_available_devices` to verify an emulator is
+Call `mobile_list_available_devices` to verify an emulator is
 running and reachable. If no device is listed, ask the user to start an
 emulator first.
 
 ### 2. Capture the current screen
 
-Call `mcp_mobile-mcp_mobile_take_screenshot` to capture and display the
+Call `mobile_take_screenshot` to capture and display the
 current screen inline in the chat. This is the primary output of this skill.
 
 ### 3. Navigate before capturing (optional)
@@ -45,21 +45,21 @@ tools **before** taking the screenshot:
 
 | Action | Tool |
 | --- | --- |
-| Discover UI elements | `mcp_mobile-mcp_mobile_list_elements_on_screen` |
-| Tap a coordinate | `mcp_mobile-mcp_mobile_click_on_screen_at_coordinates` |
-| Long-press a coordinate | `mcp_mobile-mcp_mobile_long_press_on_screen_at_coordinates` |
-| Double-tap | `mcp_mobile-mcp_mobile_double_tap_on_screen` |
-| Scroll / swipe | `mcp_mobile-mcp_mobile_swipe_on_screen` |
-| Press a hardware button | `mcp_mobile-mcp_mobile_press_button` |
-| Type text | `mcp_mobile-mcp_mobile_type_keys` |
+| Discover UI elements | `mobile_list_elements_on_screen` |
+| Tap a coordinate | `mobile_click_on_screen_at_coordinates` |
+| Long-press a coordinate | `mobile_long_press_on_screen_at_coordinates` |
+| Double-tap | `mobile_double_tap_on_screen` |
+| Scroll / swipe | `mobile_swipe_on_screen` |
+| Press a hardware button | `mobile_press_button` |
+| Type text | `mobile_type_keys` |
 
-After navigating, call `mcp_mobile-mcp_mobile_take_screenshot` again to
+After navigating, call `mobile_take_screenshot` again to
 capture the resulting screen.
 
 ### 4. Save to disk (optional)
 
 If the user wants to save the screenshot to a file, call
-`mcp_mobile-mcp_mobile_save_screenshot` with the desired path. By default
+`mobile_save_screenshot` with the desired path. By default
 screenshots are only displayed inline and not persisted.
 
 ## Output
@@ -69,10 +69,11 @@ written to the repository unless explicitly requested.
 
 ## Tips
 
-- Use `mcp_mobile-mcp_mobile_list_elements_on_screen` to find tap targets
+- Use `mobile_list_elements_on_screen` to find tap targets
   when you are unsure where a button or element is positioned.
 - Chain multiple interactions (tap → wait → screenshot) to verify multi-step
   flows.
-- All `mcp_mobile-mcp_mobile_*` tool names must be loaded via
-  `tool_search_tool_regex` before first use — search for `mcp_mobile-mcp` to
-  load them.
+- Tool names above are the mobile-mcp server's bare names. Your client
+  prefixes them (GitHub Copilot: `mcp_mobile-mcp_mobile_take_screenshot`;
+  Claude Code: `mcp__mobile-mcp__mobile_take_screenshot`) and may require
+  loading them through its tool-search mechanism before first use.

--- a/.github/skills/database-migration/SKILL.md
+++ b/.github/skills/database-migration/SKILL.md
@@ -238,11 +238,14 @@ approach:
 
 - **LincolnCents / JeffersonNickels pattern**: Add the year to `COIN_MAP`
   in the static initializer block.
+
   ```java
   COIN_MAP.put("2026", R.drawable.semiq_2026_penny_obv_unc);
   ```
+
 - **BasicDimes / BasicHalfDollars pattern**: These have no `COIN_MAP`.
   Add a simple conditional in `getCoinSlotImage()`:
+
   ```java
   if ("2026".equals(coinSlot.getIdentifier())) {
       return R.drawable.semiq_2026_dime_obv_unc;
@@ -266,29 +269,38 @@ indices corrupts image assignments for all existing collections.
 - **RooseveltDimes / KennedyHalfDollars pattern**: Add entry to
   `COIN_IMG_IDS`, then use a per-year variable in
   `populateCollectionLists()`:
+
   ```java
   {"Emerging Liberty", R.drawable.semiq_2026_dime_obv_unc},  // in COIN_IMG_IDS
   // In populateCollectionLists, compute per-year override:
   int cladImgId = (i == 2026) ? getImgId("Emerging Liberty") : -1;
   // Pass cladImgId to CoinSlot constructors for that year
   ```
+
   **In `onCollectionDatabaseUpgrade()`**, pass the same imageId:
+
   ```java
   total += DatabaseHelper.addFromYear(db, collectionListInfo, 2026, getImgId("Emerging Liberty"));
   ```
+
 - **Aggregate collections** (AllNickels, SilverDimes, SilverHalfDollars,
   SmallCents): Same approach — add the image to their `COIN_IMG_IDS`
   array and use `getImgId()` in the sub-series population loop:
+
   ```java
   String imgTag = (i == 2026) ? "1776-2026" : "Modern Jefferson";
   coinList.add(new CoinSlot(year, "P", coinIndex++, getImgId(imgTag)));
   ```
+
   **In `onCollectionDatabaseUpgrade()`**, pass the same imageId:
+
   ```java
   total += DatabaseHelper.addFromYear(db, collectionListInfo, 2026, getImgId("1776-2026"));
   ```
+
 - **Named-identifier collections** (CladQuarters, AmericanInnovationDollars):
   Build a parallel `ArrayList<Integer>` of imageIds and pass it:
+
   ```java
   ArrayList<Integer> imageIds = new ArrayList<>();
   for (String identifier : newCoinIdentifiers) {
@@ -309,6 +321,7 @@ checkbox. This requires changes in four files:
    `(1L << (N + 1)) - 1` where N is the new highest bit. The same
    rules apply when adding mint mark flags — use the next bit after
    `MINT_FRANKLIN_PROOF` and update `ALL_MINT_MASK` accordingly.
+
    ```java
    public final static long NEW_FLAG = (1L << 50);
    // Update ALL_CHECKBOXES_MASK: (1L << 51) - 1
@@ -317,9 +330,11 @@ checkbox. This requires changes in four files:
        return (getCheckboxFlagsAsLong() & NEW_FLAG) != 0;
    }
    ```
+
 2. **`CoinPageCreator.java`** — Add encoding (in
    `getCheckboxFlagsFromParameters()`) and decoding (in
    `getParametersFromCollectionListInfo()`):
+
    ```java
    // Encoding:
    } else if (optionStrId.equals(R.string.include_new_flag)) {
@@ -328,6 +343,7 @@ checkbox. This requires changes in four files:
    } else if (optionStrId.equals(R.string.include_new_flag)) {
        parameters.put(optName, existingCollection.hasNewFlag());
    ```
+
 3. **`strings.xml`** — Add the checkbox label string resource.
 4. **Collection class** — Add `OPT_CHECKBOX_N` parameter in
    `getCreationParameters()` and read it in `populateCollectionLists()`.

--- a/.github/skills/deploy-with-fastlane/SKILL.md
+++ b/.github/skills/deploy-with-fastlane/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: deploy-with-fastlane
+description: >
+  Deploy the Android app to Google Play and the Amazon Appstore with this repo's
+  Fastlane lanes. Use when asked to deploy a build, upload an APK to the Play
+  Store or Amazon Appstore, push to the alpha/beta/internal tester track, release
+  to production, wire up supply authentication, configure release signing, or
+  understand and modify the Fastfile deploy lanes and the CI release flow. NOT for
+  generating store screenshots — use the capture-store-screenshots skill — and NOT
+  the annual coin update itself — use the add-yearly-coins prompt.
+---
+
+# Deploy with Fastlane
+
+This app ships to **Google Play** (`android` flavor) and the **Amazon Appstore**
+(`amazon` flavor) through Fastlane lanes defined in
+[fastlane/Fastfile](../../../fastlane/Fastfile). Deployment normally runs from
+GitHub Actions, but every lane can be run locally once the required secrets are
+present.
+
+## Core design pattern
+
+The deploy lanes **do not build the app**. Each one receives an already-built,
+signed APK through an `apk_path` option and only uploads it. CI builds the APK
+once (`assembleAndroidRelease` / `assembleAmazonRelease`), then hands the path to
+the lane. Keep this separation when editing lanes — do not add `gradle` /
+`build_android_app` build steps to the deploy lanes.
+
+Do not rely on the lane's working directory for metadata paths. fastlane runs
+plain-Ruby blocks and the `supply` / Amazon actions with *different* effective
+working directories, so a relative `metadata_path` can be created in one place
+and looked up in another (this caused `Could not find folder metadata/android`).
+The Fastfile exposes an `android_metadata_path` helper that returns an **absolute**
+path (`File.expand_path("metadata/android", __dir__)`, anchored to the `fastlane/`
+folder); use it for both `metadata_path` and any changelog writes. The shared
+`write_changelog_file(version_code, release_notes)` helper already does this.
+
+## Lanes
+
+| Lane | Purpose | Key options |
+| --- | --- | --- |
+| `test_and_lint` | Run unit tests + lint (`testAndroidDebugUnitTest`, `lintAndroidDebug`) | none |
+| `build_and_screengrab` | Build debug + androidTest APKs and capture screenshots via Screengrab | none (see capture-store-screenshots skill) |
+| `deploy_playstore_test` | Upload a pre-built APK to a Play **tester** track | `apk_path` (required), `track` (default `internal`; one of `internal`/`alpha`/`beta`), `release_notes`, `version_code` |
+| `deploy_playstore_production` | Release to Play **production**: promotes an already-uploaded release by versionCode (default), or uploads a pre-built APK when `apk_path` is given | `version_code` (required to promote), `apk_path` (upload mode), `from_track` (default `internal`), `release_notes` |
+| `deploy_amazon_appstore` | Upload a pre-built APK to the Amazon Appstore | `apk_path` (required), `release_notes`, `version_code` |
+
+List lanes at any time:
+
+```bash
+bundle exec fastlane lanes
+```
+
+## Authentication & secrets
+
+| Secret / env var | Used by | Notes |
+| --- | --- | --- |
+| `GOOGLE_PLAY_KEY_PATH` | both Play lanes | Path to the service-account JSON; read by `json_key_file(...)` in [fastlane/Appfile](../../../fastlane/Appfile). Falls back to `/tmp/google_play_key.json` (CI writes the key there from the `GOOGLE_PLAY_JSON_KEY_DATA` secret). |
+| `AMAZON_CLIENT_ID` | `deploy_amazon_appstore` | Amazon Developer API client id. Lane fails fast if unset. |
+| `AMAZON_CLIENT_SECRET` | `deploy_amazon_appstore` | Amazon Developer API client secret. |
+| `SIGNING_KEYSTORE_PATH` | release build (CI) | Path to the keystore file. |
+| `SIGNING_KEYSTORE_PASSWORD` | release build (CI) | Keystore password. |
+| `SIGNING_KEY_ALIAS` | release build (CI) | Key alias. |
+| `SIGNING_KEY_PASSWORD` | release build (CI) | Key password. |
+
+The package name is pinned to `com.spencerpages` in
+[fastlane/Appfile](../../../fastlane/Appfile).
+
+### First-time supply setup
+
+The Play lanes need a Google service-account JSON with the Play Developer API
+enabled. Create it once following Fastlane's supply setup
+(<https://docs.fastlane.tools/getting-started/android/setup/#setting-up-supply>),
+store the JSON contents in the `GOOGLE_PLAY_JSON_KEY_DATA` repo secret, and point
+`GOOGLE_PLAY_KEY_PATH` at the file. Validate a local key before deploying:
+
+```bash
+bundle exec fastlane run validate_play_store_json_key json_key:/path/to/key.json
+```
+
+## Signing & flavors
+
+Release signing is configured in
+[app/build.gradle](../../../app/build.gradle). The `signingConfigs.Android`
+block prefers the four `SIGNING_*` environment variables (CI); if they are
+absent it falls back to a gitignored `signing.properties`. When neither is
+present `storeFile` is null and the `release` build type stays unsigned — so a
+release APK built on a plain dev box is **not** uploadable.
+
+Two product flavors share the `version` dimension:
+
+| Flavor | Application id | Store |
+| --- | --- | --- |
+| `android` | `com.spencerpages` | Google Play |
+| `amazon` | `com.spencerpages.amazon` (`applicationIdSuffix .amazon`) | Amazon Appstore |
+
+Release APKs are named `app-{flavor}-{buildType}-v{versionName}.apk`, e.g.
+`app-android-release-v3.7.4.apk`. The deploy commands below depend on this name.
+
+## Changelog ("What's new") handling
+
+`supply` (and the Amazon plugin) have **no inline `changelogs` option** — passing
+one raises `Could not find option changelogs`. Instead the release notes are read
+from a versionCode-named file. Each deploy lane therefore:
+
+1. Calls `write_changelog_file(version_code, release_notes)`, which writes
+   `release_notes` to `<android_metadata_path>/en-US/changelogs/<version_code>.txt`
+   only when `release_notes` is set **and** `version_code > 0`. A `version_code`
+   of `0` is the [deploy.yml](../../../.github/workflows/deploy.yml) sentinel that
+   skips the changelog write. The path is **absolute** (anchored to `fastlane/`)
+   so it always matches where `supply` later reads the changelog from.
+2. Sets `skip_upload_metadata`, `skip_upload_images`, and
+   `skip_upload_screenshots` to `true` on the Play lanes, so a build/track deploy
+   uploads only the APK + changelog and can **never** overwrite the live store
+   listing text or screenshots.
+
+To change store listing text or screenshots, edit the files under
+[fastlane/metadata/android/en-US/](../../../fastlane/metadata/android) and upload
+them deliberately — they are intentionally excluded from the deploy lanes.
+
+## Running a deploy
+
+Build a signed release APK first (CI does this in a separate job), then call the
+lane with the matching APK path. Examples mirror the CI invocations:
+
+Play tester track (internal testing by default):
+
+```bash
+bundle exec fastlane deploy_playstore_test \
+  apk_path:"app/build/outputs/apk/android/release/app-android-release-v3.7.4.apk" \
+  version_name:"3.7.4" \
+  version_code:"88" \
+  track:"internal" \
+  release_notes:"Added 2026 coins and bug fixes."
+```
+
+Play production:
+
+```bash
+# Promote the release already on the internal track (by versionCode) — the
+# pre-release workflow uploaded it there, and Play forbids re-uploading a
+# published APK. This is what promote.yml uses.
+bundle exec fastlane deploy_playstore_production \
+  version_name:"3.7.4" \
+  version_code:"88" \
+  release_notes:"Added 2026 coins and bug fixes."
+
+# Upload mode (fresh versionCode never sent to any track): pass apk_path.
+bundle exec fastlane deploy_playstore_production \
+  apk_path:"downloaded_apks/app-android-release-v3.7.4.apk" \
+  version_name:"3.7.4" \
+  version_code:"88" \
+  release_notes:"Added 2026 coins and bug fixes."
+```
+
+Amazon Appstore:
+
+```bash
+bundle exec fastlane deploy_amazon_appstore \
+  apk_path:"downloaded_apks/app-amazon-release-v3.7.4.apk" \
+  version_name:"3.7.4" \
+  version_code:"88" \
+  release_notes:"Added 2026 coins and bug fixes."
+```
+
+> Run these only when you intend to publish. They push to live store tracks.
+> Use a tester track (internal/alpha/beta) to validate before production.
+
+## CI release flow
+
+Deployment is normally driven by GitHub Actions, not run by hand. See
+[DEPLOYMENT.md](../../../DEPLOYMENT.md) for the full process. In short:
+
+1. **Pre-release** — [.github/workflows/release.yml](../../../.github/workflows/release.yml)
+   builds the `android` + `amazon` release APKs, creates a GitHub pre-release
+   tagged `vX.Y.Z-rc.N`, and calls `deploy_playstore_test track:"internal"`.
+2. **Promote** — [.github/workflows/promote.yml](../../../.github/workflows/promote.yml)
+   downloads the *same* APKs from the pre-release, creates the final `vX.Y.Z`
+   release, then calls `deploy_playstore_production` and `deploy_amazon_appstore`.
+3. **F-Droid** watches git tags and builds automatically from the final `vX.Y.Z`
+   tag (it ignores `-rc.N` tags).
+
+[.github/workflows/deploy.yml](../../../.github/workflows/deploy.yml) is a manual
+fallback that can target either Play track directly.
+
+## Verifying changes
+
+After editing the Fastfile or Gemfile:
+
+```bash
+bundle exec fastlane lanes          # syntax-check the Fastfile, list lanes
+```
+
+- [.github/workflows/fastlane-bundle-check.yml](../../../.github/workflows/fastlane-bundle-check.yml)
+  verifies the bundle installs and the Fastfile loads on CI.
+- The Fastlane version is pinned in [Gemfile](../../../Gemfile)
+  (`fastlane ~> 2.236.1` plus `fastlane-plugin-amazon_appstore`). Do **not** add
+  `update_fastlane` to the Fastfile — self-updating mid-run has caused flaky CI.
+  Bump versions deliberately with `bundle update fastlane` and commit
+  `Gemfile.lock`.
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+| --- | --- |
+| `Could not find option 'changelogs'` | `supply` has no inline changelogs option — write the versionCode-named changelog file instead (already handled by the lanes). |
+| `Could not find folder metadata/android` | A relative `metadata_path` resolved against the wrong working directory. Use the `android_metadata_path` helper (absolute path) for both `metadata_path` and changelog writes. |
+| Changelog/metadata lands in `fastlane/fastlane/metadata` | A path was written as `./fastlane/...` or relative. Use the absolute `android_metadata_path` helper. |
+| `APK path must be provided ... and exist` | `apk_path` missing or wrong filename — confirm `app-{flavor}-{buildType}-v{versionName}.apk` exists. |
+| `AMAZON_CLIENT_ID and AMAZON_CLIENT_SECRET must be set` | Export both env vars before `deploy_amazon_appstore`. |
+| Play upload rejected as unsigned | The release APK was built without the `SIGNING_*` vars / `signing.properties`. |
+| Locale / encoding errors from supply | Export `LC_ALL=en_US.UTF-8` and `LANG=en_US.UTF-8`. |
+
+## Related files
+
+| File | Purpose |
+| --- | --- |
+| [fastlane/Fastfile](../../../fastlane/Fastfile) | All lanes (source of truth for option names) |
+| [fastlane/Appfile](../../../fastlane/Appfile) | `json_key_file` + `package_name` |
+| [fastlane/Screengrabfile](../../../fastlane/Screengrabfile) | Screenshot capture config |
+| [Gemfile](../../../Gemfile) | Pinned Fastlane + Amazon plugin versions |
+| [app/build.gradle](../../../app/build.gradle) | Signing config, flavors, APK naming |
+| [DEPLOYMENT.md](../../../DEPLOYMENT.md) | End-to-end release process |
+| [fastlane/metadata/android/en-US/](../../../fastlane/metadata/android) | Store listing text, images, changelogs |
+| capture-store-screenshots skill | Regenerate the 18 store screenshots |

--- a/.github/skills/release-checklist/SKILL.md
+++ b/.github/skills/release-checklist/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: release-checklist
+description: >
+  Run the pre-release verification checklist before triggering the GitHub
+  Actions release workflow. Verifies unit tests, lint, version bump in
+  AndroidManifest.xml, DATABASE_VERSION, store metadata, screenshots, and
+  git state, then reports a summary table. Use when asked to run the release
+  checklist, verify release readiness, or check that everything is ready
+  before a release.
+disable-model-invocation: true
+---
+
+# Release Checklist
+
+Verify all release prerequisites before triggering the GitHub Actions release
+workflow. Run each check and report results.
+
+## Checks
+
+### 1. Unit tests pass
+
+```bash
+./gradlew testAndroidDebugUnitTest --rerun-tasks
+```
+
+All tests must pass. If any fail, report the failures and stop.
+
+### 2. Lint is clean
+
+```bash
+./gradlew lintAndroidDebug
+```
+
+No new errors should be introduced. Warnings are acceptable if pre-existing.
+
+### 3. Version is bumped
+
+Read `app/src/main/AndroidManifest.xml` and check:
+
+- `android:versionCode` — must be incremented from the last release
+- `android:versionName` — must reflect the new version string
+
+Compare with the latest git tag to confirm the version has changed:
+
+```bash
+git describe --tags --abbrev=0
+```
+
+### 4. DATABASE_VERSION is correct
+
+If any database migrations were added since the last release:
+
+- Verify `DATABASE_VERSION` in `MainApplication.java` was incremented
+- Verify all `onCollectionDatabaseUpgrade()` methods use the correct
+  version checks
+
+If no database changes were made, confirm DATABASE_VERSION is unchanged.
+
+### 5. Store metadata is current (if applicable)
+
+Check if store text needs updating:
+
+- `fastlane/metadata/android/en-US/full_description.txt`
+- `fastlane/metadata/android/en-US/short_description.txt`
+
+### 6. Screenshots are current (if UI changed)
+
+If UI changes were made, screenshots may need regenerating:
+
+- `images/screenshots/small/` (6 PNGs)
+- `images/screenshots/medium/` (6 PNGs)
+- `images/screenshots/large/` (6 PNGs)
+
+Use the `capture-store-screenshots` skill if regeneration is needed.
+
+### 7. Working tree is clean
+
+```bash
+git status
+```
+
+No uncommitted changes should exist.
+
+### 8. Branch is up to date
+
+```bash
+git fetch origin main
+git log HEAD..origin/main --oneline
+```
+
+No unmerged upstream changes should exist.
+
+## Output
+
+Report a summary table:
+
+| Check | Status | Notes |
+| --- | --- | --- |
+| Unit tests | PASS/FAIL | |
+| Lint | PASS/FAIL | |
+| Version bumped | YES/NO | vX.Y.Z (code: NN) |
+| DATABASE_VERSION | OK/NEEDS BUMP | Current: N |
+| Store metadata | OK/NEEDS UPDATE | |
+| Screenshots | OK/NEEDS UPDATE | |
+| Working tree clean | YES/NO | |
+| Branch up to date | YES/NO | |
+
+If all checks pass, the release workflow can be triggered.
+If any check fails, list the required actions before release.

--- a/.github/skills/review-changes/SKILL.md
+++ b/.github/skills/review-changes/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: review-changes
+description: Domain-specific review of uncommitted changes to collection classes, database migrations, or flags — checks migration guards (!fromImport, oldVersion <=), collection-upgrade completeness, checkbox flag round-trip and masks, COIN_IMG_IDS/COLLECTION_TYPES array immutability, and test coverage. Use before committing any change that touches DatabaseHelper migrations, collection classes, or CollectionListInfo flags. NOT a general code review — use /code-review for that.
+---
+
+# Review Changes
+
+Audit the current uncommitted changes (or a specified set of files) against
+the project's known pitfall areas. Use `git diff` to identify what changed,
+then verify each checklist section below. Skip sections that don't apply to
+the current changes.
+
+## 1. Database migration guards (`upgradeDbStructure`)
+
+For each version-gated block in `DatabaseHelper.upgradeDbStructure()`:
+
+- Classify it as **schema change** (ALTER TABLE, ADD COLUMN) or
+  **data-value migration** (UPDATE existing column values, ORing flag bits)
+- **Schema changes** must have `&& !fromImport` — imported databases already
+  have the latest columns
+- **Data-value migrations** must **omit** the `!fromImport` guard — imported
+  databases have the latest schema but carry old data values from the export
+  that also need updating
+- All blocks use `oldVersion <= N` (incremental), never `oldVersion == N`
+- **Use `Xxx.COLLECTION_TYPE` qualified references** for collection type
+  names in migration blocks (e.g., `LincolnCents.COLLECTION_TYPE` not
+  `"Pennies"`). If a `COLLECTION_TYPE` value was renamed in this diff,
+  verify that every old migration block that used `Xxx.COLLECTION_TYPE` has
+  been updated to use the old literal string value instead of the constant —
+  only the new migration performing the rename should reference the constant.
+- **Verify that no old migration block references a constant whose value
+  changed in this diff.** `COLLECTION_TYPE` constants, column name constants
+  (`COL_*`), table name constants (`TBL_*`), display constants (e.g.,
+  `SIMPLE_DISPLAY`), flag constants — any symbol whose literal value is
+  meaningful to migration SQL or logic. If a constant's value was modified,
+  every old migration block that used it must be updated to use the old
+  literal value instead of the constant, or it will silently pick up the new
+  value and break.
+
+## 2. Collection upgrade completeness
+
+For each collection class that changed:
+
+- Every collection that adds coins in `populateCollectionLists()` has a
+  matching `onCollectionDatabaseUpgrade()` block for the current
+  `DATABASE_VERSION`
+- When `populateCollectionLists()` sets `imageId` via `getImgId()`, the
+  corresponding `onCollectionDatabaseUpgrade()` passes the same image ID
+- `addFromYear` / `addFromArrayList` calls respect the user's mint mark
+  configuration
+
+## 3. Checkbox/flag round-trip integrity
+
+For any new checkbox or flag added to a collection:
+
+- Bit constant defined in `CollectionListInfo` (appended, not inserted)
+- `has*()` getter method in `CollectionListInfo`
+- Encoder block in `CoinPageCreator.getCheckboxFlagsFromParameters()`
+- Decoder block in `CoinPageCreator.getParametersFromCollectionListInfo()`
+- `ALL_CHECKBOXES_MASK` in `CollectionListInfo` updated to cover new bits
+- `ALL_MINT_MASK` in `CollectionListInfo` updated if mint mark flags changed
+- Masks use the formula `(1L << (highestBit + 1)) - 1` — no padding bits
+- Flag bit positions are contiguous — no gaps between existing and new flags
+- `testFixedCheckBoxIds` / `testFixedMintMarkIds` in `MainApplicationTests`
+  updated with the new flag assertion and updated mask assertion
+- Migration in `upgradeDbStructure()` to set the flag for existing
+  collections (so coins already added by upgrade are visible)
+
+## 4. Test coverage
+
+- `CollectionCreationTests` updated for affected collections — new checkbox
+  columns added to test arrays, expected counts adjusted
+- `CollectionUpgradeTests` covers new upgrade paths
+- `SharedTest.COLLECTION_LIST_INFO_SCENARIOS` updated if checkbox or mint
+  mark flags changed
+- Round-trip test (`CoinPageCreatorTests.test_createFromParameters`) passes
+
+## 5. Resource completeness
+
+- New string resources in `res/values/strings.xml` for any new UI labels
+- New drawable resources for any new coin images
+- **`COIN_IMG_IDS` array ordering is immutable** — the array index is the
+  `imageId` persisted in user databases. Verify that:
+  - New entries are **only appended** to the end of the array
+  - No existing entries were reordered, removed, or inserted in the middle
+  - Index comments (e.g., `// 19`) are accurate after any additions
+  - Reordering or inserting would silently remap images for every existing
+    user collection — this is a data-corruption-level bug
+- **`COLLECTION_TYPES` array ordering is immutable** — removing an entry
+  causes `getIndexFromCollectionNameStr()` to return -1, crashing the app
+  for any user who has that collection. Verify that:
+  - New entries are **only appended** to the end of the array
+  - No existing entries were reordered, removed, or inserted in the middle
+  - The display-order arrays (`BASIC_COLLECTIONS`, `ADVANCED_COLLECTIONS`,
+    `MORE_COLLECTIONS`) can be freely reordered, but `COLLECTION_TYPES`
+    cannot
+
+## 6. Scope discipline
+
+- Changes are limited to what was requested — no unrelated refactors
+- No modifications to collections excluded from scope
+- `DATABASE_VERSION` bumped only if shipping a new release (not for
+  unreleased changes already covered by the current version)
+
+## Output
+
+Report a summary table with one row per section. Skip sections that don't
+apply to the current diff.
+
+| Area | Status | Findings |
+| --- | --- | --- |
+| DB migration guards | OK / ISSUE | details |
+| Collection upgrades | OK / ISSUE | details |
+| Checkbox round-trip | OK / ISSUE | details |
+| Test coverage | OK / ISSUE | details |
+| Resources | OK / ISSUE | details |
+| Scope | OK / ISSUE | details |
+
+If all applicable areas are OK, confirm the changes look good.
+If any issues are found, list the specific problems and recommended fixes.

--- a/.github/skills/run-tests/SKILL.md
+++ b/.github/skills/run-tests/SKILL.md
@@ -27,12 +27,21 @@ APIs. This is the suite to run for most code changes.
 
 - Collection creation and coin counts (`CollectionCreationTests`)
 - Database upgrades from all previous versions (`CollectionUpgradeTests`)
+- Fixture-based upgrade tests covering all parameter configurations
+  (`CollectionUpgradeAllParamsTests`)
+- Targeted upgrade tests for SemiQ coins with non-default parameters
+  (`CollectionUpgradeSemiQParamTests`)
 - Database access patterns (`DatabaseAccessTests`)
 - Export/import (CSV and JSON) (`ExportImportTests`, `ExportImportJsonTests`)
 - Activity launch and lifecycle (`LaunchCoinPageTests`, `MainActivityTests`)
 - Application initialization (`MainApplicationTests`)
 - Collection page behavior (`CollectionPageActivityTests`)
+- Collection creator parameter round-trips (`CoinPageCreatorTests`)
 - Coin image ID correctness (`CoinImageIdTests`)
+
+Also present: `GenerateV23Fixtures` is an `@Ignore`'d manual fixture
+generator — it does not run with the suite and is only run by hand when the
+V23 upgrade fixture files need regenerating.
 
 **Report location:** `app/build/reports/tests/testAndroidDebugUnitTest/index.html`
 

--- a/.github/skills/ui-regression-test/SKILL.md
+++ b/.github/skills/ui-regression-test/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: ui-regression-test
+description: Run a UI sanity check and export/import test against a connected Android emulator using the mobile-mcp MCP server and adb. Covers the two flows Espresso cannot automate (system file picker export/import). Requires a running emulator or connected device and the mobile-mcp server. NOT for general regression testing — the instrumented test suite covers everything else.
+---
+
+# UI Regression Test — Coin Collection App
+
+## Mission
+
+Run a navigation sanity check and an export/import test for the Coin Collection Android app using the mobile-mcp MCP server and adb commands against a connected emulator or device. These two tests require system file picker interaction that Espresso cannot automate. The Android instrumented test suite (`androidTest/java/com/spencerpages/`) covers all other regression tests.
+
+## Scope and Preconditions
+
+- An Android emulator is running or a physical device is connected (verify with `adb devices`)
+- The workspace root is the `coin-collection-android-US` repository
+- The mobile-mcp MCP server is available
+- Tool names in this skill are the mobile-mcp server's bare names. Your
+  client prefixes them (GitHub Copilot: `mcp_mobile-mcp_mobile_*`;
+  Claude Code: `mcp__mobile-mcp__mobile_*`) and may require loading them
+  through its tool-search mechanism before first use
+- If any precondition is unmet, report the issue and stop
+
+## Rules
+
+Follow these rules throughout the entire test session.
+
+### Coordinate Handling
+
+- Always call `mobile_list_elements_on_screen` to get element coordinates before tapping
+- Compute tap targets as center of the element: `x + width/2`, `y + height/2`
+- Use `adb shell input tap <centerX> <centerY>` with native coordinates from `list_elements_on_screen`
+- Never estimate coordinates from screenshot images — they are scaled down and will be inaccurate
+
+### Interaction Patterns
+
+- Alert dialog buttons appear as `android.widget.Button` — check exact text via `list_elements_on_screen`:
+  - Tutorial dialogs: "OKAY!" button
+  - Delete/Warning dialogs: "NO" / "YES" buttons
+  - Some success messages have no dismiss button — use `adb shell input keyevent KEYCODE_BACK` to dismiss
+- For text input: tap the `EditText` to focus it, then use `adb shell input text "value"` (use `%s` for spaces)
+- To navigate back, use `adb shell input keyevent KEYCODE_BACK`
+
+### First-Time Tutorial Dialogs
+
+The app shows one-time tutorial dialogs on first use. Whenever an unexpected dialog appears with an "OKAY!" button, dismiss it and continue.
+
+### Verification
+
+- Take a screenshot (`mobile_take_screenshot`) after each major action for visual verification
+- Use `list_elements_on_screen` to confirm expected elements are present
+- Report each test as **PASS** or **FAIL** with a brief reason
+- On app crash, report CRITICAL FAILURE and attempt to relaunch before continuing
+
+### Scrolling
+
+- If an element is not visible in `list_elements_on_screen`, scroll down with `adb shell input swipe 540 1500 540 500 300` and re-check
+- To scroll up: `adb shell input swipe 540 500 540 1500 300`
+
+---
+
+## Setup
+
+Build, install, and launch the app:
+
+```bash
+# Build and install the debug APK
+./gradlew installAndroidDebug
+
+# Clear any existing app data for a clean test
+adb shell pm clear com.spencerpages.debug
+
+# Launch the app
+adb shell am start -n com.spencerpages.debug/com.coincollection.MainActivity
+```
+
+Wait 3 seconds for the app to fully launch, then take a screenshot to confirm.
+
+A first-time tutorial dialog ("Thanks for downloading...") will appear — dismiss it by finding and tapping the "OKAY!" button.
+
+---
+
+## Workflow
+
+### Navigation Sanity Check
+
+**Goal:** Verify the app launches, key screens render without crashes, and basic navigation works. Detailed interaction testing is handled by the Android instrumented test suite.
+
+1. Call `list_elements_on_screen` and take a screenshot of the main activity
+2. Verify these navigation items are visible: "New Collection", "Delete Collection", "Import Collection", "Export Collection", "Reorder Collections", "App Info"
+3. Tap "New Collection" — a tutorial dialog will appear on first use — dismiss it by tapping "OKAY!" — verify the `CoinPageCreator` screen loads (look for screen title "Collection Page Creator")
+4. Take a screenshot
+5. Navigate back: `adb shell input keyevent KEYCODE_BACK`
+6. Create a test collection for remaining tests:
+   - Tap "New Collection" (no tutorial dialog on subsequent visits)
+   - Tap the collection name `EditText` and enter: `adb shell input text "Sanity%sTest"`
+   - The coin type spinner defaults to "Select Collection Type" — tap it and select "Pennies" from the dropdown
+   - Call `list_elements_on_screen` to locate the "CREATE NEW COLLECTION!" button and tap it
+   - Wait 3 seconds — the app opens the new collection's `CollectionPage`, and a tutorial dialog appears — dismiss it with "OKAY!"
+   - Navigate back to main activity with `KEYCODE_BACK`
+   - A long-press tutorial dialog ("Press and hold on a collection...") appears — dismiss it with "OKAY!"
+   - Verify "Sanity Test" appears on the main activity with progress "0/N", where N is the current Pennies total (the expected count from `CollectionCreationTests`)
+7. Tap the "Sanity Test" collection — verify the `CollectionPage` opens (look for `standard_collection_page` GridView; no tutorial dialog this time since it was dismissed in step 6)
+8. Take a screenshot
+9. Navigate back to main activity
+10. Tap "App Info" — verify a dialog appears containing "Coin Collection" and a version string matching the `versionName` in `app/src/main/AndroidManifest.xml` — press BACK to dismiss
+11. Tap "Reorder Collections" — a tutorial dialog appears on first use — dismiss it with "OKAY!" — verify the reorder screen loads (look for `reorder_collections_recycler_view` with the collection name and up/down arrows) — press BACK
+
+**Pass criteria:** App launches; CoinPageCreator, CollectionPage, App Info, and Reorder screens all render without crashes.
+
+---
+
+### Export and Import (JSON)
+
+**Goal:** Verify export to JSON and re-import restores data. This test uses the system file picker which cannot be automated with Espresso.
+
+1. Ensure at least one collection exists (created in the Navigation Sanity Check above). Take a screenshot of the main activity to record current collections and their progress counts.
+2. Tap "Export Collection"
+3. Verify the format picker dialog appears with title "Select an export file format:" and options:
+   - "JSON file"
+   - "CSV file (table format)"
+4. Tap "JSON file"
+5. A system file picker opens with a default filename like `coin-collection-MMDDYY.json` and a "SAVE" button at the bottom of the screen
+6. Call `list_elements_on_screen` to find the "SAVE" button (`android:id/button1`) in the file picker and tap it. **Note:** if a file with the same name already exists, an overwrite confirmation dialog appears — tap "OK" to proceed.
+7. Wait 3 seconds for the export to complete
+8. A success dialog appears: "Successfully exported collection to '...'" — this dialog has NO dismiss button. Press BACK to dismiss it.
+9. Take a screenshot
+10. Delete all collections using "Delete Collection" nav item, one at a time:
+    - Tap "Delete Collection" — a picker dialog titled "Select a collection to delete" appears listing all collections
+    - Tap the collection name to select it
+    - A "Warning!" confirmation dialog appears: "Are you sure you want to delete collection named '...'?" — tap "YES"
+    - Repeat for each collection
+11. Verify the main activity shows only navigation items (no collection rows)
+12. Tap "Import Collection"
+13. The system file picker opens (in open mode — no SAVE button). Call `list_elements_on_screen` to find the exported JSON file and tap it.
+14. Wait 3 seconds — the import completes silently and returns to the main activity (no success dialog)
+15. Verify collections are restored with the same names and progress counts as before the export
+16. Take a screenshot and compare with the screenshot from step 1
+
+**Pass criteria:** Export creates a JSON file; import restores all collections with correct data.
+
+---
+
+## Teardown
+
+After all tests complete:
+
+1. Delete all test collections via "Delete Collection" nav item, or clear app data:
+
+   ```bash
+   adb shell pm clear com.spencerpages.debug
+   ```
+
+> **Warning:** `pm clear` erases all app data on the device. Only run this on a test device or emulator.
+
+---
+
+## Output
+
+Provide a summary table:
+
+| Test | Result | Notes |
+| --- | --- | --- |
+| Navigation Sanity Check | | |
+| Export and Import (JSON) | | |
+
+Report total PASS / FAIL counts and any issues found.
+
+Remind the user to run the full Android instrumented test suite for complete coverage:
+
+```bash
+./gradlew connectedAndroidDebugAndroidTest
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,122 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository.
+
+## Project Overview
+
+Java-based Android app for tracking coin collections. Gradle builds, Fastlane
+automation, distributed via Google Play and Amazon Appstore (plus F-Droid from
+git tags). Includes Activities, Fragments, a SQLite database, unit and
+instrumented test suites, and Fastlane scripts for deployment and screenshot
+generation.
+
+## Architecture
+
+- **Activities**: `MainActivity` (collection list), `CollectionPage` (coin
+  grid), `CoinPageCreator` (collection creator/editor)
+- **Database**: SQLite via `DatabaseHelper` (schema/migrations) and
+  `DatabaseAdapter` (CRUD). Version-gated incremental upgrades.
+- **Collection types**: ~52 classes in `com.spencerpages.collections`, each
+  extending `CollectionInfo` (9 abstract methods). Registered in
+  `MainApplication.COLLECTION_TYPES[]`. Two patterns: year-based (e.g.,
+  `LincolnCents`) and named-identifier (e.g., `AmericanWomenQuarters`).
+- **Product flavors**: `android` (Google Play) and `amazon` (Amazon Appstore).
+  Default build/test variant: `androidDebug`.
+
+## Build and Test Commands
+
+```bash
+./gradlew assembleDebug                       # Build debug APKs
+./gradlew testAndroidDebugUnitTest            # Unit tests (Robolectric, primary suite)
+./gradlew lintAndroidDebug                    # Lint
+./gradlew connectedAndroidDebugAndroidTest    # Instrumented tests (needs emulator/device)
+```
+
+- Run a single test class:
+  `./gradlew testAndroidDebugUnitTest --tests "com.spencerpages.ClassName"`
+- Use `--rerun-tasks` only for full release verification — not for everyday
+  test runs.
+- Unit test report:
+  `app/build/reports/tests/testAndroidDebugUnitTest/index.html`
+
+## Key Facts (do not get these wrong)
+
+- `DATABASE_VERSION` and `DATABASE_NAME` live in
+  `app/src/main/java/com/spencerpages/MainApplication.java` — **not** in
+  `DatabaseHelper`. Never hardcode the current version number; check the file.
+- `versionCode`/`versionName` live in `app/src/main/AndroidManifest.xml` —
+  atypical for Android projects (NOT in `build.gradle`). Three release
+  workflows (`release.yml`, `promote.yml`, `deploy.yml`) grep them from there,
+  so keep them in the manifest.
+- Every Java file needs the GPL-3.0 license header block — copy it from any
+  existing Java file in the repo.
+- `compileSdk 37` / `minSdk 21`. The `amazon` flavor pins `targetSdk 35`
+  intentionally — never "unify" it with the main `targetSdk`.
+
+## Critical Invariants
+
+- `MainApplication.COLLECTION_TYPES[]` and each collection's `COIN_IMG_IDS[]`
+  are **append-only** — array indices are persisted in user databases.
+- DB migrations use `oldVersion <= N`, never `==` — upgrades must work from
+  any older version.
+- Adding coins to an existing series requires an
+  `onCollectionDatabaseUpgrade()` block — identifier arrays and
+  `OPTVAL_STILL_IN_PRODUCTION` only affect newly created collections.
+- Never reference a constant in an old migration block if its value can change
+  later — old blocks would silently pick up the new value and break. If a
+  constant's value changes, rewrite old blocks to use the old literal value.
+- Schema changes (ALTER TABLE, ADD COLUMN) need the `!fromImport` guard;
+  data-value migrations must NOT have it. See
+  `app/src/main/java/com/coincollection/CLAUDE.md` for exact rules.
+
+## Guiding Principles
+
+- **OS-agnostic**: developed on macOS, Linux, and Windows. NEVER use
+  OS-specific paths (e.g., `~/Library/...`, `/Users/...`) in code, scripts,
+  or suggestions. Use the Gradle wrapper (`./gradlew` or `gradlew.bat`),
+  environment variables (`$ANDROID_HOME`, `$JAVA_HOME`), or auto-detection.
+- **Avoid hardcoded values**: don't hardcode API levels, SDK paths, or other
+  environment-specific values — reference configuration files instead.
+- **Design before coding**: for new features or significant changes, outline
+  the design (class structure, method signatures, component interactions)
+  before writing code.
+- **Focused changes**: keep changes scoped to the task at hand; no unrelated
+  refactors or improvements in the same change.
+
+## Common Tasks
+
+| Task | Skill |
+| --- | --- |
+| Add a new coin collection type | `add-coin-collection` |
+| Add coins to existing collections / schema changes | `database-migration` |
+| Annual coin update workflow | `add-yearly-coins` |
+| Run tests / lint and interpret results | `run-tests` |
+| Domain-specific review of collection/DB changes | `review-changes` |
+| Pre-release verification | `release-checklist` |
+| Quick emulator screenshot for UI debugging | `capture-debug-screenshot` |
+| Regenerate the 18 store screenshots | `capture-store-screenshots` |
+| Deploy to Play / Amazon via Fastlane | `deploy-with-fastlane` |
+| Emulator UI sanity + export/import test | `ui-regression-test` |
+
+Skills are single-sourced in `.github/skills/<name>/SKILL.md` (shared with
+GitHub Copilot). `.claude/skills` is a symlink to `.github/skills` so Claude
+Code auto-discovers them — edit skills only under `.github/skills/`. On
+checkouts where the symlink doesn't materialize (e.g. Windows without
+symlink support), read the SKILL.md from `.github/skills/` directly when a
+task matches.
+
+Directory-specific rules live in nested `CLAUDE.md` files:
+
+- `app/src/main/java/com/spencerpages/collections/CLAUDE.md` — collection
+  class rules
+- `app/src/main/java/com/coincollection/CLAUDE.md` — database layer rules
+- `app/src/test/CLAUDE.md` — test writing rules
+
+## CI Gates
+
+- **markdownlint** (`markdownlint.yml`): markdownlint-cli2 runs on all `.md`
+  files (default rules, MD013 disabled) — authored markdown must be
+  lint-clean.
+- **gradle.yml**: runs `testAndroidDebugUnitTest` + `lintAndroidDebug` on PRs.
+- **fastlane-bundle-check.yml**: verifies the bundle installs and the
+  Fastfile loads when Fastfile changes.

--- a/app/src/main/java/com/coincollection/CLAUDE.md
+++ b/app/src/main/java/com/coincollection/CLAUDE.md
@@ -1,0 +1,47 @@
+# Database Layer Editing Guidelines
+
+These rules apply primarily to `Database*.java` in this package
+(`com.coincollection`).
+
+When editing `DatabaseHelper.java` or `DatabaseAdapter.java`, follow these rules:
+
+## Key constants
+
+- `DATABASE_VERSION` lives in `MainApplication.java`, **not** `DatabaseHelper`
+- `DATABASE_NAME` also lives in `MainApplication.java`
+- Current version: check `MainApplication.DATABASE_VERSION` (do not hardcode)
+
+## Upgrade flow (DatabaseHelper.upgradeDb)
+
+1. `upgradeDbStructure()` — app-level schema changes (columns, renames, data fixes)
+2. Loop over all user collections → call each type's `onCollectionDatabaseUpgrade()`
+3. Update collection totals based on return values
+
+## upgradeDbStructure rules
+
+- Guard **schema changes** (ALTER TABLE, ADD COLUMN) with `if (oldVersion <= N && !fromImport)` — imported DBs have the latest schema
+- **Data-value migrations** (updating existing column values like checkbox flags) must **omit** the `!fromImport` guard — use just `if (oldVersion <= N)`. Imported databases have the latest schema but carry old data values from the export that also need updating.
+- Use incremental checks (`oldVersion <= N`), never equality checks
+- Never drop existing columns — SQLite has limited ALTER TABLE support
+- Collection-specific coin additions do NOT go here — they go in each collection's `onCollectionDatabaseUpgrade()`
+- **Use `Xxx.COLLECTION_TYPE` qualified references** for collection type names (e.g., `LincolnCents.COLLECTION_TYPE` not `"Pennies"`). If a `COLLECTION_TYPE` value is later renamed via a separate migration, every old migration block that used the constant must be updated to use the old literal string value instead — only the new migration performing the rename should reference the constant.
+- **More generally, if the value of any static import or constant used in a migration block changes, old migrations referencing it will silently pick up the new value and break.** This applies to `COLLECTION_TYPE` constants, column name constants (`COL_*`), table name constants (`TBL_*`), display constants (e.g., `SIMPLE_DISPLAY`), and flag constants. If a constant's value must change, update every old migration block that used it to use the old literal value instead of the constant.
+
+## Helper methods
+
+- `addFromYear(db, collectionListInfo, year)` — adds coins for a year respecting user's mint marks
+- `addFromArrayList(db, collectionListInfo, identifiers)` — adds named coins respecting user's mint marks
+- `runSqlUpdate(db, table, values, where, args)` — update rows
+- `runSqlDelete(db, table, where, args)` — delete rows
+- `getNextCoinSortOrder(db, tableName)` — returns next available sort order value
+
+## Table naming
+
+- Collection tables use the collection name as the table name, wrapped in brackets: `[tableName]`
+- Use `DatabaseAdapter.removeBrackets()` when constructing SQL to prevent injection
+
+## After editing
+
+- Bump `DATABASE_VERSION` in `MainApplication.java` if not already done
+- Add test coverage in `CollectionUpgradeTests.java`
+- Run `./gradlew testAndroidDebugUnitTest` to verify

--- a/app/src/main/java/com/spencerpages/collections/CLAUDE.md
+++ b/app/src/main/java/com/spencerpages/collections/CLAUDE.md
@@ -1,0 +1,56 @@
+# Collection Type Editing Guidelines
+
+These rules apply to files in this package (`com.spencerpages.collections`).
+
+## Class structure
+
+- All collections extend `CollectionInfo` (`com.coincollection.CollectionInfo`)
+- 9 abstract methods must be implemented — see `CollectionInfo.java` for contracts
+- Use a `public static final String COLLECTION_TYPE` constant for `getCoinType()`
+
+## populateCollectionLists rules
+
+- Maintain a `int coinIndex = 0` counter, incrementing for every `CoinSlot` added
+- Each coin slot: `new CoinSlot(identifier, mintMark, coinIndex++)`
+- Check `OPT_SHOW_MINT_MARKS` first, then individual `OPT_SHOW_MINT_MARK_N` booleans
+- Use `getBooleanParameter()` and `getIntegerParameter()` helpers from the base class
+- Year-based: loop from `startYear` to `stopYear` using `getIntegerParameter()`
+- Named-identifier: loop over `COIN_IDENTIFIERS[]` array
+
+## onCollectionDatabaseUpgrade rules
+
+- **Every collection that receives new coins MUST have an upgrade block** — bumping `OPTVAL_STILL_IN_PRODUCTION` or adding to identifier arrays only affects newly created collections; existing user collections need the upgrade block to receive new coins
+- Use incremental version checks: `if (oldVersion <= N)` where N is the version **before** the bump
+- Never use `oldVersion == N` — upgrades must work from any older version
+- Return the **net total** of coins added minus coins removed
+- Use `DatabaseHelper.addFromArrayList()` for named-identifier coins
+- Use `DatabaseHelper.addFromYear()` for year-based coins
+- Both helpers respect the user's existing mint mark configuration
+- **Use `Xxx.COLLECTION_TYPE` qualified references** for collection type names in migration code (e.g., `LincolnCents.COLLECTION_TYPE` not `"Pennies"`). If a `COLLECTION_TYPE` value is later renamed via a separate migration, every old migration block that used the constant must be updated to use the old literal string value instead — only the new migration performing the rename should reference the constant.
+- **More generally, if the value of any static import or constant used in an upgrade block changes, old blocks referencing it will silently pick up the new value and break.** This applies to `COLLECTION_TYPE` constants, column name constants (`COL_*`), table name constants (`TBL_*`), display constants, flag constants, and any other symbol whose literal value is meaningful to migration SQL or logic. If a constant's value must change, update every old migration block that used it to use the old literal value instead of the constant.
+- **When `populateCollectionLists()` uses `getImgId()` to set `imageId` on `CoinSlot` objects, the corresponding `onCollectionDatabaseUpgrade()` must also pass the same `imageId`** — use `addFromYear(db, info, year, getImgId("tag"))` or `addFromArrayList(db, info, identifiers, imageIds)`. Failing to do so causes upgraded collections to show fallback images instead of the correct designs.
+
+## Mint mark options
+
+- `OPT_SHOW_MINT_MARKS` — master toggle (Boolean)
+- `OPT_SHOW_MINT_MARK_1` through `OPT_SHOW_MINT_MARK_5` — individual mint toggles (Boolean)
+- `OPT_SHOW_MINT_MARK_N_STRING_ID` — string resource ID for the label (e.g., `R.string.include_p`)
+
+## Checkbox and mint mark flag invariants
+
+- Flag bit positions in `CollectionListInfo` must be **unique and contiguous** — no gaps
+- `ALL_MINT_MASK` must equal `(1L << (highestMintBit + 1)) - 1`
+- `ALL_CHECKBOXES_MASK` must equal `(1L << (highestCheckboxBit + 1)) - 1`
+- When adding a new flag, also update the corresponding mask and add an assertion in `MainApplicationTests`
+
+## Special images
+
+- Override `getImageIds()` to return `Object[][]` of `{"description", imageResId}`
+- Use `getImgId(tag)` to map tags to indices at runtime
+- **NEVER reorder or insert into the middle of `COIN_IMG_IDS`** — the array index is the `imageId` stored in user databases. Always append new entries to the end of the array.
+
+## After editing
+
+- Update expected counts in `CollectionCreationTests.java`
+- Update scenarios in `SharedTest.COLLECTION_LIST_INFO_SCENARIOS` if parameters changed
+- Run `./gradlew testAndroidDebugUnitTest` to verify

--- a/app/src/test/CLAUDE.md
+++ b/app/src/test/CLAUDE.md
@@ -1,0 +1,46 @@
+# Test Writing Guidelines
+
+These rules apply to test code (`app/src/test/`, `app/src/androidTest/`, and
+`shared-test/`).
+
+## Unit tests (app/src/test/)
+
+- Framework: JUnit 4.13.2 + Robolectric 4.16.1 + Mockito 5
+- Base class: extend `BaseTestCase`
+- Test runner: Robolectric (AndroidJUnit4 via Robolectric)
+- Run with: `./gradlew testAndroidDebugUnitTest`
+- Default variant: `androidDebug` (not amazon)
+
+## Instrumented tests (app/src/androidTest/)
+
+- Framework: Espresso 3.7.0 + UIAutomator 2.3.0
+- Test runner: AndroidJUnitRunner
+- Run with: `./gradlew connectedAndroidTest`
+- Requires a running emulator or connected device
+- Helper: `UITestHelper.java` provides common test utilities
+- `ScreenshotsUITest.java` is for automated store screenshots — don't modify unless updating those
+
+## Shared test library (shared-test/)
+
+- `SharedTest.java` provides:
+  - `COLLECTION_LIST_INFO_SCENARIOS[]` — pre-built collection metadata for parametrized tests
+  - `COIN_SLOT_SCENARIOS[]` — sample coin slots with various states
+  - `PARAMETER_SCENARIOS[]` — parameter HashMap examples
+  - `compareCollectionListInfos()` — deep comparison of collection metadata
+  - `compareCoinSlots()` — compare coin slots with optional fields
+  - `compareCoinSlotLists()` — compare full coin lists
+  - `compareParameters()` — compare parameter HashMaps
+- Used by both unit and instrumented tests
+
+## Test patterns
+
+- Collection creation tests: create instance → getCreationParameters → set up test matrix of parameters → populateCollectionLists → assert coin count
+- Database upgrade tests: create DB at old version → upgrade → verify coins added correctly
+- Export/import tests: create collection → export → import → compare
+
+## When to update tests
+
+- Adding coins to a collection → update expected counts in `CollectionCreationTests`
+- Database migration → add upgrade path test in `CollectionUpgradeTests`
+- New collection type → add creation test + SharedTest scenario
+- Changed collection parameters → update `SharedTest.COLLECTION_LIST_INFO_SCENARIOS`


### PR DESCRIPTION
## Summary

Adds AI agent customization files so both GitHub Copilot and Claude Code have shared, single-sourced domain knowledge for working in this repo.

## Changes

**New skills** (`.github/skills/`):
- `add-yearly-coins` — annual coin update workflow
- `deploy-with-fastlane` — Play/Amazon deployment lanes
- `release-checklist` — pre-release verification
- `review-changes` — domain-specific review of collection/DB changes
- `ui-regression-test` — emulator UI sanity + export/import test

**Updated skills:**
- `capture-debug-screenshot`
- `database-migration`
- `run-tests`

**CLAUDE.md guidance files:**
- Root `CLAUDE.md`
- `app/src/main/java/com/coincollection/CLAUDE.md` (database layer rules)
- `app/src/main/java/com/spencerpages/collections/CLAUDE.md` (collection class rules)
- `app/src/test/CLAUDE.md` (test writing rules)

**Tooling:**
- `.claude/skills` symlink → `../.github/skills` so Claude Code auto-discovers the shared skills

## Notes

- `docs/plans/*` files were intentionally excluded — not checked in.
- markdownlint-cli2 passes on all 12 markdown files (0 errors).
