### PR TITLE
Bump version to 3.8.4 (versionCode 41)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:versionCode="40"
-    android:versionName="3.8.3">
+    android:versionCode="41"
+    android:versionName="3.8.4">
 
     <!-- Reorder view, long press menu, and menu options require a touchscreen -->
     <uses-feature android:name="android.hardware.touchscreen"

--- a/fastlane/metadata/android/en-US/changelogs/41.txt
+++ b/fastlane/metadata/android/en-US/changelogs/41.txt
@@ -1,0 +1,5 @@
+Bug fixes and stability improvements:
+- Fixed crashes reported in the 3.8.2 release
+- Adding 2026 semi-q coins plus a few app improvements
+- Special thanks to Hruday Rudraraju for adding search support.
+- Find us on GitHub for feature requests, feedback, and to contribute to the project!


### PR DESCRIPTION
## Description

Bumps the app version to 3.8.4 (versionCode 41) to prepare for the pre-release and promotion flow.

- `AndroidManifest.xml`: `versionCode` 40 → 41, `versionName` 3.8.3 → 3.8.4
- Added `fastlane/metadata/android/en-US/changelogs/41.txt` (identical release note to v40)
