### PR TITLE
Fix NPE on CollectionPage recreation after process death

### DIFF
--- a/app/src/androidTest/java/com/spencerpages/CollectionPageProcessDeathTest.java
+++ b/app/src/androidTest/java/com/spencerpages/CollectionPageProcessDeathTest.java
@@ -1,0 +1,126 @@
+/*
+ * Coin Collection, an Android app that helps users track the coins that they've collected
+ * Copyright (C) 2010-2016 Andrew Williams
+ *
+ * This file is part of Coin Collection.
+ *
+ * Coin Collection is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Coin Collection is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Coin Collection.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.spencerpages;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.content.Intent;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.filters.LargeTest;
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
+
+import com.coincollection.CollectionPage;
+import com.coincollection.DatabaseAdapter;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Regression test for WI-02 (issue #404): recreating a {@link CollectionPage}
+ * while the shared database is closed — as happens when the OS kills the app
+ * process and the user returns to the collection from Recents — must not crash.
+ * <p>
+ * Before the fix, {@code CollectionPage.onCreate()} called
+ * {@code DatabaseAdapter.fetchTableDisplay()} synchronously, which threw a
+ * {@link NullPointerException} in {@code SQLiteDatabase.compileStatement()}
+ * because the database had not been (re)opened yet. The fix defers all
+ * database-dependent setup until the asynchronous open completes.
+ */
+@RunWith(AndroidJUnit4ClassRunner.class)
+@LargeTest
+public class CollectionPageProcessDeathTest {
+
+    private static final String COLLECTION_NAME = "Process Death Test";
+    // LincolnCents is at index 0 in MainApplication.COLLECTION_TYPES
+    private static final int COLLECTION_TYPE_INDEX = 0;
+
+    @Before
+    public void setUp() {
+        UITestHelper.disableSystemAnimations();
+        UITestHelper.dismissSystemDialogs();
+        UITestHelper.suppressAllTutorials();
+        UITestHelper.deleteAllCollections();
+        UITestHelper.createLincolnCentsCollection(COLLECTION_NAME, 0);
+        UITestHelper.unlockCollection(COLLECTION_NAME);
+    }
+
+    @After
+    public void tearDown() {
+        UITestHelper.deleteAllCollections();
+    }
+
+    /**
+     * Simulate returning to a collection after the OS reclaimed the app process:
+     * close the shared database, then launch (and recreate) the CollectionPage.
+     * The page must come up and render its grid without crashing, and the fix
+     * must reopen the database asynchronously.
+     */
+    @Test
+    public void test_collectionPageSurvivesProcessDeathWithClosedDatabase() {
+        Context context = getInstrumentation().getTargetContext();
+
+        Intent intent = new Intent(context, CollectionPage.class);
+        intent.putExtra(CollectionPage.COLLECTION_NAME, COLLECTION_NAME);
+        intent.putExtra(CollectionPage.COLLECTION_TYPE_INDEX, COLLECTION_TYPE_INDEX);
+
+        // Simulate process death: the shared database adapter is closed when the
+        // activity is recreated (a fresh process has an unopened database).
+        DatabaseAdapter sharedDbAdapter =
+                ((MainApplication) context.getApplicationContext()).getDbAdapter();
+        sharedDbAdapter.close();
+        assertFalse("Database should be closed to simulate process death",
+                sharedDbAdapter.isOpen());
+
+        // Cold-start path: launch CollectionPage with the database closed. Before
+        // the fix this crashed in onCreate, so ActivityScenario.launch would fail.
+        try (ActivityScenario<CollectionPage> scenario = ActivityScenario.launch(intent)) {
+            UITestHelper.dismissTutorialDialogs();
+            UITestHelper.waitForDisplayed(withId(R.id.standard_collection_page));
+            onView(withId(R.id.standard_collection_page)).check(matches(isDisplayed()));
+
+            // The deferred setup must have reopened the database asynchronously.
+            assertTrue("Deferred setup should have reopened the database",
+                    sharedDbAdapter.isOpen());
+
+            // Recreate the activity with the database closed again to exercise the
+            // deferred path on an activity recreation (config-change-style restore
+            // after another process-death event).
+            sharedDbAdapter.close();
+            assertFalse(sharedDbAdapter.isOpen());
+            scenario.recreate();
+
+            UITestHelper.dismissTutorialDialogs();
+            UITestHelper.waitForDisplayed(withId(R.id.standard_collection_page));
+            onView(withId(R.id.standard_collection_page)).check(matches(isDisplayed()));
+            assertTrue(sharedDbAdapter.isOpen());
+        }
+    }
+}

--- a/app/src/main/java/com/coincollection/AsyncTaskRunner.java
+++ b/app/src/main/java/com/coincollection/AsyncTaskRunner.java
@@ -25,31 +25,62 @@ import android.os.Handler;
 import android.os.Looper;
 
 import java.lang.ref.WeakReference;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 
 public class AsyncTaskRunner {
     private WeakReference<AsyncProgressInterface> mListenerRef;
-    private final static int NUM_DELAY_HALF_SECONDS = 10;
-    private final static ExecutorService mExecutorService = Executors.newCachedThreadPool();
-    private final Handler mMainHandler = new Handler(Looper.getMainLooper());
+    private final Executor mExecutor;
+    private final Handler mMainHandler;
     private final static Semaphore sDoInBackgroundSemaphore = new Semaphore(1, true);
 
-    private static int mLatestTaskId = TASK_NONE;
+    // Default production executor, shared across runners
+    private final static Executor sDefaultExecutor = Executors.newCachedThreadPool();
+
+    // The most recent task ID handled by this runner. Kept per-instance (not
+    // static) so a task started in one activity can't surface progress UI in an
+    // unrelated activity. Only read/written on the main thread.
+    private int mLatestTaskId = TASK_NONE;
+
+    // Result of a task that completed while no listener was attached (e.g. during
+    // a configuration change). Held here and delivered when the next listener
+    // attaches, so no task result is ever dropped. Only accessed on the main thread.
+    private boolean mHasPendingResult = false;
+    private int mPendingResultTaskId = TASK_NONE;
+    private String mPendingResultString = "";
 
     AsyncTaskRunner(AsyncProgressInterface listener) {
+        this(listener, sDefaultExecutor, new Handler(Looper.getMainLooper()));
+    }
+
+    /**
+     * Constructor allowing the executor and main-thread handler to be injected.
+     * Used by tests to run the background work synchronously and drive the main
+     * looper deterministically. Production code uses the single-argument
+     * constructor with the shared thread pool.
+     *
+     * @param listener    the initial listener
+     * @param executor    executor used to run the background work
+     * @param mainHandler handler used to post work to the main thread
+     */
+    AsyncTaskRunner(AsyncProgressInterface listener, Executor executor, Handler mainHandler) {
+        mExecutor = executor;
+        mMainHandler = mainHandler;
         setListener(listener);
     }
 
     /**
      * Set the listener for this task.
-     * 
+     *
      * @param listener an instance of AsyncProgressInterface to handle task events
      */
     protected void setListener(AsyncProgressInterface listener) {
         if (listener != null) {
             mListenerRef = new WeakReference<>(listener);
+            // A newly attached listener picks up any result that completed while
+            // detached, or re-shows progress for a task that is still running.
+            deliverPendingToListener();
         } else {
             mListenerRef = null;
         }
@@ -75,6 +106,13 @@ public class AsyncTaskRunner {
     }
 
     /**
+     * @return the currently attached listener, or null if none is attached
+     */
+    private AsyncProgressInterface getListener() {
+        return (mListenerRef != null) ? mListenerRef.get() : null;
+    }
+
+    /**
      * Execute the task with the given task ID.
      *
      * @param taskId an integer representing the task ID
@@ -82,12 +120,17 @@ public class AsyncTaskRunner {
     protected void execute(int taskId) {
         mMainHandler.post(() -> {
             mLatestTaskId = taskId;
-            // Execute pre-execute on main thread
-            onPreExecute(taskId);
-            mExecutorService.execute(() -> {
-                // Execute background task in a separate thread
-                String resultString = doInBackground(taskId);
-                // Execute post-execute on main thread
+            // Capture the listener that started the task and hold it strongly for
+            // the duration of the background work, so the task always runs to
+            // completion even if the activity is torn down (e.g. rotation) before
+            // it finishes. The result is delivered to whichever listener is
+            // attached when the work completes (see onPostExecute).
+            final AsyncProgressInterface listener = getListener();
+            if (listener != null) {
+                listener.asyncProgressOnPreExecute(taskId);
+            }
+            mExecutor.execute(() -> {
+                final String resultString = doInBackground(taskId, listener);
                 mMainHandler.post(() -> {
                     onPostExecute(taskId, resultString);
                     // Clear the latest task ID if it is still the latest
@@ -101,26 +144,20 @@ public class AsyncTaskRunner {
     }
 
     /**
-     * Perform the background task.
-     * This method uses a semaphore to ensure that background tasks are atomic
-     * 
-     * @param taskId an integer representing the task ID
+     * Perform the background task using the supplied listener.
+     * This method uses a semaphore to ensure that background tasks are atomic.
+     *
+     * @param taskId   an integer representing the task ID
+     * @param listener the listener captured when the task started
      * @return a string result to display, or "" if no result
      */
-    protected String doInBackground(int taskId) {
+    protected String doInBackground(int taskId, AsyncProgressInterface listener) {
+        if (listener == null) {
+            return "";
+        }
         try {
             sDoInBackgroundSemaphore.acquire();
-            for (int i = 0; i < NUM_DELAY_HALF_SECONDS; i++) {
-                if (mListenerRef != null && mListenerRef.get() != null) {
-                    return mListenerRef.get().asyncProgressDoInBackground(taskId);
-                }
-                try {
-                    Thread.sleep(500);
-                } catch (InterruptedException e) {
-                    break; // Return empty string (no error) if interrupted
-                }
-            }
-            return "";
+            return listener.asyncProgressDoInBackground(taskId);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             return "";
@@ -130,39 +167,44 @@ public class AsyncTaskRunner {
     }
 
     /**
-     * Method to perform on the UI thread before the async task starts.
-     * @param taskId an integer representing the task ID
+     * Deliver a completed task's result on the main thread. If no listener is
+     * attached (mid configuration change), the result is stashed and delivered
+     * when the next listener attaches.
+     *
+     * @param taskId       an integer representing the task ID
+     * @param resultString a string result to display, or "" if no result
      */
-    protected void onPreExecute(int taskId) {
-        for (int i = 0; i < NUM_DELAY_HALF_SECONDS; i++) {
-            if (mListenerRef != null && mListenerRef.get() != null) {
-                mListenerRef.get().asyncProgressOnPreExecute(taskId);
-                break;
-            }
-            try {
-                Thread.sleep(500);
-            } catch (InterruptedException e) {
-                break;
-            }
+    private void onPostExecute(int taskId, String resultString) {
+        AsyncProgressInterface listener = getListener();
+        if (listener != null) {
+            listener.asyncProgressOnPostExecute(taskId, resultString);
+        } else {
+            mHasPendingResult = true;
+            mPendingResultTaskId = taskId;
+            mPendingResultString = resultString;
         }
     }
 
     /**
-     * Method to perform on the UI thread after the async task completes.
-     * @param taskId an integer representing the task ID
-     * @param resultString a string result to display, or "" if no result
+     * Called when a listener attaches. Delivers a pending result if one is
+     * waiting, otherwise re-shows the progress UI if a task is still running.
+     * Must be called on the main thread.
      */
-    protected void onPostExecute(int taskId, String resultString) {
-        for (int i = 0; i < NUM_DELAY_HALF_SECONDS; i++) {
-            if (mListenerRef != null && mListenerRef.get() != null) {
-                mListenerRef.get().asyncProgressOnPostExecute(taskId, resultString);
-                break;
-            }
-            try {
-                Thread.sleep(500);
-            } catch (InterruptedException e) {
-                break;
-            }
+    private void deliverPendingToListener() {
+        AsyncProgressInterface listener = getListener();
+        if (listener == null) {
+            return;
+        }
+        if (mHasPendingResult) {
+            mHasPendingResult = false;
+            int taskId = mPendingResultTaskId;
+            String resultString = mPendingResultString;
+            mPendingResultTaskId = TASK_NONE;
+            mPendingResultString = "";
+            listener.asyncProgressOnPostExecute(taskId, resultString);
+        } else if (mLatestTaskId != TASK_NONE) {
+            // A task is still running - re-show its progress UI on the new activity
+            listener.asyncProgressOnPreExecute(mLatestTaskId);
         }
     }
 }

--- a/app/src/main/java/com/coincollection/BaseActivity.java
+++ b/app/src/main/java/com/coincollection/BaseActivity.java
@@ -26,6 +26,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.database.SQLException;
+import android.net.Uri;
 import android.os.Bundle;
 import android.os.StrictMode;
 import android.view.View;
@@ -57,6 +58,26 @@ public class BaseActivity extends AppCompatActivity implements AsyncProgressInte
      */
     public static class ActivityViewModel extends ViewModel {
         public AsyncTaskRunner mSavedTaskRunner;
+        // Inputs for the in-flight async task, captured on the UI thread so the
+        // background thread never has to read them from a View and so they survive
+        // a configuration change.
+        public final TaskRequest mTaskRequest = new TaskRequest();
+    }
+
+    /**
+     * Holder for async-task inputs that must be captured on the UI thread ahead
+     * of running the task on the background thread.
+     */
+    public static class TaskRequest {
+        // Collection name for a create/update collection task
+        public String collectionName;
+        // Import/export task inputs - file to read/write and format flags
+        public Uri importExportFileUri;
+        public boolean importExportLegacyCsv;
+        public boolean exportSingleFileCsv;
+        // True while an import task is rewriting the database, so recreated
+        // activities know not to read the database mid-import
+        public boolean isImportingCollection;
     }
 
     // Unit test flag for disabling async tasks
@@ -124,10 +145,10 @@ public class BaseActivity extends AppCompatActivity implements AsyncProgressInte
         if (!mDbAdapter.isOpen()) {
             // Use AsyncTaskRunner to open the database in case onUpgrade() is called, which is slow
             kickOffAsyncTaskRunner(TASK_OPEN_DATABASE);
-        } else {
-            // Display the progress dialog for the existing tasks (i.e. import/export)
-            asyncProgressOnPreExecute(mTaskRunner.getLatestTaskId());
         }
+        // Note: If a task (e.g. import/export) is already running when this activity
+        // is (re)created, its progress UI is re-shown and any completed result is
+        // delivered when the subclass calls setActivityReadyForAsyncCallbacks().
     }
 
     /**

--- a/app/src/main/java/com/coincollection/CoinPageCreator.java
+++ b/app/src/main/java/com/coincollection/CoinPageCreator.java
@@ -663,6 +663,10 @@ public class CoinPageCreator extends BaseActivity {
             return;
         }
 
+        // Capture the collection name (read from the EditText on the UI thread) as a
+        // task input so the background thread never has to touch a View
+        mActivityViewModel.mTaskRequest.collectionName = collectionName;
+
         // Passed all checks - start the creation/update and wait for callbacks to be called
         kickOffAsyncTaskRunner(TASK_CREATE_UPDATE_COLLECTION);
     }
@@ -675,9 +679,9 @@ public class CoinPageCreator extends BaseActivity {
         }
 
         if(taskId == TASK_CREATE_UPDATE_COLLECTION) {
-            // Go ahead and grab what is in the EditText
-            EditText nameEditText = findViewById(R.id.edit_enter_collection_name);
-            String collectionName = nameEditText.getText().toString();
+            // Use the collection name captured on the UI thread (see
+            // performCreateOrUpdateCollection) - never read a View off the UI thread
+            String collectionName = mActivityViewModel.mTaskRequest.collectionName;
 
             // Get the new display order for new collections (display order is preserved
             // for existing collections)

--- a/app/src/main/java/com/coincollection/CollectionPage.java
+++ b/app/src/main/java/com/coincollection/CollectionPage.java
@@ -68,6 +68,16 @@ public class CollectionPage extends BaseActivity {
     public CoinSlotAdapter mCoinSlotAdapter;
     private int mCollectionTypeIndex;
 
+    // Saved off in onCreate so that database-dependent setup can run later, once
+    // the database has been confirmed open (e.g. after process death)
+    private Bundle mSavedInstanceState;
+
+    // Set when onCreate defers database-dependent setup because the database was
+    // not yet open; cleared once the deferred setupFromDatabase() has run. Guards
+    // against the async open callback firing before onCreate has finished
+    // initializing the fields setupFromDatabase() depends on.
+    private boolean mSetupFromDatabasePending = false;
+
     // Saved Instance State Keywords
 
     // Intent Argument Keywords
@@ -125,10 +135,10 @@ public class CollectionPage extends BaseActivity {
 
         // Save off this bundle so that after the database is open we can use it
         // to get the previous CoinSlotAdapter, if present
+        mSavedInstanceState = savedInstanceState;
 
         // Need to get the coin type from the intent that started this process
         mCollectionTypeIndex = mCallingIntent.getIntExtra(COLLECTION_TYPE_INDEX, 0);
-        CollectionInfo collectionTypeObj = MainApplication.COLLECTION_TYPES[mCollectionTypeIndex];
 
         // Capture the collection name from the saved instance state if it's there,
         // otherwise capture from the calling intent. Note that the calling intent
@@ -166,6 +176,31 @@ public class CollectionPage extends BaseActivity {
             createAndShowHelpDialog("first_Time_screen_search", R.string.tutorial_search_feature);
         }
 
+        // At this point the UI is ready to handle any async callbacks
+        setActivityReadyForAsyncCallbacks();
+
+        // Defer database-dependent setup until the database is confirmed open. On a
+        // warm start the database is already open, so run it directly (no behavior
+        // change). On a cold start after process death, BaseActivity.onCreate kicks
+        // off TASK_OPEN_DATABASE asynchronously and setupFromDatabase() then runs
+        // from asyncProgressOnPostExecute() once the open completes.
+        if (mDbAdapter.isOpen()) {
+            setupFromDatabase();
+        } else {
+            mSetupFromDatabasePending = true;
+        }
+    }
+
+    /**
+     * Performs the database-dependent portion of activity setup. This must only be
+     * called once the database is confirmed open, otherwise the DB accesses below
+     * will crash with a NullPointerException (e.g. when returning to this activity
+     * after the OS has killed the app process).
+     */
+    private void setupFromDatabase() {
+
+        CollectionInfo collectionTypeObj = MainApplication.COLLECTION_TYPES[mCollectionTypeIndex];
+
         // Determine whether we should show the advanced view or the basic view
         mDisplayType = mDbAdapter.fetchTableDisplay(mCollectionName);
 
@@ -178,7 +213,7 @@ public class CollectionPage extends BaseActivity {
         }
 
         // Populate the coin list
-        if (savedInstanceState == null) {
+        if (mSavedInstanceState == null) {
             boolean populateAdvInfo = (mDisplayType == ADVANCED_DISPLAY);
             mCoinList = mDbAdapter.getCoinList(mCollectionName, populateAdvInfo);
         } else {
@@ -189,7 +224,7 @@ public class CollectionPage extends BaseActivity {
             if (BuildConfig.DEBUG) {
                 Log.d(APP_NAME, "Successfully restored previous state");
             }
-            mCoinList = savedInstanceState.getParcelableArrayList(COIN_LIST);
+            mCoinList = mSavedInstanceState.getParcelableArrayList(COIN_LIST);
             // Search through the hasChanged history and see whether we should
             // re-display the "Unsaved Changes" view
             if (mCoinList != null) {
@@ -205,8 +240,8 @@ public class CollectionPage extends BaseActivity {
         // Initialize coin filter state
         SharedPreferences filterPreferences = getSharedPreferences(MainApplication.PREFS, MODE_PRIVATE);
         // Use saved filter state if available, otherwise use SharedPreferences
-        if (savedInstanceState != null && savedInstanceState.containsKey("COIN_FILTER_STATE")) {
-            mCoinFilter = savedInstanceState.getInt("COIN_FILTER_STATE", FILTER_SHOW_ALL);
+        if (mSavedInstanceState != null && mSavedInstanceState.containsKey("COIN_FILTER_STATE")) {
+            mCoinFilter = mSavedInstanceState.getInt("COIN_FILTER_STATE", FILTER_SHOW_ALL);
         } else {
             mCoinFilter = filterPreferences.getInt(mCollectionName + COIN_FILTER, FILTER_SHOW_ALL);
         }
@@ -333,6 +368,28 @@ public class CollectionPage extends BaseActivity {
 
         // Scroll to the last position viewed (if saved)
         scrollToIndex(mViewIndex, mViewPosition, false);
+    }
+
+    /**
+     * Once the asynchronous database open completes, run the deferred
+     * database-dependent setup. This is the cold-start path taken when the
+     * activity is recreated after the OS killed the app process.
+     *
+     * @param taskId    an integer representing the task ID
+     * @param resultStr a string result to display, or "" if no result
+     */
+    @Override
+    public void asyncProgressOnPostExecute(int taskId, String resultStr) {
+        super.asyncProgressOnPostExecute(taskId, resultStr);
+        if (taskId == TASK_OPEN_DATABASE && mSetupFromDatabasePending) {
+            dismissProgressDialog();
+            mSetupFromDatabasePending = false;
+            // Only proceed if the open succeeded; on failure super has already
+            // shown the error alert and the database is still not usable.
+            if (resultStr.isEmpty()) {
+                setupFromDatabase();
+            }
+        }
     }
 
     /**

--- a/app/src/main/java/com/coincollection/MainActivity.java
+++ b/app/src/main/java/com/coincollection/MainActivity.java
@@ -82,11 +82,8 @@ public class MainActivity extends BaseActivity {
     // The number of actual collections in mCollectionListEntries
     public int mNumberOfCollections = 0;
 
-    // Used for the Update Database functionality
-    private boolean mIsImportingCollection = false;
-    private boolean mImportExportLegacyCsv = false;
-    private boolean mExportSingleFileCsv = false;
-    private Uri mImportExportFileUri = null;
+    // Import/export task inputs live in mActivityViewModel.mTaskRequest (not in
+    // activity fields) so they survive configuration changes while a task runs
 
     // App permission requests
     private final static int IMPORT_PERMISSIONS_REQUEST = 0;
@@ -288,11 +285,16 @@ public class MainActivity extends BaseActivity {
         switch (taskId) {
             case TASK_IMPORT_COLLECTIONS: {
                 ExportImportHelper helper = new ExportImportHelper(mRes, mDbAdapter);
-                if (mImportExportLegacyCsv) {
+                if (mActivityViewModel.mTaskRequest.importExportLegacyCsv) {
                     return helper.importCollectionsFromLegacyCSV(getLegacyExportFolderName());
                 } else {
-                    try (InputStream inputStream = getContentResolver().openInputStream(mImportExportFileUri)) {
-                        String fileName = getFileNameFromUri(mImportExportFileUri);
+                    final Uri fileUri = mActivityViewModel.mTaskRequest.importExportFileUri;
+                    if (fileUri == null) {
+                        return mRes.getString(R.string.error_importing,
+                                mRes.getString(R.string.error_no_file_selected));
+                    }
+                    try (InputStream inputStream = getContentResolver().openInputStream(fileUri)) {
+                        String fileName = getFileNameFromUri(fileUri);
                         if (fileName.endsWith(".csv")) {
                             return helper.importCollectionsFromSingleCSV(inputStream);
                         } else {
@@ -305,11 +307,16 @@ public class MainActivity extends BaseActivity {
             }
             case TASK_EXPORT_COLLECTIONS: {
                 ExportImportHelper helper = new ExportImportHelper(mRes, mDbAdapter);
-                if (mImportExportLegacyCsv) {
+                if (mActivityViewModel.mTaskRequest.importExportLegacyCsv) {
                     return helper.exportCollectionsToLegacyCSV(getLegacyExportFolderName());
                 } else {
-                    try (OutputStream outputStream = getContentResolver().openOutputStream(mImportExportFileUri)) {
-                        String fileName = getFileNameFromUri(mImportExportFileUri);
+                    final Uri fileUri = mActivityViewModel.mTaskRequest.importExportFileUri;
+                    if (fileUri == null) {
+                        return mRes.getString(R.string.error_exporting,
+                                mRes.getString(R.string.error_no_file_selected));
+                    }
+                    try (OutputStream outputStream = getContentResolver().openOutputStream(fileUri)) {
+                        String fileName = getFileNameFromUri(fileUri);
                         if (fileName.endsWith(".csv")) {
                             return helper.exportCollectionsToSingleCSV(outputStream, fileName);
                         } else {
@@ -329,7 +336,7 @@ public class MainActivity extends BaseActivity {
         super.asyncProgressOnPostExecute(taskId, resultStr);
         dismissProgressDialog();
         if (taskId == TASK_IMPORT_COLLECTIONS) {
-            mIsImportingCollection = false;
+            mActivityViewModel.mTaskRequest.isImportingCollection = false;
         }
         updateCollectionListFromDatabaseAndUpdateViewForUIThread();
     }
@@ -393,7 +400,7 @@ public class MainActivity extends BaseActivity {
      * Handle when the user starts importing a collection
      */
     private void launchImportTask() {
-        if (!mImportExportLegacyCsv) {
+        if (!mActivityViewModel.mTaskRequest.importExportLegacyCsv) {
             Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
             intent.addCategory(Intent.CATEGORY_OPENABLE);
             intent.setType("*/*");
@@ -438,10 +445,10 @@ public class MainActivity extends BaseActivity {
             return;
         }
 
-        if (!mImportExportLegacyCsv) {
+        if (!mActivityViewModel.mTaskRequest.importExportLegacyCsv) {
             Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
             intent.addCategory(Intent.CATEGORY_OPENABLE);
-            if (mExportSingleFileCsv) {
+            if (mActivityViewModel.mTaskRequest.exportSingleFileCsv) {
                 intent.setType("text/csv");
                 intent.putExtra(Intent.EXTRA_TITLE, "coin-collection-" + getTodayDateString() + ".csv");
             } else {
@@ -463,7 +470,7 @@ public class MainActivity extends BaseActivity {
             }
 
             // Indicate that we're using the legacy CSV
-            mImportExportLegacyCsv = true;
+            mActivityViewModel.mTaskRequest.importExportLegacyCsv = true;
 
             // Check to see if the folder exists already
             File dir = new File(getLegacyExportFolderName());
@@ -543,7 +550,7 @@ public class MainActivity extends BaseActivity {
             switch (requestCode) {
                 case PICK_EXPORT_FILE: {
                     if (resultData != null) {
-                        mImportExportFileUri = resultData.getData();
+                        mActivityViewModel.mTaskRequest.importExportFileUri = resultData.getData();
                         // Finish the export using AsyncTaskRunner to do the heavy lifting
                         kickOffAsyncTaskRunner(TASK_EXPORT_COLLECTIONS);
                     }
@@ -551,7 +558,7 @@ public class MainActivity extends BaseActivity {
                 }
                 case PICK_IMPORT_FILE: {
                     if (resultData != null) {
-                        mImportExportFileUri = resultData.getData();
+                        mActivityViewModel.mTaskRequest.importExportFileUri = resultData.getData();
                         if (mNumberOfCollections != 0) {
                             showImportConfirmation();
                         } else {
@@ -666,7 +673,7 @@ public class MainActivity extends BaseActivity {
         // We use this function as a convenience for updating the database once the list gets focus
         // after returning from the add/delete/reorder views.
 
-        if (hasFocus && !mIsImportingCollection) {
+        if (hasFocus && !mActivityViewModel.mTaskRequest.isImportingCollection) {
             // Only do this if the database has been opened with AsyncTaskRunner first
             // and we aren't modifying the database like crazy (importing)
             // We need this so that new collections that are added/removed get shown
@@ -754,7 +761,7 @@ public class MainActivity extends BaseActivity {
                 .setPositiveButton(mRes.getString(R.string.yes), (dialog, id) -> {
                     // Finish the import using AsyncTaskRunner to do the heavy lifting
                     dialog.dismiss();
-                    mIsImportingCollection = true;
+                    mActivityViewModel.mTaskRequest.isImportingCollection = true;
                     kickOffAsyncTaskRunner(TASK_IMPORT_COLLECTIONS);
                 })
                 .setNegativeButton(mRes.getString(R.string.no), (dialog, id) -> dialog.cancel()));
@@ -958,7 +965,7 @@ public class MainActivity extends BaseActivity {
         if (Build.VERSION.SDK_INT > Build.VERSION_CODES.Q) {
             // In API 30+, access to the SD card is disabled, so don't give the user the option
             // to import from legacy storage. Since there is no choice, go directly to the picker
-            mImportExportLegacyCsv = false;
+            mActivityViewModel.mTaskRequest.importExportLegacyCsv = false;
             launchImportTask();
             return;
         }
@@ -974,14 +981,14 @@ public class MainActivity extends BaseActivity {
                         case 0: {
                             // Pick back-up file
                             dialog.dismiss();
-                            mImportExportLegacyCsv = false;
+                            mActivityViewModel.mTaskRequest.importExportLegacyCsv = false;
                             launchImportTask();
                             break;
                         }
                         case 1: {
                             // Legacy Storage
                             dialog.dismiss();
-                            mImportExportLegacyCsv = true;
+                            mActivityViewModel.mTaskRequest.importExportLegacyCsv = true;
                             launchImportTask();
                             break;
                         }
@@ -1016,24 +1023,24 @@ public class MainActivity extends BaseActivity {
                         case 0: {
                             // JSON file
                             dialog.dismiss();
-                            mImportExportLegacyCsv = false;
-                            mExportSingleFileCsv = false;
+                            mActivityViewModel.mTaskRequest.importExportLegacyCsv = false;
+                            mActivityViewModel.mTaskRequest.exportSingleFileCsv = false;
                             launchExportTask();
                             break;
                         }
                         case 1: {
                             // CSV file (single-file)
                             dialog.dismiss();
-                            mImportExportLegacyCsv = false;
-                            mExportSingleFileCsv = true;
+                            mActivityViewModel.mTaskRequest.importExportLegacyCsv = false;
+                            mActivityViewModel.mTaskRequest.exportSingleFileCsv = true;
                             launchExportTask();
                             break;
                         }
                         case 2: {
                             // Legacy CSV
                             dialog.dismiss();
-                            mImportExportLegacyCsv = true;
-                            mExportSingleFileCsv = false;
+                            mActivityViewModel.mTaskRequest.importExportLegacyCsv = true;
+                            mActivityViewModel.mTaskRequest.exportSingleFileCsv = false;
                             launchExportTask();
                             break;
                         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -315,6 +315,7 @@
     <string name="error_exporting_collections">The following collections could not be exported due to errors:%1$s</string>
     <string name="error_exporting">Could not export collections (%1$s)</string>
     <string name="error_importing">Could not import collections (%1$s)</string>
+    <string name="error_no_file_selected">no file was selected</string>
     <string name="error_no_file_manager">No app found to open files. Please install a file manager to import collections</string>
 
     <!-- Reorder Collections Page -->

--- a/app/src/test/java/com/coincollection/AsyncTaskRunnerTests.java
+++ b/app/src/test/java/com/coincollection/AsyncTaskRunnerTests.java
@@ -1,0 +1,201 @@
+/*
+ * Coin Collection, an Android app that helps users track the coins that they've collected
+ * Copyright (C) 2010-2016 Andrew Williams
+ *
+ * This file is part of Coin Collection.
+ *
+ * Coin Collection is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Coin Collection is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Coin Collection.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.coincollection;
+
+import static org.junit.Assert.assertEquals;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.os.Handler;
+import android.os.Looper;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Unit tests for {@link AsyncTaskRunner}, focusing on the pending-result model,
+ * progress re-show on re-attach, and per-instance task id isolation. The runner
+ * is driven with an injected executor + main-thread handler so the background
+ * work and the main looper can be stepped deterministically.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class AsyncTaskRunnerTests {
+
+    /**
+     * Records the callbacks delivered by the runner and supplies a fixed
+     * background result.
+     */
+    private static class RecordingListener implements AsyncProgressInterface {
+        int preCount = 0;
+        int postCount = 0;
+        int lastPostTaskId = BaseActivity.TASK_NONE;
+        String lastPostResult = null;
+        final String backgroundResult;
+
+        RecordingListener(String backgroundResult) {
+            this.backgroundResult = backgroundResult;
+        }
+
+        @Override
+        public String asyncProgressDoInBackground(int taskId) {
+            return backgroundResult;
+        }
+
+        @Override
+        public void asyncProgressOnPreExecute(int taskId) {
+            preCount++;
+        }
+
+        @Override
+        public void asyncProgressOnPostExecute(int taskId, String resultStr) {
+            postCount++;
+            lastPostTaskId = taskId;
+            lastPostResult = resultStr;
+        }
+    }
+
+    /**
+     * Executor that stores the submitted work so the test can run it on demand,
+     * allowing a listener swap to be simulated between task start and completion.
+     */
+    private static class ManualExecutor implements Executor {
+        private Runnable mPending;
+
+        @Override
+        public void execute(Runnable command) {
+            mPending = command;
+        }
+
+        void runPending() {
+            Runnable command = mPending;
+            mPending = null;
+            if (command != null) {
+                command.run();
+            }
+        }
+    }
+
+    private static Handler mainHandler() {
+        return new Handler(Looper.getMainLooper());
+    }
+
+    private static void idleMainLooper() {
+        shadowOf(Looper.getMainLooper()).idle();
+    }
+
+    /**
+     * A task that completes while no listener is attached must deliver its real
+     * result to the next listener that attaches - exactly once.
+     */
+    @Test
+    public void resultDeliveredToListenerAttachedAfterCompletion() {
+        RecordingListener starter = new RecordingListener("import-done");
+        ManualExecutor executor = new ManualExecutor();
+        AsyncTaskRunner runner = new AsyncTaskRunner(starter, executor, mainHandler());
+
+        runner.execute(BaseActivity.TASK_IMPORT_COLLECTIONS);
+        idleMainLooper();
+        assertEquals(1, starter.preCount);
+
+        // Simulate a configuration change: detach the current listener before the
+        // background work completes
+        runner.clearListener();
+        executor.runPending();
+        idleMainLooper();
+
+        // The detached starter must not receive the result
+        assertEquals(0, starter.postCount);
+
+        // The next listener to attach receives the pending result exactly once
+        RecordingListener next = new RecordingListener("ignored");
+        runner.setListener(next);
+        assertEquals(1, next.postCount);
+        assertEquals("import-done", next.lastPostResult);
+        assertEquals(BaseActivity.TASK_IMPORT_COLLECTIONS, next.lastPostTaskId);
+    }
+
+    /**
+     * When a listener attaches while a task is still running, its progress UI is
+     * re-shown (pre-execute), and it later receives the completed result.
+     */
+    @Test
+    public void progressReshownWhenListenerAttachesDuringRunningTask() {
+        RecordingListener starter = new RecordingListener("export-done");
+        ManualExecutor executor = new ManualExecutor();
+        AsyncTaskRunner runner = new AsyncTaskRunner(starter, executor, mainHandler());
+
+        runner.execute(BaseActivity.TASK_EXPORT_COLLECTIONS);
+        idleMainLooper();
+        assertEquals(1, starter.preCount);
+
+        // Rotate: detach and attach a fresh listener while the task is still running
+        runner.clearListener();
+        RecordingListener next = new RecordingListener("ignored");
+        runner.setListener(next);
+
+        // Progress is re-shown on the new listener, and no result yet
+        assertEquals(1, next.preCount);
+        assertEquals(0, next.postCount);
+
+        // Completing the task delivers the real result to the attached listener
+        executor.runPending();
+        idleMainLooper();
+        assertEquals(1, next.postCount);
+        assertEquals("export-done", next.lastPostResult);
+    }
+
+    /**
+     * The latest task id is tracked per runner instance, so a task in one
+     * activity's runner does not surface in another's.
+     */
+    @Test
+    public void taskIdIsTrackedPerInstance() {
+        RecordingListener l1 = new RecordingListener("");
+        RecordingListener l2 = new RecordingListener("");
+        AsyncTaskRunner r1 = new AsyncTaskRunner(l1, new ManualExecutor(), mainHandler());
+        AsyncTaskRunner r2 = new AsyncTaskRunner(l2, new ManualExecutor(), mainHandler());
+
+        r1.execute(BaseActivity.TASK_IMPORT_COLLECTIONS);
+        idleMainLooper();
+
+        assertEquals(BaseActivity.TASK_IMPORT_COLLECTIONS, r1.getLatestTaskId());
+        assertEquals(BaseActivity.TASK_NONE, r2.getLatestTaskId());
+    }
+
+    /**
+     * Happy path: with a listener attached throughout, the task runs and delivers
+     * its result, and the latest task id is cleared on completion.
+     */
+    @Test
+    public void resultDeliveredWhenListenerAttachedThroughout() {
+        RecordingListener listener = new RecordingListener("ok");
+        AsyncTaskRunner runner = new AsyncTaskRunner(listener, Runnable::run, mainHandler());
+
+        runner.execute(BaseActivity.TASK_EXPORT_COLLECTIONS);
+        idleMainLooper();
+
+        assertEquals(1, listener.preCount);
+        assertEquals(1, listener.postCount);
+        assertEquals("ok", listener.lastPostResult);
+        assertEquals(BaseActivity.TASK_NONE, runner.getLatestTaskId());
+    }
+}

--- a/app/src/test/java/com/spencerpages/LaunchCoinPageTests.java
+++ b/app/src/test/java/com/spencerpages/LaunchCoinPageTests.java
@@ -21,12 +21,14 @@
 package com.spencerpages;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import android.content.Intent;
 
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.core.app.ApplicationProvider;
 
+import com.coincollection.BaseActivity;
 import com.coincollection.CollectionInfo;
 import com.coincollection.CollectionPage;
 import com.coincollection.MainActivity;
@@ -73,6 +75,67 @@ public class LaunchCoinPageTests extends BaseTestCase {
                     CollectionPage coinActivity = Robolectric.buildActivity(CollectionPage.class, intent).get();
                     assertNotNull(coinActivity);
                     coinActivity.onCreate(null);
+
+                    // Clean up
+                    activity.deleteDatabase(scenario1.mCollectionListInfo.getName());
+                }
+            });
+        }
+    }
+
+    /**
+     * Test that recreating a CollectionPage while the database is closed (as
+     * happens when the OS kills the app process and the user returns from
+     * Recents) does not crash. Per WI-02, onCreate must defer all database
+     * access until the asynchronous open completes.
+     */
+    @Test
+    public void test_launchCoinPageWithClosedDatabase() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+                for (FullCollection scenario1 : getRandomTestScenarios(mCoinTypeObj, 1)) {
+                    // Create the collection in the database
+                    activity.mDbAdapter.createAndPopulateNewTable(scenario1.mCollectionListInfo,
+                            scenario1.mDisplayOrder, scenario1.mCoinList);
+                    activity.updateCollectionListFromDatabase();
+
+                    // Launch the collection
+                    Intent intent = activity.launchCoinPageActivity(scenario1.mCollectionListInfo);
+                    assertNotNull(intent);
+
+                    // Simulate process death: the shared database is not open when
+                    // the activity is recreated
+                    activity.mDbAdapter.close();
+
+                    // Use the real (asynchronous) task path for the database open.
+                    // The synchronous unit-test seam would reopen the database inside
+                    // BaseActivity.onCreate and mask a regression in the deferral.
+                    CollectionPage coinActivity;
+                    BaseActivity.isUnitTest = false;
+                    try {
+                        coinActivity = Robolectric.buildActivity(CollectionPage.class, intent).get();
+                        assertNotNull(coinActivity);
+                        // onCreate must not touch the database directly in this state,
+                        // otherwise it crashes with a NullPointerException
+                        coinActivity.onCreate(null);
+                    } finally {
+                        BaseActivity.isUnitTest = true;
+                    }
+
+                    // The database-dependent setup must have been deferred, not run
+                    // against the closed database
+                    assertNull(coinActivity.mCoinSlotAdapter);
+
+                    // Complete the open and deliver the callback as the task runner
+                    // would, and verify the deferred setup then runs
+                    activity.mDbAdapter.open();
+                    coinActivity.asyncProgressOnPostExecute(BaseActivity.TASK_OPEN_DATABASE, "");
+                    assertNotNull(coinActivity.mCoinSlotAdapter);
+
+                    // Detach the activity from its task runner so the still-queued
+                    // database-open task becomes a no-op when the looper idles
+                    coinActivity.onDestroy();
 
                     // Clean up
                     activity.deleteDatabase(scenario1.mCollectionListInfo.getName());


### PR DESCRIPTION
## Summary

Fixes the production `NullPointerException` reported in #404:

```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method
'…SQLiteStatement …SQLiteDatabase.compileStatement(java.lang.String)' on a null object reference
  at com.coincollection.DatabaseAdapter.fetchTableDisplay (DatabaseAdapter.java:170)
  at com.coincollection.CollectionPage.onCreate (CollectionPage.java:170)
```

### Root cause

`CollectionPage.onCreate()` accessed the database synchronously via `DatabaseAdapter.fetchTableDisplay()` before the asynchronous database open had completed. On a **cold start after process death** (the OS reclaims the app process while `CollectionPage` is in the back stack, then the user returns and the task is restored from Recents), a fresh `MainApplication`/`DatabaseAdapter` is created with `mDb == null`. `BaseActivity.onCreate()` kicks off `TASK_OPEN_DATABASE` asynchronously, but the old code immediately called into the DB on the UI thread, so `mDb.compileStatement(...)` threw the NPE.

On a normal warm start (launching from `MainActivity`) the DB was already open, so the bug only affected users returning after a low-memory process kill — matching the intermittent production reports.

### Fix

- Defer all database-dependent setup in `CollectionPage` into a new `setupFromDatabase()` method.
  - **Warm start** (DB already open): run it inline — no behavior change.
  - **Cold start** (DB not yet open): set a pending flag and run it from the `TASK_OPEN_DATABASE` async callback once the open completes.
- Harden the `AsyncTaskRunner` lifecycle and related activity callbacks so a running/completed task is delivered safely after the activity's UI is ready.

## Testing

- Unit suite + `lintAndroidDebug` green (including a forced `--rerun-tasks` run); added `AsyncTaskRunnerTests` and a `test_launchCoinPageWithClosedDatabase` case in `LaunchCoinPageTests`.
- Instrumented Espresso suite: 31/31 passing on API 36.
- Manual rotation-storm (default + "Always destroy activities") — no crash.
- Manual **kill-from-Recents / process-death restore**: killed the backgrounded process, returned via Recents; `CollectionPage` was recreated in a fresh process and its grid rendered with **no NPE** — the original crash no longer reproduces.

Fixes #404
