### PR TITLE
Fix Philadelphia penny mint marks, including the 2017 "P"

### DIFF
--- a/app/src/main/java/com/coincollection/DatabaseHelper.java
+++ b/app/src/main/java/com/coincollection/DatabaseHelper.java
@@ -1,5 +1,6 @@
 package com.coincollection;
 
+import static com.coincollection.CoinSlot.COIN_SLOT_NAME_MINT_WHERE_CLAUSE;
 import static com.coincollection.CoinSlot.COL_ADV_GRADE_INDEX;
 import static com.coincollection.CoinSlot.COL_ADV_NOTES;
 import static com.coincollection.CoinSlot.COL_ADV_QUANTITY_INDEX;
@@ -44,6 +45,7 @@ import com.spencerpages.collections.AllNickels;
 import com.spencerpages.collections.Cartwheels;
 import com.spencerpages.collections.CladQuarters;
 import com.spencerpages.collections.KennedyHalfDollars;
+import com.spencerpages.collections.LincolnCents;
 import com.spencerpages.collections.NativeAmericanDollars;
 import com.spencerpages.collections.RooseveltDimes;
 import com.spencerpages.collections.SilverDimes;
@@ -327,6 +329,50 @@ public class DatabaseHelper extends SQLiteOpenHelper {
                         ContentValues values = new ContentValues();
                         values.put(COL_SHOW_CHECKBOXES, Long.toString(checkboxFlags));
                         runSqlUpdate(db, TBL_COLLECTION_INFO, values, COL_NAME + "=?", new String[]{name});
+                    }
+                } while (resultCursor.moveToNext());
+            }
+            resultCursor.close();
+        }
+
+        // Fix Philadelphia penny mint marks. Upgrades before V26 added them with a "P"
+        // mint mark (from addFromYear's default mint list) while newly created
+        // collections used "", and the 2017 cent — the only cent the Philadelphia Mint
+        // ever struck with a "P", for its 225th anniversary — never got its mint mark.
+        // Note: No fromImport guard — imported databases have the latest schema but
+        // carry the old mint mark values that also need fixing.
+        if (oldVersion <= 25) {
+            // The year is deliberately a literal rather than a constant: if the mint ever
+            // uses a "P" again, changing a shared constant would silently alter this block.
+            final String pMintMarkYear = "2017";
+
+            Cursor resultCursor = db.query(TBL_COLLECTION_INFO,
+                    new String[]{COL_NAME, COL_COIN_TYPE, COL_SHOW_MINT_MARKS},
+                    null, null, null, null, COL_DISPLAY_ORDER);
+            if (resultCursor.moveToFirst()) {
+                do {
+                    String coinType = resultCursor.getString(resultCursor.getColumnIndexOrThrow(COL_COIN_TYPE));
+                    if (LincolnCents.COLLECTION_TYPE.equals(coinType)) {
+                        String name = resultCursor.getString(resultCursor.getColumnIndexOrThrow(COL_NAME));
+                        String mintMarkStr = resultCursor.getString(resultCursor.getColumnIndexOrThrow(COL_SHOW_MINT_MARKS));
+                        long mintMarkFlags = CollectionListInfo.parseFlagString(mintMarkStr);
+
+                        // Clear the "P" from every year except 2017
+                        ContentValues values = new ContentValues();
+                        values.put(COL_COIN_MINT, "");
+                        runSqlUpdate(db, name, values,
+                                COL_COIN_MINT + "=? AND " + COL_COIN_IDENTIFIER + "!=?",
+                                new String[]{"P", pMintMarkYear});
+
+                        // Give the 2017 cent the "P" it was actually struck with. Collections
+                        // without mint marks correctly use "" for every coin and are skipped.
+                        boolean hasPMintMarks = (mintMarkFlags & CollectionListInfo.SHOW_MINT_MARKS) != 0
+                                && (mintMarkFlags & CollectionListInfo.MINT_P) != 0;
+                        if (hasPMintMarks) {
+                            values.put(COL_COIN_MINT, "P");
+                            runSqlUpdate(db, name, values, COIN_SLOT_NAME_MINT_WHERE_CLAUSE,
+                                    new String[]{pMintMarkYear, ""});
+                        }
                     }
                 } while (resultCursor.moveToNext());
             }

--- a/app/src/main/java/com/coincollection/DatabaseHelper.java
+++ b/app/src/main/java/com/coincollection/DatabaseHelper.java
@@ -340,7 +340,9 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         // collections used "", and the 2017 cent — the only cent the Philadelphia Mint
         // ever struck with a "P", for its 225th anniversary — never got its mint mark.
         // Note: No fromImport guard — imported databases have the latest schema but
-        // carry the old mint mark values that also need fixing.
+        // carry the old mint mark values that also need fixing. Custom coins are skipped
+        // throughout, matching removeDuplicateCoinsByIdentifier: their mint marks are
+        // user-entered and may intentionally differ from the generated slots.
         if (oldVersion <= 25) {
             // The year is deliberately a literal rather than a constant: if the mint ever
             // uses a "P" again, changing a shared constant would silently alter this block.
@@ -357,11 +359,13 @@ public class DatabaseHelper extends SQLiteOpenHelper {
                         String mintMarkStr = resultCursor.getString(resultCursor.getColumnIndexOrThrow(COL_SHOW_MINT_MARKS));
                         long mintMarkFlags = CollectionListInfo.parseFlagString(mintMarkStr);
 
-                        // Clear the "P" from every year except 2017
+                        // Clear the "P" from every year except 2017. Custom coins are left
+                        // alone — the mint mark is user-entered, so it isn't ours to correct.
                         ContentValues values = new ContentValues();
                         values.put(COL_COIN_MINT, "");
                         runSqlUpdate(db, name, values,
-                                COL_COIN_MINT + "=? AND " + COL_COIN_IDENTIFIER + "!=?",
+                                COL_COIN_MINT + "=? AND " + COL_COIN_IDENTIFIER + "!=?"
+                                        + " AND " + COL_CUSTOM_COIN + "=0",
                                 new String[]{"P", pMintMarkYear});
 
                         // Give the 2017 cent the "P" it was actually struck with. Collections
@@ -370,7 +374,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
                                 && (mintMarkFlags & CollectionListInfo.MINT_P) != 0;
                         if (hasPMintMarks) {
                             values.put(COL_COIN_MINT, "P");
-                            runSqlUpdate(db, name, values, COIN_SLOT_NAME_MINT_WHERE_CLAUSE,
+                            runSqlUpdate(db, name, values,
+                                    COIN_SLOT_NAME_MINT_WHERE_CLAUSE + " AND " + COL_CUSTOM_COIN + "=0",
                                     new String[]{pMintMarkYear, ""});
                         }
                     }

--- a/app/src/main/java/com/spencerpages/MainApplication.java
+++ b/app/src/main/java/com/spencerpages/MainApplication.java
@@ -242,7 +242,7 @@ public class MainApplication extends Application {
      * Version 21-23 - Used in Version 3.7.0 of the app
      * Version 24 - Used in Version 3.8.0 of the app
      * Version 25 - Adds the 2018 Roosevelt "S Reverse Silver Proof" dime (#362)
-     * Version 26 - Fixes Philadelphia pennies stored with a "P" mint mark (#366)
+     * Version 26 - Fixes Philadelphia penny mint marks, including the 2017 "P" (#366)
      */
     public static final int DATABASE_VERSION = 26;
 

--- a/app/src/main/java/com/spencerpages/MainApplication.java
+++ b/app/src/main/java/com/spencerpages/MainApplication.java
@@ -242,8 +242,9 @@ public class MainApplication extends Application {
      * Version 21-23 - Used in Version 3.7.0 of the app
      * Version 24 - Used in Version 3.8.0 of the app
      * Version 25 - Adds the 2018 Roosevelt "S Reverse Silver Proof" dime (#362)
+     * Version 26 - Fixes Philadelphia pennies stored with a "P" mint mark (#366)
      */
-    public static final int DATABASE_VERSION = 25;
+    public static final int DATABASE_VERSION = 26;
 
     /**
      * Get the collection index from collection type name

--- a/app/src/main/java/com/spencerpages/collections/LincolnCents.java
+++ b/app/src/main/java/com/spencerpages/collections/LincolnCents.java
@@ -21,6 +21,7 @@
 package com.spencerpages.collections;
 
 import static com.coincollection.CoinSlot.COIN_SLOT_NAME_MINT_WHERE_CLAUSE;
+import static com.coincollection.CoinSlot.COL_COIN_IDENTIFIER;
 import static com.coincollection.CoinSlot.COL_COIN_MINT;
 import static com.coincollection.DatabaseHelper.runSqlDelete;
 import static com.coincollection.DatabaseHelper.runSqlUpdate;
@@ -62,6 +63,10 @@ public class LincolnCents extends CollectionInfo {
 
     private static final Integer START_YEAR = 1909;
     private static final Integer STOP_YEAR = CoinPageCreator.OPTVAL_STILL_IN_PRODUCTION;
+
+    // The only year the Philadelphia Mint put a "P" mint mark on a cent, marking its
+    // 225th anniversary. Every other year's Philadelphia cents carry no mint mark.
+    private static final int P_MINT_MARK_YEAR = 2017;
 
     private static final int OBVERSE_IMAGE_COLLECTED = R.drawable.obv_lincoln_cent_unc;
 
@@ -147,8 +152,9 @@ public class LincolnCents extends CollectionInfo {
 
             if (showMintMarks) {
                 if (showP) {
-                    // The P was never on any Pennies
-                    coinList.add(new CoinSlot(year, "", coinIndex++));
+                    // The P was never on any Pennies, except for 2017, when it was added to
+                    // mark the Philadelphia Mint's 225th anniversary
+                    coinList.add(new CoinSlot(year, (i == P_MINT_MARK_YEAR) ? "P" : "", coinIndex++));
                 }
                 if (showD) {
                     if (i != 1909 && i != 1910 && i != 1921 && i != 1923 && i != 1965 && i != 1966 && i != 1967) {
@@ -190,16 +196,18 @@ public class LincolnCents extends CollectionInfo {
     /**
      * Gets the mint variants to use when adding coins during a database upgrade. This can't
      * use DatabaseHelper.addFromYear's default "P"/"D" mint list because the "P" mint mark
-     * was never on any pennies, so Philadelphia coins are stored with an empty mint mark
-     * (matching populateCollectionLists).
+     * was only ever on the 2017 penny, so Philadelphia coins from every other year are
+     * stored with an empty mint mark (matching populateCollectionLists).
      *
      * @param collectionListInfo the collection info
+     * @param year               coin year
      * @return ordered map of mint mark flag to mint mark string
      */
-    private static LinkedHashMap<Long, String> getUpgradeMintVariants(CollectionListInfo collectionListInfo) {
+    private static LinkedHashMap<Long, String> getUpgradeMintVariants(CollectionListInfo collectionListInfo,
+                                                                      int year) {
         LinkedHashMap<Long, String> mintVariants = new LinkedHashMap<>();
         if (collectionListInfo.hasMintMarks()) {
-            mintVariants.put(CollectionListInfo.MINT_P, "");
+            mintVariants.put(CollectionListInfo.MINT_P, (year == P_MINT_MARK_YEAR) ? "P" : "");
             mintVariants.put(CollectionListInfo.MINT_D, "D");
         } else {
             // Key of 0 is unconditional — (flags & 0) == 0 is always true
@@ -218,7 +226,7 @@ public class LincolnCents extends CollectionInfo {
      */
     private static int addPennyYear(SQLiteDatabase db, CollectionListInfo collectionListInfo, int year) {
         return DatabaseHelper.addFromYear(db, collectionListInfo, year - 1, year,
-                String.valueOf(year), getUpgradeMintVariants(collectionListInfo), -1);
+                String.valueOf(year), getUpgradeMintVariants(collectionListInfo, year), -1);
     }
 
     @Override
@@ -237,7 +245,8 @@ public class LincolnCents extends CollectionInfo {
             // 1. Bug fix: The bicentennials should not display mint mark "P"
             ContentValues values = new ContentValues();
             values.put(COL_COIN_MINT, "");
-            // This shortcut works because pennies never carried the "P" mint mark
+            // This shortcut works because the only penny that carried a "P" mint mark is
+            // the 2017, which isn't added to collections until the oldVersion <= 8 block
             runSqlUpdate(db, tableName, values, COL_COIN_MINT + "=?", new String[]{"P"});
 
             // 3. 1909 V.D.B. - Can't do anything since it is in the middle of the collection
@@ -325,10 +334,22 @@ public class LincolnCents extends CollectionInfo {
             // Bug fix: Philadelphia pennies added by previous upgrades were stored with the
             // "P" mint mark, while newly created collections use "" (issue #366). This runs
             // last so that it also fixes any coins added by the upgrade blocks above.
+            // The 2017 cent is deliberately excluded — it's the one year the Philadelphia
+            // Mint actually put a "P" on the cent, for its 225th anniversary.
             ContentValues values = new ContentValues();
             values.put(COL_COIN_MINT, "");
-            // This shortcut works because pennies never carried the "P" mint mark
-            runSqlUpdate(db, tableName, values, COL_COIN_MINT + "=?", new String[]{"P"});
+            runSqlUpdate(db, tableName, values,
+                    COL_COIN_MINT + "=? AND " + COL_COIN_IDENTIFIER + "!=?",
+                    new String[]{"P", String.valueOf(P_MINT_MARK_YEAR)});
+
+            // Collections created before the 2017 "P" was modeled hold it with an empty mint
+            // mark, so give it the "P" it was actually struck with. Collections without mint
+            // marks correctly use "" for every coin and are left alone.
+            if (collectionListInfo.hasMintMarks() && collectionListInfo.hasPMintMarks()) {
+                values.put(COL_COIN_MINT, "P");
+                runSqlUpdate(db, tableName, values, COIN_SLOT_NAME_MINT_WHERE_CLAUSE,
+                        new String[]{String.valueOf(P_MINT_MARK_YEAR), ""});
+            }
         }
 
         return total;

--- a/app/src/main/java/com/spencerpages/collections/LincolnCents.java
+++ b/app/src/main/java/com/spencerpages/collections/LincolnCents.java
@@ -245,9 +245,12 @@ public class LincolnCents extends CollectionInfo {
             // 1. Bug fix: The bicentennials should not display mint mark "P"
             ContentValues values = new ContentValues();
             values.put(COL_COIN_MINT, "");
-            // This shortcut works because the only penny that carried a "P" mint mark is
-            // the 2017, which isn't added to collections until the oldVersion <= 8 block
-            runSqlUpdate(db, tableName, values, COL_COIN_MINT + "=?", new String[]{"P"});
+            // 2017 is excluded because it's the one year the Philadelphia Mint struck the
+            // cent with a "P". A database this old can't contain 2017 coins yet, but the
+            // exclusion keeps this correct regardless of when it runs.
+            runSqlUpdate(db, tableName, values,
+                    COL_COIN_MINT + "=? AND " + COL_COIN_IDENTIFIER + "!=?",
+                    new String[]{"P", "2017"});
 
             // 3. 1909 V.D.B. - Can't do anything since it is in the middle of the collection
 
@@ -328,28 +331,6 @@ public class LincolnCents extends CollectionInfo {
         if (oldVersion <= 23) {
             // Add in new 2026 coins if applicable
             total += addPennyYear(db, collectionListInfo, 2026);
-        }
-
-        if (oldVersion <= 25) {
-            // Bug fix: Philadelphia pennies added by previous upgrades were stored with the
-            // "P" mint mark, while newly created collections use "" (issue #366). This runs
-            // last so that it also fixes any coins added by the upgrade blocks above.
-            // The 2017 cent is deliberately excluded — it's the one year the Philadelphia
-            // Mint actually put a "P" on the cent, for its 225th anniversary.
-            ContentValues values = new ContentValues();
-            values.put(COL_COIN_MINT, "");
-            runSqlUpdate(db, tableName, values,
-                    COL_COIN_MINT + "=? AND " + COL_COIN_IDENTIFIER + "!=?",
-                    new String[]{"P", String.valueOf(P_MINT_MARK_YEAR)});
-
-            // Collections created before the 2017 "P" was modeled hold it with an empty mint
-            // mark, so give it the "P" it was actually struck with. Collections without mint
-            // marks correctly use "" for every coin and are left alone.
-            if (collectionListInfo.hasMintMarks() && collectionListInfo.hasPMintMarks()) {
-                values.put(COL_COIN_MINT, "P");
-                runSqlUpdate(db, tableName, values, COIN_SLOT_NAME_MINT_WHERE_CLAUSE,
-                        new String[]{String.valueOf(P_MINT_MARK_YEAR), ""});
-            }
         }
 
         return total;

--- a/app/src/main/java/com/spencerpages/collections/LincolnCents.java
+++ b/app/src/main/java/com/spencerpages/collections/LincolnCents.java
@@ -37,6 +37,7 @@ import com.spencerpages.R;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 
 public class LincolnCents extends CollectionInfo {
 
@@ -186,6 +187,40 @@ public class LincolnCents extends CollectionInfo {
         return STOP_YEAR;
     }
 
+    /**
+     * Gets the mint variants to use when adding coins during a database upgrade. This can't
+     * use DatabaseHelper.addFromYear's default "P"/"D" mint list because the "P" mint mark
+     * was never on any pennies, so Philadelphia coins are stored with an empty mint mark
+     * (matching populateCollectionLists).
+     *
+     * @param collectionListInfo the collection info
+     * @return ordered map of mint mark flag to mint mark string
+     */
+    private static LinkedHashMap<Long, String> getUpgradeMintVariants(CollectionListInfo collectionListInfo) {
+        LinkedHashMap<Long, String> mintVariants = new LinkedHashMap<>();
+        if (collectionListInfo.hasMintMarks()) {
+            mintVariants.put(CollectionListInfo.MINT_P, "");
+            mintVariants.put(CollectionListInfo.MINT_D, "D");
+        } else {
+            // Key of 0 is unconditional — (flags & 0) == 0 is always true
+            mintVariants.put(0L, "");
+        }
+        return mintVariants;
+    }
+
+    /**
+     * Adds the coins for a new year, using the penny-specific mint variants
+     *
+     * @param db                 database
+     * @param collectionListInfo the collection info
+     * @param year               coin year
+     * @return total number of coins added
+     */
+    private static int addPennyYear(SQLiteDatabase db, CollectionListInfo collectionListInfo, int year) {
+        return DatabaseHelper.addFromYear(db, collectionListInfo, year - 1, year,
+                String.valueOf(year), getUpgradeMintVariants(collectionListInfo), -1);
+    }
+
     @Override
     public int onCollectionDatabaseUpgrade(SQLiteDatabase db, CollectionListInfo collectionListInfo,
                                            int oldVersion, int newVersion) {
@@ -208,67 +243,67 @@ public class LincolnCents extends CollectionInfo {
             // 3. 1909 V.D.B. - Can't do anything since it is in the middle of the collection
 
             // Add in new 2013 coins if applicable
-            total += DatabaseHelper.addFromYear(db, collectionListInfo, 2013);
+            total += addPennyYear(db, collectionListInfo, 2013);
         }
 
         if (oldVersion <= 4) {
             // Add in new 2014 coins if applicable
-            total += DatabaseHelper.addFromYear(db, collectionListInfo, 2014);
+            total += addPennyYear(db, collectionListInfo, 2014);
         }
 
         if (oldVersion <= 6) {
             // Add in new 2015 coins if applicable
-            total += DatabaseHelper.addFromYear(db, collectionListInfo, 2015);
+            total += addPennyYear(db, collectionListInfo, 2015);
         }
 
         if (oldVersion <= 7) {
             // Add in new 2016 coins if applicable
-            total += DatabaseHelper.addFromYear(db, collectionListInfo, 2016);
+            total += addPennyYear(db, collectionListInfo, 2016);
         }
 
         if (oldVersion <= 8) {
             // Add in new 2017 coins if applicable
-            total += DatabaseHelper.addFromYear(db, collectionListInfo, 2017);
+            total += addPennyYear(db, collectionListInfo, 2017);
         }
 
         if (oldVersion <= 11) {
             // Add in new 2018 coins if applicable
-            total += DatabaseHelper.addFromYear(db, collectionListInfo, 2018);
+            total += addPennyYear(db, collectionListInfo, 2018);
         }
 
         if (oldVersion <= 12) {
             // Add in new 2019 coins if applicable
-            total += DatabaseHelper.addFromYear(db, collectionListInfo, 2019);
+            total += addPennyYear(db, collectionListInfo, 2019);
         }
 
         if (oldVersion <= 13) {
             // Add in new 2020 coins if applicable
-            total += DatabaseHelper.addFromYear(db, collectionListInfo, 2020);
+            total += addPennyYear(db, collectionListInfo, 2020);
         }
 
         if (oldVersion <= 15) {
             // Add in new 2021 coins if applicable
-            total += DatabaseHelper.addFromYear(db, collectionListInfo, 2021);
+            total += addPennyYear(db, collectionListInfo, 2021);
         }
 
         if (oldVersion <= 17) {
             // Add in new 2022 coins if applicable
-            total += DatabaseHelper.addFromYear(db, collectionListInfo, 2022);
+            total += addPennyYear(db, collectionListInfo, 2022);
         }
 
         if (oldVersion <= 18) {
             // Add in new 2023 coins if applicable
-            total += DatabaseHelper.addFromYear(db, collectionListInfo, 2023);
+            total += addPennyYear(db, collectionListInfo, 2023);
         }
 
         if (oldVersion <= 19) {
             // Add in new 2024 coins if applicable
-            total += DatabaseHelper.addFromYear(db, collectionListInfo, 2024);
+            total += addPennyYear(db, collectionListInfo, 2024);
         }
 
         if (oldVersion <= 22) {
             // Add in new 2025 coins if applicable
-            total += DatabaseHelper.addFromYear(db, collectionListInfo, 2025);
+            total += addPennyYear(db, collectionListInfo, 2025);
         }
 
         if (oldVersion <= 23) {
@@ -283,7 +318,17 @@ public class LincolnCents extends CollectionInfo {
 
         if (oldVersion <= 23) {
             // Add in new 2026 coins if applicable
-            total += DatabaseHelper.addFromYear(db, collectionListInfo, 2026);
+            total += addPennyYear(db, collectionListInfo, 2026);
+        }
+
+        if (oldVersion <= 25) {
+            // Bug fix: Philadelphia pennies added by previous upgrades were stored with the
+            // "P" mint mark, while newly created collections use "" (issue #366). This runs
+            // last so that it also fixes any coins added by the upgrade blocks above.
+            ContentValues values = new ContentValues();
+            values.put(COL_COIN_MINT, "");
+            // This shortcut works because pennies never carried the "P" mint mark
+            runSqlUpdate(db, tableName, values, COL_COIN_MINT + "=?", new String[]{"P"});
         }
 
         return total;

--- a/app/src/test/java/com/spencerpages/CollectionCreationTests.java
+++ b/app/src/test/java/com/spencerpages/CollectionCreationTests.java
@@ -2000,6 +2000,44 @@ public class CollectionCreationTests extends BaseTestCase {
                 hasCoin(coinList, "2019", "S Reverse Silver Proof"));
     }
 
+    /**
+     * For LincolnCents
+     * - The Philadelphia Mint put a "P" mint mark on the cent only in 2017, to mark its
+     *   225th anniversary. Every other year's Philadelphia cent carries no mint mark.
+     */
+    @Test
+    public void test_LincolnCents2017PMintMark() {
+
+        ParcelableHashMap parameters = new ParcelableHashMap();
+        LincolnCents coinClass = new LincolnCents();
+        coinClass.getCreationParameters(parameters);
+        parameters.put(CoinPageCreator.OPT_SHOW_MINT_MARKS, Boolean.TRUE);
+        parameters.put(CoinPageCreator.OPT_SHOW_MINT_MARK_1, Boolean.TRUE);  // include P
+
+        ArrayList<CoinSlot> coinList = new ArrayList<>();
+        coinClass.populateCollectionLists(parameters, coinList);
+
+        assertTrue("2017 Philadelphia cent should have the 'P' mint mark",
+                hasCoin(coinList, "2017", "P"));
+        assertFalse("2017 Philadelphia cent should not also exist without a mint mark",
+                hasCoin(coinList, "2017", ""));
+        assertFalse("'P' should only be used for 2017 (not 2016)",
+                hasCoin(coinList, "2016", "P"));
+        assertFalse("'P' should only be used for 2017 (not 2018)",
+                hasCoin(coinList, "2018", "P"));
+        assertTrue("2016 Philadelphia cent should have no mint mark",
+                hasCoin(coinList, "2016", ""));
+
+        // Without mint marks enabled, every coin including 2017 uses an empty mint mark
+        parameters.put(CoinPageCreator.OPT_SHOW_MINT_MARKS, Boolean.FALSE);
+        ArrayList<CoinSlot> noMintMarkList = new ArrayList<>();
+        coinClass.populateCollectionLists(parameters, noMintMarkList);
+        assertFalse("2017 should have no mint mark when mint marks are disabled",
+                hasCoin(noMintMarkList, "2017", "P"));
+        assertTrue("2017 should use an empty mint mark when mint marks are disabled",
+                hasCoin(noMintMarkList, "2017", ""));
+    }
+
     private static boolean hasCoin(ArrayList<CoinSlot> coinList, String identifier, String mint) {
         for (CoinSlot slot : coinList) {
             if (identifier.equals(slot.getIdentifier()) && mint.equals(slot.getMint())) {

--- a/app/src/test/java/com/spencerpages/CollectionUpgradeAllParamsTests.java
+++ b/app/src/test/java/com/spencerpages/CollectionUpgradeAllParamsTests.java
@@ -35,7 +35,6 @@ import com.coincollection.CollectionListInfo;
 import com.coincollection.ExportImportHelper;
 import com.coincollection.MainActivity;
 import com.coincollection.helper.ParcelableHashMap;
-import com.spencerpages.collections.LincolnCents;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,8 +45,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * Upgrade tests using static V23 JSON fixture files. Each fixture contains all
@@ -65,15 +62,6 @@ import java.util.Set;
 public class CollectionUpgradeAllParamsTests extends BaseTestCase {
 
     private static final String FIXTURE_DIR = "src/test/data/v23-upgrades";
-
-    // Collections with known upgrade vs. fresh-creation mismatches.
-    // LincolnCents: addFromYear uses "P" for Philadelphia, but pennies use "" since
-    // the P mint mark was never on any pennies. This is a pre-existing bug across all
-    // upgrade versions (V4–V24). See https://github.com/anwilli5/coin-collection-android-US/issues/366
-    private static final Set<String> KNOWN_UPGRADE_MISMATCHES = new HashSet<>();
-    static {
-        KNOWN_UPGRADE_MISMATCHES.add(LincolnCents.COLLECTION_TYPE);
-    }
 
     /**
      * Import a V23 fixture, validate each collection after upgrade.
@@ -107,11 +95,6 @@ public class CollectionUpgradeAllParamsTests extends BaseTestCase {
                 assertTrue("No collections imported", collectionListEntries.size() > 0);
 
                 for (CollectionListInfo importedInfo : collectionListEntries) {
-                    // Skip collections with known pre-existing upgrade mismatches
-                    if (KNOWN_UPGRADE_MISMATCHES.contains(importedInfo.getType())) {
-                        continue;
-                    }
-
                     // Reconstruct the parameters used to create this collection
                     ParcelableHashMap parameters = CoinPageCreator.getParametersFromCollectionListInfo(importedInfo);
 

--- a/app/src/test/java/com/spencerpages/CollectionUpgradeSemiQParamTests.java
+++ b/app/src/test/java/com/spencerpages/CollectionUpgradeSemiQParamTests.java
@@ -328,6 +328,30 @@ public class CollectionUpgradeSemiQParamTests extends BaseTestCase {
         validateUpdatedDbWithParams(collection, collectionName, validateParams);
     }
 
+    /**
+     * Philadelphia pennies are stored with an empty mint mark since the "P" was never on
+     * any penny. Verifies the upgrade doesn't add "P" coins (issue #366).
+     */
+    @Test
+    public void test_LincolnCentsUpgradeWithMintMarks() {
+        CollectionInfo collection = new LincolnCents();
+        String coinType = "Pennies";
+        String collectionName = coinType + " Upgrade MintMarks";
+
+        ParcelableHashMap createParams = getAllEnabledParams(collection);
+        createParams.put(CoinPageCreator.OPT_STOP_YEAR, 2025);
+
+        TestDatabaseHelperV23 testDbHelper = new TestDatabaseHelperV23(
+                ApplicationProvider.getApplicationContext());
+        SQLiteDatabase db = testDbHelper.getWritableDatabase();
+        createV23FromPopulateWithParams(db, collection, coinType, collectionName, null, createParams);
+        db.close();
+        testDbHelper.close();
+
+        ParcelableHashMap validateParams = getAllEnabledParams(collection);
+        validateUpdatedDbWithParams(collection, collectionName, validateParams);
+    }
+
     @Test
     public void test_CartwheelsUpgradeWithMintMarks() {
         CollectionInfo collection = new Cartwheels();

--- a/app/src/test/java/com/spencerpages/CollectionUpgradeTests.java
+++ b/app/src/test/java/com/spencerpages/CollectionUpgradeTests.java
@@ -21,6 +21,7 @@
 package com.spencerpages;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -1917,4 +1918,104 @@ public class CollectionUpgradeTests extends BaseTestCase {
         }
     }
 
+    /**
+     * The V26 penny mint mark migration must not touch custom (user-added) coins.
+     * Their mint marks are user-entered, so neither the blanket "P" clear nor the
+     * 2017 "P" repair should rewrite them. See issue #366.
+     */
+    @Test
+    public void test_LincolnCentsPMintMarkMigrationPreservesCustomCoins() {
+
+        CollectionInfo collection = new LincolnCents();
+        String coinType = LincolnCents.COLLECTION_TYPE;
+        String collectionName = coinType + " Custom Coin Test";
+
+        ParcelableHashMap parameters = getAllEnabledParams(collection);
+        parameters.put(CoinPageCreator.OPT_STOP_YEAR, 2025);
+
+        TestDatabaseHelperV23 testDbHelper = new TestDatabaseHelperV23(
+                ApplicationProvider.getApplicationContext());
+        SQLiteDatabase db = testDbHelper.getWritableDatabase();
+        createV23FromPopulateWithParams(db, collection, coinType, collectionName, null, parameters);
+
+        // Put the generated coins back into the buggy pre-V26 state: the 2017 cent
+        // without its "P", and an ordinary year carrying a "P" it never had.
+        ContentValues clear2017 = new ContentValues();
+        clear2017.put(CoinSlot.COL_COIN_MINT, "");
+        db.update("[" + collectionName + "]", clear2017,
+                CoinSlot.COL_COIN_IDENTIFIER + "=? AND " + CoinSlot.COL_COIN_MINT + "=?",
+                new String[]{"2017", "P"});
+
+        ContentValues bogusP = new ContentValues();
+        bogusP.put(CoinSlot.COL_COIN_MINT, "P");
+        db.update("[" + collectionName + "]", bogusP,
+                CoinSlot.COL_COIN_IDENTIFIER + "=? AND " + CoinSlot.COL_COIN_MINT + "=?",
+                new String[]{"2020", ""});
+
+        // Custom coin carrying a "P" the migration must not clear
+        ContentValues customP = new ContentValues();
+        customP.put(CoinSlot.COL_COIN_IDENTIFIER, "1943");
+        customP.put(CoinSlot.COL_COIN_MINT, "P");
+        customP.put(CoinSlot.COL_IN_COLLECTION, 1);
+        customP.put(CoinSlot.COL_SORT_ORDER, 9998);
+        customP.put(CoinSlot.COL_CUSTOM_COIN, 1);
+        db.insert("[" + collectionName + "]", null, customP);
+
+        // Custom 2017 coin with no mint mark, which must not be given a "P"
+        ContentValues custom2017 = new ContentValues();
+        custom2017.put(CoinSlot.COL_COIN_IDENTIFIER, "2017");
+        custom2017.put(CoinSlot.COL_COIN_MINT, "");
+        custom2017.put(CoinSlot.COL_IN_COLLECTION, 1);
+        custom2017.put(CoinSlot.COL_SORT_ORDER, 9999);
+        custom2017.put(CoinSlot.COL_CUSTOM_COIN, 1);
+        db.insert("[" + collectionName + "]", null, custom2017);
+
+        db.close();
+        testDbHelper.close();
+
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+
+                ArrayList<CoinSlot> dbCoins = activity.mDbAdapter.getCoinList(collectionName, true);
+                assertNotNull(dbCoins);
+
+                ArrayList<CoinSlot> custom = new ArrayList<>();
+                ArrayList<CoinSlot> generated = new ArrayList<>();
+                for (CoinSlot coin : dbCoins) {
+                    if (coin.isCustomCoin()) {
+                        custom.add(coin);
+                    } else {
+                        generated.add(coin);
+                    }
+                }
+
+                // Both custom coins keep exactly the mint marks the user gave them
+                assertEquals("Both custom coins should survive", 2, custom.size());
+                assertTrue("Custom '1943 P' should keep its P mint mark",
+                        hasCoin(custom, "1943", "P"));
+                assertTrue("Custom 2017 should keep its empty mint mark",
+                        hasCoin(custom, "2017", ""));
+                assertFalse("Custom 2017 should not have been given a P",
+                        hasCoin(custom, "2017", "P"));
+
+                // The generated coins are corrected
+                assertTrue("Generated 2017 should be repaired to 'P'",
+                        hasCoin(generated, "2017", "P"));
+                assertFalse("Generated 2020 should have its bogus P cleared",
+                        hasCoin(generated, "2020", "P"));
+                assertTrue("Generated 2020 should use an empty mint mark",
+                        hasCoin(generated, "2020", ""));
+            });
+        }
+    }
+
+    private static boolean hasCoin(ArrayList<CoinSlot> coinList, String identifier, String mint) {
+        for (CoinSlot slot : coinList) {
+            if (identifier.equals(slot.getIdentifier()) && mint.equals(slot.getMint())) {
+                return true;
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
## Description

Fixes #366.

`LincolnCents.onCollectionDatabaseUpgrade` added each new year's coins with `DatabaseHelper.addFromYear(db, info, year)`, whose default mint list is `["P", "D"]`. That stores Philadelphia cents with a `"P"` mint mark, but `populateCollectionLists` uses `""`, so an upgraded Pennies collection didn't match a freshly created one. The original V3 fix ran a one-time blanket `"P" -> ""` update, and every `addFromYear` call from V4 onward quietly reintroduced the problem.

While fixing that, a second bug turned up: the 2017 cent genuinely does carry a `"P"`, struck for the Philadelphia Mint's 225th anniversary and the only year the Mint ever did this. `SmallCents` already models it, but `LincolnCents` used `""` for every year, so a naive blanket clear would have destroyed a legitimate mint mark for anyone who had it.

### Approach

- `LincolnCents.populateCollectionLists` now uses `"P"` for 2017 when mint marks and the P checkbox are enabled, matching `SmallCents` and reality.
- Year additions go through a new `addPennyYear` helper that passes explicit mint variants (`MINT_P -> ""`, `MINT_D -> "D"`, and `"P"` for 2017), so future annual updates cannot reintroduce the bug.
- A data fix in `DatabaseHelper.upgradeDbStructure` repairs existing databases: it clears `"P"` from every year except 2017 and gives the 2017 cent the `"P"` it was struck with. It lives in the central file alongside the other app level migrations, following the same shape as the V23 SEMIQ block (iterate `collection_info`, filter by coin type, update in place). Adding coins for a new year stays in the collection class, per the documented split.
- `DATABASE_VERSION` goes to 26 so the fix runs for everyone.

### Notes for reviewers

A few decisions worth a look:

- **Custom coins are excluded.** Users can copy a slot and type any mint mark into the edit dialog, so both statements carry `AND customCoin = 0`, matching the rule `removeDuplicateCoinsByIdentifier` already applies. Note this only covers rows flagged `customCoin=1`; a coin added through the "add coin" dialog is stored with `customCoin=0`, so a `"P"` typed there is still cleared. That flagging gap is pre-existing and left alone here.
- **The year is a literal, not a shared constant**, in the migration. If the Mint ever uses a `"P"` again and someone extends a shared constant, a reference would silently rewrite this migration's meaning.
- **`upgradeDbStructure` runs before the per-collection upgrade loop**, so the fix repairs pre-existing rows only. That is sufficient because `addPennyYear` writes correct values for coins it adds. It does mean the `oldVersion <= 3` blanket clear now runs after the fix, so that block excludes 2017 too. A database that old cannot hold 2017 coins, but the exclusion keeps it correct regardless of ordering.
- `LincolnCents` was removed from `KNOWN_UPGRADE_MISMATCHES` in `CollectionUpgradeAllParamsTests`, which leaves that set empty, so the set and its skip logic are gone.

### Testing

`./gradlew testAndroidDebugUnitTest` (702 tests, 0 failures) and `./gradlew lintAndroidDebug` both pass.

Three tests were added, and each was verified to fail when its corresponding fix is reverted:

- `test_LincolnCents2017PMintMark` covers the 2017 mint mark in collection creation.
- `test_LincolnCentsUpgradeWithMintMarks` covers the upgrade path with all mint marks enabled.
- `test_LincolnCentsPMintMarkMigrationPreservesCustomCoins` seeds the buggy pre-V26 state plus custom coins and asserts generated coins get corrected while custom ones are untouched.

The four frozen V23 fixtures also cover both migration paths: `all-params-enabled` and `alternating-B` have P enabled and exercise the `"" -> "P"` repair, while `default-params` and `alternating-A` have mint marks off and confirm 2017 stays `""`.