### PR TITLE
ci: source release notes from checked-in fastlane changelogs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,10 +32,6 @@ on:
         required: false
         type: string
         default: ''
-      releaseNotes:
-        description: 'Release notes for the app store listings. Can match or differ from the GitHub Release notes.'
-        required: true
-        type: string
 
 jobs:
   download_and_deploy:
@@ -175,36 +171,28 @@ jobs:
 
       - name: Deploy to Google Play (Testers)
         if: (github.event.inputs.stores == 'android' || github.event.inputs.stores == 'both') && github.event.inputs.play_track != 'production'
-        env:
-          RELEASE_NOTES: ${{ github.event.inputs.releaseNotes }}
         run: |
           bundle exec fastlane deploy_playstore_test \
             apk_path:"${{ github.workspace }}/downloaded_apks/app-android-release-v${{ steps.resolve_version.outputs.version_name }}.apk" \
             version_name:"${{ steps.resolve_version.outputs.version_name }}" \
             version_code:"${{ steps.resolve_version.outputs.version_code }}" \
-            track:"${{ github.event.inputs.play_track }}" \
-            release_notes:"$RELEASE_NOTES"
+            track:"${{ github.event.inputs.play_track }}"
 
       - name: Deploy to Google Play (Production)
         if: (github.event.inputs.stores == 'android' || github.event.inputs.stores == 'both') && github.event.inputs.play_track == 'production'
-        env:
-          RELEASE_NOTES: ${{ github.event.inputs.releaseNotes }}
         run: |
           bundle exec fastlane deploy_playstore_production \
             apk_path:"${{ github.workspace }}/downloaded_apks/app-android-release-v${{ steps.resolve_version.outputs.version_name }}.apk" \
             version_name:"${{ steps.resolve_version.outputs.version_name }}" \
-            version_code:"${{ steps.resolve_version.outputs.version_code }}" \
-            release_notes:"$RELEASE_NOTES"
+            version_code:"${{ steps.resolve_version.outputs.version_code }}"
 
       - name: Deploy to Amazon Appstore
         if: github.event.inputs.stores == 'amazon' || github.event.inputs.stores == 'both'
         env:
           AMAZON_CLIENT_ID: ${{ secrets.AMAZON_CLIENT_ID }}
           AMAZON_CLIENT_SECRET: ${{ secrets.AMAZON_CLIENT_SECRET }}
-          RELEASE_NOTES: ${{ github.event.inputs.releaseNotes }}
         run: |
           bundle exec fastlane deploy_amazon_appstore \
             apk_path:"${{ github.workspace }}/downloaded_apks/app-amazon-release-v${{ steps.resolve_version.outputs.version_name }}.apk" \
             version_name:"${{ steps.resolve_version.outputs.version_name }}" \
-            version_code:"${{ steps.resolve_version.outputs.version_code }}" \
-            release_notes:"$RELEASE_NOTES"
+            version_code:"${{ steps.resolve_version.outputs.version_code }}"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -7,10 +7,6 @@ on:
         description: 'Pre-release tag to promote (e.g. v3.7.4-rc.1).'
         required: true
         type: string
-      releaseNotes:
-        description: "What's-new text for Google Play production and the Amazon Appstore."
-        required: true
-        type: string
 
 jobs:
   promote:
@@ -58,6 +54,28 @@ jobs:
           echo "commit_sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
           echo "version_code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
           echo "Commit: $COMMIT_SHA versionCode: $VERSION_CODE"
+
+      - name: Verify checked-in release notes exist
+        # Production/Amazon "what's new" text comes from the release notes checked
+        # into the repo at fastlane/metadata/android/en-US/changelogs/<versionCode>.txt
+        # (as of the RC tag commit checked out above). No pre-release notice is
+        # prepended for the production release.
+        run: |
+          set -euo pipefail
+          VC="${{ steps.resolve.outputs.version_code }}"
+          NOTES_FILE="fastlane/metadata/android/en-US/changelogs/${VC}.txt"
+          if [ ! -s "$NOTES_FILE" ]; then
+            echo "::error::Release notes file $NOTES_FILE is missing or empty at ${{ steps.parse.outputs.rc_tag }}. Add it (checked in) before promoting."
+            exit 1
+          fi
+          echo "Using release notes from $NOTES_FILE:"
+          echo "----------------------------------------"
+          cat "$NOTES_FILE"
+          echo "----------------------------------------"
+          CHARS=$(wc -m < "$NOTES_FILE" | tr -d ' ')
+          if [ "$CHARS" -gt 500 ]; then
+            echo "::warning::Release notes are ${CHARS} characters; Google Play truncates 'what's new' at 500."
+          fi
 
       - name: Verify pre-release exists and final release does not
         env:
@@ -147,27 +165,24 @@ jobs:
           }
 
       - name: Deploy to Google Play (Production)
-        env:
-          RELEASE_NOTES: ${{ github.event.inputs.releaseNotes }}
         run: |
           VERSION_NAME="${{ steps.parse.outputs.version_name }}"
           # Promote the release already uploaded to the internal track by the
           # pre-release workflow (keyed off versionCode) — Google Play forbids
           # re-uploading an already-published APK, so no apk_path is passed.
+          # Release notes come from the checked-in changelog file for this
+          # versionCode.
           bundle exec fastlane deploy_playstore_production \
             version_name:"${VERSION_NAME}" \
-            version_code:"${{ steps.resolve.outputs.version_code }}" \
-            release_notes:"$RELEASE_NOTES"
+            version_code:"${{ steps.resolve.outputs.version_code }}"
 
       - name: Deploy to Amazon Appstore
         env:
           AMAZON_CLIENT_ID: ${{ secrets.AMAZON_CLIENT_ID }}
           AMAZON_CLIENT_SECRET: ${{ secrets.AMAZON_CLIENT_SECRET }}
-          RELEASE_NOTES: ${{ github.event.inputs.releaseNotes }}
         run: |
           VERSION_NAME="${{ steps.parse.outputs.version_name }}"
           bundle exec fastlane deploy_amazon_appstore \
             apk_path:"${{ github.workspace }}/downloaded_apks/app-amazon-release-v${VERSION_NAME}.apk" \
             version_name:"${VERSION_NAME}" \
-            version_code:"${{ steps.resolve.outputs.version_code }}" \
-            release_notes:"$RELEASE_NOTES"
+            version_code:"${{ steps.resolve.outputs.version_code }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,6 @@ on:
         required: true
         type: string
         default: '1'
-      releaseNotes:
-        description: "What's-new text for the Google Play internal testing track."
-        required: true
-        type: string
 
 jobs:
   build_and_prerelease:
@@ -46,6 +42,32 @@ jobs:
           echo "Extracted versionCode: $VERSION_CODE"
           echo "manifest_version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
           echo "manifest_version_code=$VERSION_CODE" >> $GITHUB_OUTPUT
+
+      - name: Verify checked-in release notes exist
+        # Release notes are checked into the repo at
+        # fastlane/metadata/android/en-US/changelogs/<versionCode>.txt (supply and
+        # the Amazon plugin read them from there). Fail fast with a clear message
+        # if the operator forgot to add/update them for this versionCode.
+        id: release_notes
+        run: |
+          set -euo pipefail
+          VC="${{ steps.extract_versions.outputs.manifest_version_code }}"
+          NOTES_FILE="fastlane/metadata/android/en-US/changelogs/${VC}.txt"
+          if [ ! -s "$NOTES_FILE" ]; then
+            echo "::error::Release notes file $NOTES_FILE is missing or empty. Add it (checked in) before running this workflow."
+            exit 1
+          fi
+          echo "Using release notes from $NOTES_FILE:"
+          echo "----------------------------------------"
+          cat "$NOTES_FILE"
+          echo "----------------------------------------"
+          # Google Play limits each language's "what's new" to 500 characters.
+          # The pre-release notice is prepended at deploy time, so warn early if
+          # the base notes are already close to the limit.
+          CHARS=$(wc -m < "$NOTES_FILE" | tr -d ' ')
+          if [ "$CHARS" -gt 500 ]; then
+            echo "::warning::Release notes are ${CHARS} characters; Google Play truncates 'what's new' at 500. The prepended pre-release notice may push it further over."
+          fi
 
       - name: Compose RC tag and check tags do not exist
         id: check_tag
@@ -174,15 +196,20 @@ jobs:
 
       - name: Deploy to Google Play (internal testing)
         env:
-          RELEASE_NOTES: ${{ github.event.inputs.releaseNotes }}
+          RC_TAG: ${{ steps.check_tag.outputs.rc_tag }}
         run: |
           MVN="${{ steps.extract_versions.outputs.manifest_version_name }}"
+          # Prepend a pre-release notice to the checked-in release notes so
+          # internal testers can tell this is a release candidate, not the final
+          # build. The Fastfile prepends this to the ephemeral CI copy of
+          # <versionCode>.txt before uploading (never committed).
+          PRERELEASE_NOTICE="[PRE-RELEASE ${RC_TAG} - internal testing build, not the final release]"
           bundle exec fastlane deploy_playstore_test \
             apk_path:"${{ github.workspace }}/app/build/outputs/apk/android/release/app-android-release-v${MVN}.apk" \
             version_name:"${MVN}" \
             version_code:"${{ steps.extract_versions.outputs.manifest_version_code }}" \
             track:"internal" \
-            release_notes:"$RELEASE_NOTES"
+            prerelease_notice:"$PRERELEASE_NOTICE"
 
       - name: Create GitHub Pre-release
         uses: softprops/action-gh-release@v3

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -78,23 +78,35 @@ The pipeline has two operator-driven stages.
    value is already well into the dozens — just `+1` from whatever's on
    `main` (and confirm it exceeds the latest Play / Amazon production
    versionCode).
-2. Merge the version bump to `main`.
-3. In GitHub, go to **Actions → Build and Publish Pre-release → Run
+2. Write the release notes for this version and **check them in** at
+   [`fastlane/metadata/android/en-US/changelogs/<versionCode>.txt`](fastlane/metadata/android/en-US/changelogs)
+   (the file name must match the new `versionCode`). This single file is the
+   source of "what's new" text for internal testing, Google Play production,
+   and the Amazon Appstore — so newlines and bullet points are supported and
+   render identically everywhere. Keep it under **500 characters** (Google
+   Play truncates longer text). The pre-release workflow automatically
+   prepends a short `[PRE-RELEASE …]` notice to these notes for the internal
+   track only, so you can preview exactly how the notes will read before
+   promoting.
+3. Merge the version bump **and** the release-notes file to `main`.
+4. In GitHub, go to **Actions → Build and Publish Pre-release → Run
    workflow** and fill in the inputs:
    - `rc_number`: the release-candidate number for this attempt (`1` the
      first time; bump to `2`, `3`, … if you need another pre-release of the
      same version). This produces the tag `vX.Y.Z-rc.N`.
-   - `releaseNotes`: the "what's new" text shown to Play internal testers.
-4. The workflow:
+5. The workflow:
    - Refuses to run if the final tag `vX.Y.Z` **or** the chosen
      `vX.Y.Z-rc.N` tag already exists.
+   - Fails fast if the checked-in
+     `changelogs/<versionCode>.txt` release-notes file is missing or empty.
    - Builds `:app:assembleAndroidRelease` and `:app:assembleAmazonRelease`.
    - Verifies the APKs are signed with the release key (fails on
      debug-signed APKs).
    - Creates a GitHub **pre-release** tagged `vX.Y.Z-rc.N` with both APKs
      attached.
-   - Uploads the `android` APK to the Google Play **internal** track.
-5. F-Droid does **not** build at this stage: the `vX.Y.Z-rc.N` tag is
+   - Uploads the `android` APK to the Google Play **internal** track, with a
+     `[PRE-RELEASE vX.Y.Z-rc.N …]` notice prepended to the checked-in notes.
+6. F-Droid does **not** build at this stage: the `vX.Y.Z-rc.N` tag is
    excluded by the `fdroiddata` `UpdateCheckMode` regex
    (`Tags ^v[0-9.]+$`), and the bare `vX.Y.Z` tag does not exist yet.
    Amazon and Play production are untouched.
@@ -102,7 +114,9 @@ The pipeline has two operator-driven stages.
 ### 1.2 Verify on the internal track
 
 1. Open Google Play Console → **Testing → Internal testing**. Confirm
-   a new release exists with the expected `versionCode`.
+   a new release exists with the expected `versionCode`. The "what's new"
+   text shows the `[PRE-RELEASE …]` notice followed by the checked-in
+   release notes — a live preview of how production will read.
 2. On a test device opted into the internal-test program, install the build
    from the Play Store and exercise the changed flows.
 3. Watch the Play Console pre-launch report for crashes / policy issues
@@ -119,10 +133,12 @@ Once internal testing is green:
 1. **Actions → Promote Pre-release to Release → Run workflow**.
 2. Inputs:
    - `rc_tag`: the pre-release tag you verified, e.g. `v3.8.1-rc.1`.
-   - `releaseNotes`: production "what's new" text for Google Play and Amazon.
-     May match or differ from the internal notes.
 3. The workflow:
    - Verifies the pre-release exists and the final `vX.Y.Z` release does not.
+   - Reads the production "what's new" text from the checked-in
+     `changelogs/<versionCode>.txt` file (as of the RC tag commit) — the same
+     notes internal testers saw, minus the `[PRE-RELEASE …]` prefix — and
+     fails fast if that file is missing or empty.
    - Downloads the exact APKs from the pre-release (no rebuild — guaranteeing
      production gets the same bytes internal testers verified).
    - Creates the final GitHub Release tagged `vX.Y.Z`, pointing at the same
@@ -147,22 +163,34 @@ Defined in [`fastlane/Fastfile`](fastlane/Fastfile). Each workflow passes a
 pre-built APK to the relevant lane via `apk_path` — the pre-release workflow
 builds it fresh, the promote workflow downloads it from the pre-release.
 
+Release notes ("what's new" text) are **checked into the repo** at
+[`fastlane/metadata/android/en-US/changelogs/<versionCode>.txt`](fastlane/metadata/android/en-US/changelogs)
+— the standard path `supply` and the Amazon plugin read from. The lanes upload
+whatever is in that file for the target `versionCode`; multi-line notes are
+supported. An optional inline `release_notes:` string can still be passed to
+overwrite the file (legacy override), but the normal flow relies on the
+checked-in file.
+
 - `deploy_playstore_test`
   - Uploads to a Google Play tester track (`alpha`, `beta`, or `internal`).
     The pre-release workflow always uses `internal`.
-  - Inputs: `apk_path`, `track`, `release_notes`, optional
-    `version_name`, `version_code`.
+  - Inputs: `apk_path`, `track`, `version_code`, optional `version_name`,
+    `prerelease_notice`, `release_notes`. The pre-release workflow passes
+    `prerelease_notice`, which is prepended to the checked-in changelog for the
+    internal track (ephemeral CI copy only — never committed).
 - `deploy_playstore_production`
   - Uploads to the Google Play production track. Used by the promote workflow.
-  - Inputs: `apk_path`, `release_notes`.
+  - Inputs: `version_code` (promote mode), optional `apk_path` (upload mode),
+    `release_notes`. Release notes come from the checked-in
+    `changelogs/<versionCode>.txt` file.
 - `deploy_amazon_appstore`
   - Uploads to the Amazon Appstore via `fastlane-plugin-amazon_appstore`.
     Used by the promote workflow.
-  - Inputs: `apk_path`, `release_notes`, `version_code`. The promote workflow
-    passes the real `version_code` (read from the manifest at the RC tag),
-    so the Amazon changelog file is written from `release_notes`. A
+  - Inputs: `apk_path`, `version_code`, optional `release_notes`. The promote
+    workflow passes the real `version_code` (read from the manifest at the RC
+    tag), so the Amazon changelog is read from `changelogs/<versionCode>.txt`. A
     `version_code` of `0` (the sentinel used by the optional `deploy.yml`
-    fallback) skips the changelog rewrite and reuses existing metadata.
+    fallback) skips the file lookup and reuses existing metadata.
 
 ---
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,21 +28,68 @@ def android_metadata_path
   File.expand_path("metadata/android", __dir__)
 end
 
-# Write the "what's new" changelog file for the given versionCode and return
-# true when a file was actually written. supply (and the Amazon plugin) read
-# release notes from <metadata_path>/en-US/changelogs/<versionCode>.txt.
-# Writes nothing and returns false when the notes are blank or version_code <= 0
-# (0 is the deploy.yml sentinel meaning "don't trust the manifest versionCode").
-def write_changelog_file(version_code, release_notes)
+# Absolute path to the checked-in "what's new" changelog file for the given
+# versionCode. supply (and the Amazon plugin) read release notes from
+# <metadata_path>/en-US/changelogs/<versionCode>.txt. Returns nil when
+# version_code <= 0 (0 is the deploy.yml sentinel meaning "don't trust the
+# manifest versionCode").
+def changelog_file_path(version_code)
   vc = version_code.to_i
-  return false if release_notes.nil? || release_notes.to_s.strip.empty? || vc <= 0
+  return nil if vc <= 0
+  File.join(android_metadata_path, "en-US", "changelogs", "#{vc}.txt")
+end
 
-  changelog_dir = File.join(android_metadata_path, "en-US", "changelogs")
-  FileUtils.mkdir_p(changelog_dir)
-  changelog_path = File.join(changelog_dir, "#{vc}.txt")
+# True when a non-empty checked-in changelog file exists for the versionCode.
+def changelog_file_exists?(version_code)
+  path = changelog_file_path(version_code)
+  !path.nil? && File.exist?(path) && !File.read(path).strip.empty?
+end
+
+# Write the "what's new" changelog file for the given versionCode and return
+# true when a file was actually written. Release notes are normally checked into
+# the repo at <metadata_path>/en-US/changelogs/<versionCode>.txt; this helper is
+# only used to (over)write that file from an inline string when one is passed
+# explicitly (legacy override). Writes nothing and returns false when the notes
+# are blank or version_code <= 0.
+def write_changelog_file(version_code, release_notes)
+  return false if release_notes.nil? || release_notes.to_s.strip.empty?
+  changelog_path = changelog_file_path(version_code)
+  return false if changelog_path.nil?
+
+  FileUtils.mkdir_p(File.dirname(changelog_path))
   File.write(changelog_path, release_notes)
-  UI.message("Wrote release notes to #{changelog_path} for version code #{vc}")
+  UI.message("Wrote release notes to #{changelog_path} for version code #{version_code.to_i}")
   true
+end
+
+# Prepend a pre-release notice to the checked-in changelog file for the given
+# versionCode so internal testers can see it's a release candidate. Modifies the
+# ephemeral CI checkout only (never committed). Returns true when the notice was
+# prepended. Does nothing when the notice is blank, the versionCode is invalid,
+# or no changelog file exists.
+def prepend_prerelease_notice(version_code, notice)
+  return false if notice.nil? || notice.to_s.strip.empty?
+  path = changelog_file_path(version_code)
+  return false if path.nil? || !File.exist?(path)
+
+  existing = File.read(path)
+  File.write(path, "#{notice.to_s.strip}\n\n#{existing}")
+  UI.message("Prepended pre-release notice to #{path} for version code #{version_code.to_i}")
+  true
+end
+
+# Prepare the "what's new" changelog for upload. Precedence:
+#   1. If options[:release_notes] is provided, (over)write the checked-in
+#      changelog file from it (legacy inline override).
+#   2. Otherwise the checked-in changelog file for the versionCode is used as-is.
+#   3. If options[:prerelease_notice] is provided, prepend it to the changelog
+#      (pre-release / internal-track builds only).
+# Returns true when a changelog file exists for the versionCode (so supply
+# should upload it), false otherwise.
+def prepare_changelog(options)
+  write_changelog_file(options[:version_code], options[:release_notes])
+  prepend_prerelease_notice(options[:version_code], options[:prerelease_notice])
+  changelog_file_exists?(options[:version_code])
 end
 
 platform :android do
@@ -103,9 +150,11 @@ platform :android do
       }
 
       # supply has no inline "changelogs" option; the "what's new" text is read
-      # from a versionCode-named file under the metadata path. Enable changelog
-      # upload only when a changelog file was actually written.
-      supply_params[:skip_upload_changelogs] = false if write_changelog_file(options[:version_code], options[:release_notes])
+      # from the checked-in versionCode-named file under the metadata path.
+      # Enable changelog upload only when a changelog file exists for this
+      # versionCode. For pre-release/internal builds, options[:prerelease_notice]
+      # is prepended to the checked-in notes (ephemeral CI checkout only).
+      supply_params[:skip_upload_changelogs] = false if prepare_changelog(options)
 
       supply(supply_params)
       UI.success("Successfully deployed to Google Play Store (#{track} track)!")
@@ -165,10 +214,11 @@ platform :android do
         supply_params[:skip_upload_aab] = true
       end
 
-      # supply has no inline "changelogs" option; write the "what's new" text to
-      # a versionCode-named file and enable changelog upload only when one was
-      # actually written.
-      supply_params[:skip_upload_changelogs] = false if write_changelog_file(options[:version_code], options[:release_notes])
+      # supply has no inline "changelogs" option; the "what's new" text is read
+      # from the checked-in versionCode-named file under the metadata path.
+      # Enable changelog upload only when a changelog file exists for this
+      # versionCode.
+      supply_params[:skip_upload_changelogs] = false if prepare_changelog(options)
 
       supply(supply_params)
       UI.success("Successfully released to Google Play Store (Production Track)!")
@@ -186,12 +236,13 @@ platform :android do
 
       # Gradle build steps are removed. APK is provided via options[:apk_path].
 
-      # Handle changelogs by writing to file. The deploy workflow passes
-      # version_code="0" as a sentinel when the operator supplied an explicit
-      # release_tag (in which case the workflow can't trust main's manifest).
-      # write_changelog_file skips the file in that case rather than writing "0.txt".
-      unless write_changelog_file(options[:version_code], options[:release_notes])
-        UI.important("No release notes or valid version code provided for Amazon changelog generation; relying on existing changelog files (if any).")
+      # The "what's new" text is read from the checked-in versionCode-named file
+      # under the metadata path. The deploy workflow passes version_code="0" as a
+      # sentinel when the operator supplied an explicit release_tag (in which case
+      # the workflow can't trust main's manifest); prepare_changelog skips the
+      # file lookup in that case and the plugin relies on existing files (if any).
+      unless prepare_changelog(options)
+        UI.important("No checked-in changelog file for this version code; relying on existing changelog files (if any).")
       end
 
       # Check to ensure ENV variables are set

--- a/fastlane/metadata/android/en-US/changelogs/40.txt
+++ b/fastlane/metadata/android/en-US/changelogs/40.txt
@@ -1,0 +1,5 @@
+Bug fixes and stability improvements:
+- Fixed crashes reported in the 3.8.2 release
+- Adding 2026 semi-q coins plus a few app improvements
+- Special thanks to Hruday Rudraraju for adding search support.
+- Find us on GitHub for feature requests, feedback, and to contribute to the project!


### PR DESCRIPTION
## Description

Migrates the release pipeline off the `workflow_dispatch` `releaseNotes` text box. Release notes are now **checked into the repo** at `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt` — the standard path `supply` and the Amazon plugin already read from. This supports newlines/bullets, lets the notes be code-reviewed, and lets us preview exactly how they render on the Play internal track before promoting.

### What changed

- **Workflows** (`release.yml`, `promote.yml`, `deploy.yml`): removed the `releaseNotes` input; notes are read from the checked-in changelog file for the target `versionCode`.
  - `release.yml` and `promote.yml` add a "Verify checked-in release notes exist" step that **fails fast** if the file is missing/empty, plus a warning when notes exceed Google Play's 500-char limit.
  - `release.yml` (pre-release) prepends a `[PRE-RELEASE <rc_tag> - internal testing build...]` notice to the **ephemeral CI copy** of the changelog for the internal track only. It's never committed, so `promote.yml` ships the clean checked-in notes to production/Amazon.
- **Fastfile**: new helpers `changelog_file_path`, `changelog_file_exists?`, `prepend_prerelease_notice`, `prepare_changelog`. Each deploy lane uploads the checked-in file and enables changelog upload only when one exists. The inline `release_notes:` override is still supported for manual runs.
- **Docs**: `DEPLOYMENT.md` updated to describe the checked-in workflow and the pre-release preview behavior.
- Added an example `changelogs/40.txt` (v3.8.3).

### How the release flow changes for operators

Before running the pre-release workflow, add/update `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt` and merge it to `main` (alongside the version bump). No more pasting release notes into a text box.

### Validation

- `ruby -c fastlane/Fastfile` → Syntax OK
- No lingering `releaseNotes` / `release_notes` references in workflows
- `markdownlint-cli2 DEPLOYMENT.md` → 0 issues
