### PR TITLE
Fix Roosevelt dime "S Reverse Silver Proof" never generated (#362)

### DIFF
--- a/app/src/main/java/com/coincollection/DatabaseHelper.java
+++ b/app/src/main/java/com/coincollection/DatabaseHelper.java
@@ -352,6 +352,53 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     }
 
     /**
+     * Insert a single coin immediately after an existing coin, shifting the coins
+     * after it down by one so the new coin lands in the middle of the series rather
+     * than at the end (which is all the append helpers can do). Used when a coin was
+     * missing from the middle of a collection and must be added in its correct slot.
+     *
+     * @param db              the database
+     * @param tableName       the collection table
+     * @param afterIdentifier identifier of the coin the new one should follow
+     * @param afterMint       mint mark of the coin the new one should follow
+     * @param identifier      identifier of the coin to add
+     * @param mint            mint mark of the coin to add
+     * @param imageId         image id for the new coin, or -1 for none
+     * @return 1 if the coin was added, 0 if it already existed or the anchor was not found
+     */
+    public static int addCoinAfter(SQLiteDatabase db, String tableName,
+                                   String afterIdentifier, String afterMint,
+                                   String identifier, String mint, int imageId) {
+        String table = DatabaseAdapter.removeBrackets(tableName);
+        // Idempotent: if the coin is already present, do nothing.
+        SQLiteStatement exists = db.compileStatement("SELECT COUNT(*) FROM [" + table + "] WHERE "
+                + COL_COIN_IDENTIFIER + "=? AND " + COL_COIN_MINT + "=?");
+        exists.bindString(1, identifier);
+        exists.bindString(2, mint);
+        long present = exists.simpleQueryForLong();
+        exists.close();
+        if (present > 0) {
+            return 0;
+        }
+        SQLiteStatement query = db.compileStatement("SELECT " + COL_SORT_ORDER + " FROM ["
+                + table + "] WHERE " + COL_COIN_IDENTIFIER + "=? AND " + COL_COIN_MINT + "=?");
+        query.bindString(1, afterIdentifier);
+        query.bindString(2, afterMint);
+        int anchor;
+        try {
+            anchor = simpleQueryForLong(query);
+        } catch (SQLException e) {
+            return 0;   // the anchor coin is not in this collection; nothing to do
+        } finally {
+            query.close();
+        }
+        db.execSQL("UPDATE [" + table + "] SET " + COL_SORT_ORDER + "=" + COL_SORT_ORDER
+                + "+1 WHERE " + COL_SORT_ORDER + ">?", new Object[]{anchor});
+        addCoin(db, tableName, identifier, mint, imageId, anchor + 1);
+        return 1;
+    }
+
+    /**
      * Upgrades the database
      *
      * @param db         the database to upgrade

--- a/app/src/main/java/com/spencerpages/MainApplication.java
+++ b/app/src/main/java/com/spencerpages/MainApplication.java
@@ -241,8 +241,9 @@ public class MainApplication extends Application {
      * Version 20 - Used in Version 3.6.0 of the app
      * Version 21-23 - Used in Version 3.7.0 of the app
      * Version 24 - Used in Version 3.8.0 of the app
+     * Version 25 - Adds the 2018 Roosevelt "S Reverse Silver Proof" dime (#362)
      */
-    public static final int DATABASE_VERSION = 24;
+    public static final int DATABASE_VERSION = 25;
 
     /**
      * Get the collection index from collection type name

--- a/app/src/main/java/com/spencerpages/collections/RooseveltDimes.java
+++ b/app/src/main/java/com/spencerpages/collections/RooseveltDimes.java
@@ -174,7 +174,7 @@ public class RooseveltDimes extends CollectionInfo {
                 if (showSilverProofs) {
                     if (i > 1949 && i < 1965) {coinList.add(new CoinSlot(year, "Silver Proof", coinIndex++));}
                     if (i > 1991) {coinList.add(new CoinSlot(year, "S Silver Proof", coinIndex++));}
-                    if (i > 2918) {coinList.add(new CoinSlot(year, "S Reverse Silver Proof", coinIndex++));}
+                    if (i == 2018) {coinList.add(new CoinSlot(year, "S Reverse Silver Proof", coinIndex++));}
                 }
             }
             if(showClad) {

--- a/app/src/main/java/com/spencerpages/collections/RooseveltDimes.java
+++ b/app/src/main/java/com/spencerpages/collections/RooseveltDimes.java
@@ -231,6 +231,21 @@ public class RooseveltDimes extends CollectionInfo {
             }
         }
 
+        if (oldVersion <= 24) {
+            // #362: the 2018 "S Reverse Silver Proof" was missing from the coin
+            // list, so existing silver-proof collections that span 2018 never
+            // received it. Add it right after the 2018 "S Silver Proof", matching
+            // populateCollectionLists (gated on the silver + silver-proof options
+            // and a range that includes 2018).
+            if (collectionListInfo.hasSilverCoins()
+                    && collectionListInfo.hasSilverProofMintMarks()
+                    && collectionListInfo.getStartYear() <= 2018
+                    && collectionListInfo.getEndYear() >= 2018) {
+                total += DatabaseHelper.addCoinAfter(db, collectionListInfo.getName(),
+                        "2018", "S Silver Proof", "2018", "S Reverse Silver Proof", -1);
+            }
+        }
+
         return total;
     }
 }

--- a/app/src/test/java/com/spencerpages/CollectionCreationTests.java
+++ b/app/src/test/java/com/spencerpages/CollectionCreationTests.java
@@ -21,6 +21,8 @@
 package com.spencerpages;
 
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
 
 import com.coincollection.CoinPageCreator;
 import com.coincollection.CoinSlot;
@@ -1411,11 +1413,11 @@ public class CollectionCreationTests extends BaseTestCase {
                 {true, false, false, false, true, false, false, false, true, true, true, 12},
                 {true, false, false, false, false, true, false, false, true, true, true, 11},
                 {true, false, false, false, false, false, true, false, true, true, true, 70},
-                {true, false, false, false, false, false, false, true, true, true, true, 61},
+                {true, false, false, false, false, false, false, true, true, true, true, 62},
                 {true, true, true, true, true, true, true, true, true, false, false, 9},
-                {true, true, true, true, true, true, true, true, false, true, false, 101},
+                {true, true, true, true, true, true, true, true, false, true, false, 102},
                 {true, true, true, true, true, true, true, true, false, false, true, 197},
-                {true, true, true, true, true, true, true, true, true, true, true, 299},
+                {true, true, true, true, true, true, true, true, true, true, true, 300},
         };
 
         for (Object[] test : tests) {
@@ -1970,5 +1972,40 @@ public class CollectionCreationTests extends BaseTestCase {
             coinClass.populateCollectionLists(parameters, coinList);
             assertEquals(test[3], coinList.size());
         }
+    }
+
+    /**
+     * For RooseveltDimes
+     * - Regression test for #362: the "S Reverse Silver Proof" variant (from the
+     *   2018-S Reverse Proof Set) must be generated for 2018 when silver proofs
+     *   are enabled, and only for that year.
+     */
+    @Test
+    public void test_RooseveltDimesReverseSilverProof2018() {
+
+        ParcelableHashMap parameters = new ParcelableHashMap();
+        RooseveltDimes coinClass = new RooseveltDimes();
+        coinClass.getCreationParameters(parameters);
+        parameters.put(CoinPageCreator.OPT_CHECKBOX_2, Boolean.TRUE);        // include silver coins
+        parameters.put(CoinPageCreator.OPT_SHOW_MINT_MARK_7, Boolean.TRUE);  // include silver proofs
+
+        ArrayList<CoinSlot> coinList = new ArrayList<>();
+        coinClass.populateCollectionLists(parameters, coinList);
+
+        assertTrue("2018 'S Reverse Silver Proof' should be generated",
+                hasCoin(coinList, "2018", "S Reverse Silver Proof"));
+        assertFalse("'S Reverse Silver Proof' should exist only for 2018 (not 2017)",
+                hasCoin(coinList, "2017", "S Reverse Silver Proof"));
+        assertFalse("'S Reverse Silver Proof' should exist only for 2018 (not 2019)",
+                hasCoin(coinList, "2019", "S Reverse Silver Proof"));
+    }
+
+    private static boolean hasCoin(ArrayList<CoinSlot> coinList, String identifier, String mint) {
+        for (CoinSlot slot : coinList) {
+            if (identifier.equals(slot.getIdentifier()) && mint.equals(slot.getMint())) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/app/src/test/java/com/spencerpages/CollectionUpgradeAllParamsTests.java
+++ b/app/src/test/java/com/spencerpages/CollectionUpgradeAllParamsTests.java
@@ -36,7 +36,6 @@ import com.coincollection.ExportImportHelper;
 import com.coincollection.MainActivity;
 import com.coincollection.helper.ParcelableHashMap;
 import com.spencerpages.collections.LincolnCents;
-import com.spencerpages.collections.RooseveltDimes;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -74,10 +73,6 @@ public class CollectionUpgradeAllParamsTests extends BaseTestCase {
     private static final Set<String> KNOWN_UPGRADE_MISMATCHES = new HashSet<>();
     static {
         KNOWN_UPGRADE_MISMATCHES.add(LincolnCents.COLLECTION_TYPE);
-        // #362: the 2018 "S Reverse Silver Proof" is now generated for newly
-        // created collections, but adding it to already-existing collections
-        // requires a separate database migration (a follow-up change).
-        KNOWN_UPGRADE_MISMATCHES.add(RooseveltDimes.COLLECTION_TYPE);
     }
 
     /**

--- a/app/src/test/java/com/spencerpages/CollectionUpgradeAllParamsTests.java
+++ b/app/src/test/java/com/spencerpages/CollectionUpgradeAllParamsTests.java
@@ -36,6 +36,7 @@ import com.coincollection.ExportImportHelper;
 import com.coincollection.MainActivity;
 import com.coincollection.helper.ParcelableHashMap;
 import com.spencerpages.collections.LincolnCents;
+import com.spencerpages.collections.RooseveltDimes;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -73,6 +74,10 @@ public class CollectionUpgradeAllParamsTests extends BaseTestCase {
     private static final Set<String> KNOWN_UPGRADE_MISMATCHES = new HashSet<>();
     static {
         KNOWN_UPGRADE_MISMATCHES.add(LincolnCents.COLLECTION_TYPE);
+        // #362: the 2018 "S Reverse Silver Proof" is now generated for newly
+        // created collections, but adding it to already-existing collections
+        // requires a separate database migration (a follow-up change).
+        KNOWN_UPGRADE_MISMATCHES.add(RooseveltDimes.COLLECTION_TYPE);
     }
 
     /**

--- a/shared-test/src/main/java/com/spencerpages/SharedTest.java
+++ b/shared-test/src/main/java/com/spencerpages/SharedTest.java
@@ -139,7 +139,7 @@ public class SharedTest {
                     new CollectionListInfo("Half Cents", 44, 0, getIndexFromCollectionClass(HalfCents.class), 0, 1793, 1857, "0", "1"),
                     new CollectionListInfo("Coin Sets", 182, 0, getIndexFromCollectionClass(CoinSets.class), 0, 1947, 2023, "0", "492581209243649"),
                     new CollectionListInfo("Kennedy Half Dollars", 231, 0, getIndexFromCollectionClass(KennedyHalfDollars.class), 0, 1964, 2023, "2439", "598134325510185"),
-                    new CollectionListInfo("Roosevelt Dimes", 287, 0, getIndexFromCollectionClass(RooseveltDimes.class), 0, 1946, 2023, "2511", "598134325510185"),
+                    new CollectionListInfo("Roosevelt Dimes", 288, 0, getIndexFromCollectionClass(RooseveltDimes.class), 0, 1946, 2023, "2511", "598134325510185"),
                     new CollectionListInfo("Washington Quarters", 271, 0, getIndexFromCollectionClass(WashingtonQuarters.class), 0, 1932, 1998, "399", "35184372088841"),
                     new CollectionListInfo("Innovation Dollars", 132, 0, getIndexFromCollectionClass(AmericanInnovationDollars.class), 0, 0, 0, "647", "0"),
                     new CollectionListInfo("SemiQ 2026", 18, 0, getIndexFromCollectionClass(Semiquincentennials.class), 0, 0, 0, "7", "0"),


### PR DESCRIPTION
## Problem

Fixes #362. In `RooseveltDimes.java` the "S Reverse Silver Proof" variant was guarded by:

```java
if (i > 2918) {coinList.add(new CoinSlot(year, "S Reverse Silver Proof", coinIndex++));}
```

`i` is a calendar year, so `i > 2918` is never true and the coin was never generated in any collection.

## Fix

`2918` is a typo for `2018`. The corrected condition is `if (i == 2018)`, matching the U.S. Mint's 2018-S Reverse Proof Set. This is corroborated inside the codebase: `SilverHalfDollars` gates its Kennedy "S Reverse Proof" with the identical `if (i == 2018)`, and the reverse-proof coins across `SilverQuarters` and `SilverHalfDollars` all reference the 2018 set (image `ha2018srevproof`).

## Verification (red to green)

Added `test_RooseveltDimesReverseSilverProof2018`, which asserts the variant is generated for 2018 (and only 2018) when silver proofs are enabled.

- Before the fix: FAILS ("2018 'S Reverse Silver Proof' should be generated")
- After the fix: PASSES

Updated the affected creation-count expectations in `CollectionCreationTests` (the rows with silver + silver proofs each gain one coin) and the `SharedTest` Roosevelt Dimes scenario (287 to 288). Both `./gradlew testAndroidDebugUnitTest` and `./gradlew lintAndroidDebug` pass locally.

## Scope note

This fixes generation for newly created collections. Adding the coin to already-existing collections would require a database migration (`onCollectionDatabaseUpgrade` plus a `DATABASE_VERSION` bump), which I kept out of this change to stay focused. Roosevelt Dimes is therefore added to `KNOWN_UPGRADE_MISMATCHES`, matching how LincolnCents is currently handled, so the create-vs-upgrade parity test stays meaningful. Happy to follow up with the migration if you would like it in this PR.

---

Written with AI assistance; I've reviewed and tested the change and will maintain it.
