### PR TITLE
Fix NPE in showUnsavedTextView on state restore (#405)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -104,8 +104,12 @@ android {
                 showStackTraces = true
                 showStandardStreams = true
             }
-            // Configure JVM arguments to prevent Mockito self-attachment warnings
-            jvmArgs '-XX:+EnableDynamicAgentLoading'
+            // Load Mockito as an explicit Java agent instead of relying on its
+            // inline mock maker self-attaching at runtime. Self-attach is fragile
+            // on JDK 21+ (and fails outright on some JVMs, e.g. the JetBrains
+            // Runtime used in CI), which caused Mockito to break for the rest of
+            // the forked JVM once another test polluted its state.
+            jvmArgs "-javaagent:${configurations.mockitoAgent.asPath}", '-XX:+EnableDynamicAgentLoading'
         }
         unitTests.includeAndroidResources = true
     }
@@ -123,6 +127,9 @@ android {
 }
 
 configurations {
+    // Resolves the Mockito jar so it can be passed to the test JVM as a
+    // -javaagent (see testOptions above).
+    mockitoAgent
     configureEach {
         exclude module: 'commons-logging'
     }
@@ -139,6 +146,7 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.16.1'
     testImplementation 'androidx.test:core:1.7.0'
     testImplementation 'org.mockito:mockito-core:5.23.0'
+    mockitoAgent('org.mockito:mockito-core:5.23.0') { transitive = false }
     androidTestImplementation(project(":shared-test"))
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.7.0'

--- a/app/src/main/java/com/coincollection/CollectionPage.java
+++ b/app/src/main/java/com/coincollection/CollectionPage.java
@@ -213,6 +213,7 @@ public class CollectionPage extends BaseActivity {
         }
 
         // Populate the coin list
+        boolean showUnsavedChanges = false;
         if (mSavedInstanceState == null) {
             boolean populateAdvInfo = (mDisplayType == ADVANCED_DISPLAY);
             mCoinList = mDbAdapter.getCoinList(mCollectionName, populateAdvInfo);
@@ -226,11 +227,13 @@ public class CollectionPage extends BaseActivity {
             }
             mCoinList = mSavedInstanceState.getParcelableArrayList(COIN_LIST);
             // Search through the hasChanged history and see whether we should
-            // re-display the "Unsaved Changes" view
+            // re-display the "Unsaved Changes" view. Defer the actual view update
+            // until after setContentView() has run below, otherwise
+            // findViewById() returns null and showUnsavedTextView() crashes.
             if (mCoinList != null) {
                 for (int i = 0; i < mCoinList.size(); i++) {
                     if (mCoinList.get(i).hasAdvInfoChanged()) {
-                        this.showUnsavedTextView();
+                        showUnsavedChanges = true;
                         break;
                     }
                 }
@@ -339,6 +342,12 @@ public class CollectionPage extends BaseActivity {
                 promptCoinSlotActions(position);
                 return true;
             });
+        }
+
+        // Now that the content view has been set, re-display the "Unsaved
+        // Changes" indicator if the restored state had pending edits.
+        if (showUnsavedChanges) {
+            showUnsavedTextView();
         }
 
         // Setup filter status indicator

--- a/app/src/test/java/com/coincollection/CollectionPageRestoreTests.java
+++ b/app/src/test/java/com/coincollection/CollectionPageRestoreTests.java
@@ -1,0 +1,110 @@
+/*
+ * Coin Collection, an Android app that helps users track the coins that they've collected
+ * Copyright (C) 2010-2016 Andrew Williams
+ *
+ * This file is part of Coin Collection.
+ *
+ * Coin Collection is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Coin Collection is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Coin Collection.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.coincollection;
+
+import static com.spencerpages.SharedTest.COLLECTION_LIST_INFO_SCENARIOS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+import android.content.Intent;
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.core.app.ApplicationProvider;
+
+import com.coincollection.helper.ParcelableHashMap;
+import com.spencerpages.BaseTestCase;
+import com.spencerpages.R;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+
+/**
+ * Regression tests for {@link CollectionPage}'s saved-instance-state restore
+ * path. Lives in the {@code com.coincollection} package so it can flag a coin
+ * as having uncommitted advanced-info edits via the package-private
+ * {@link CoinSlot#setAdvInfoChanged(boolean)}.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class CollectionPageRestoreTests extends BaseTestCase {
+
+    /**
+     * Reproduces the crash from issue #405: on a state restore where a coin has
+     * uncommitted advanced-info changes, {@code setupFromDatabase()} used to call
+     * {@code showUnsavedTextView()} before {@code setContentView()} had run, so
+     * {@code findViewById(R.id.unsaved_message_textview)} returned null and
+     * {@code setVisibility()} threw a NullPointerException.
+     * <p>
+     * Before the fix this test crashes during {@link ActivityScenario#recreate()};
+     * after the fix the "Unsaved Changes" indicator is shown correctly.
+     */
+    @Test
+    public void test_showUnsavedTextViewSurvivesStateRestore() {
+        CollectionListInfo info = COLLECTION_LIST_INFO_SCENARIOS[0];
+        String collectionName = info.getName();
+        int coinTypeIdx = info.getCollectionTypeIndex();
+
+        // Create the collection in the database so CollectionPage can load it.
+        // Use the advanced display, since that is the view that tracks uncommitted
+        // advanced-info edits and hosts the "Unsaved Changes" indicator.
+        try (ActivityScenario<CoinPageCreator> creatorScenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), CoinPageCreator.class))) {
+            creatorScenario.onActivity(activity -> {
+                activity.mCoinList = new ArrayList<>();
+                ParcelableHashMap parameters = CoinPageCreator.getParametersFromCollectionListInfo(info);
+                int index = info.getCollectionTypeIndex();
+                activity.setInternalStateFromCollectionIndex(index, activity.getCollectionListPos(index), parameters);
+                activity.createOrUpdateCoinListForAsyncThread();
+                activity.mDbAdapter.createAndPopulateNewTable(info, 0, activity.mCoinList);
+                activity.mDbAdapter.updateTableDisplay(collectionName, CollectionPage.ADVANCED_DISPLAY);
+            });
+        }
+
+        try (ActivityScenario<CollectionPage> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), CollectionPage.class)
+                        .putExtra(CollectionPage.COLLECTION_TYPE_INDEX, coinTypeIdx)
+                        .putExtra(CollectionPage.COLLECTION_NAME, collectionName))) {
+
+            // Simulate an uncommitted advanced-info edit on the first coin. This is
+            // what onSaveInstanceState() persists and what the restore path checks.
+            scenario.onActivity(activity -> {
+                assertFalse("Collection should have coins", activity.mOriginalCoinList.isEmpty());
+                activity.mOriginalCoinList.get(0).setAdvInfoChanged(true);
+            });
+
+            // Recreate the activity: onSaveInstanceState() saves the coin list and
+            // onCreate() re-runs with a non-null savedInstanceState, exercising the
+            // restore path that previously crashed.
+            scenario.recreate();
+
+            scenario.onActivity(activity -> {
+                TextView unsavedView = activity.findViewById(R.id.unsaved_message_textview);
+                assertNotNull("Unsaved-changes view should exist after restore", unsavedView);
+                assertEquals("Unsaved-changes indicator should be shown after restore",
+                        View.VISIBLE, unsavedView.getVisibility());
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fixes #405.

### Problem

On a saved-instance-state restore (e.g. returning to `CollectionPage` after the OS killed the app process — hence the `ActivityRelaunchItem` frames in the crash report), `setupFromDatabase()` called `showUnsavedTextView()` from within the restore loop **before** `setContentView()` had run. At that point no content view was set, so `findViewById(R.id.unsaved_message_textview)` returned `null` and `setVisibility()` threw a `NullPointerException`:

```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method
  'void android.widget.TextView.setVisibility(int)' on a null object reference
  at com.coincollection.CollectionPage.showUnsavedTextView (CollectionPage.java:344)
  at com.coincollection.CollectionPage.onCreate (CollectionPage.java:198)
```

### Fix

Defer the indicator update: the restore loop now sets a local `showUnsavedChanges` flag instead of touching the view, and `showUnsavedTextView()` is invoked after `setContentView()` has set up the layout, so the view is guaranteed to exist.

### Testing

Added `CollectionPageRestoreTests` (in the `com.coincollection` package so it can flag a coin's uncommitted advanced-info edits via the package-private `CoinSlot.setAdvInfoChanged`). The test reproduces the crash through `ActivityScenario.recreate()`:

- **Without the fix:** fails with the exact `NullPointerException` from the issue (`showUnsavedTextView` → `setupFromDatabase` → `onCreate`).
- **With the fix:** passes, and the "Unsaved Changes" indicator is shown correctly after restore.

The existing `CollectionPageActivityTests` suite continues to pass.
