### PR TITLE
Flag coins added via "Add Coin" as custom coins

### DIFF
--- a/app/src/main/java/com/coincollection/CoinSlot.java
+++ b/app/src/main/java/com/coincollection/CoinSlot.java
@@ -181,6 +181,23 @@ public class CoinSlot implements Parcelable {
         mImageId = imageId;
     }
 
+    /**
+     * Constructor used when a coin is added to an existing collection by the user
+     *
+     * @param identifier coin name
+     * @param mint       coin mint
+     * @param sortOrder  sort order in collection
+     * @param imageId    image id
+     * @param customCoin whether the coin was manually added by the user
+     */
+    public CoinSlot(String identifier, String mint, int sortOrder, int imageId, boolean customCoin) {
+        mIdentifier = identifier;
+        mMint = mint;
+        mSortOrder = sortOrder;
+        mImageId = imageId;
+        mCustomCoin = customCoin;
+    }
+
     public void setDatabaseId(long databaseId) {
         this.mDatabaseId = databaseId;
     }

--- a/app/src/main/java/com/coincollection/CollectionPage.java
+++ b/app/src/main/java/com/coincollection/CollectionPage.java
@@ -735,7 +735,8 @@ public class CollectionPage extends BaseActivity {
      */
     public void addNewCoin(String newName, String coinMint, int imageId) {
         int sortOrder = mDbAdapter.getNextCoinSortOrder(mCollectionName);
-        CoinSlot newCoinSlot = new CoinSlot(newName, coinMint, sortOrder, imageId);
+        // Mark as custom coin since it wasn't added when the collection was created
+        CoinSlot newCoinSlot = new CoinSlot(newName, coinMint, sortOrder, imageId, true);
         try {
             // Insert the new coin into the database
             mDbAdapter.addCoinSlotToCollection(newCoinSlot, mCollectionName, true, mOriginalCoinList.size() + 1);

--- a/app/src/test/java/com/spencerpages/CollectionPageActivityTests.java
+++ b/app/src/test/java/com/spencerpages/CollectionPageActivityTests.java
@@ -29,6 +29,7 @@ import static com.spencerpages.SharedTest.COLLECTION_LIST_INFO_SCENARIOS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import android.content.Intent;
@@ -131,11 +132,85 @@ public class CollectionPageActivityTests extends BaseTestCase {
     }
 
     /**
+     * Test that a coin added via the "Add Coin" action is flagged as a custom coin
+     * and isn't dropped when the collection's parameters are saved again
+     */
+    @Test
+    public void test_addNewCoinIsCustomAndSurvivesCollectionUpdate() {
+        final String customCoinName = "Custom Test Coin";
+        final String customCoinMint = "Custom Test Mint";
+        for (FullCollection collection : mCollectionList) {
+            final CollectionListInfo info = collection.mCollectionListInfo;
+            final String collectionName = info.getName();
+            int coinTypeIdx = info.getCollectionTypeIndex();
+
+            // Add a coin the same way the "Add Coin" menu item does
+            try (ActivityScenario<CollectionPage> scenario = ActivityScenario.launch(
+                    new Intent(ApplicationProvider.getApplicationContext(), CollectionPage.class)
+                            .putExtra(CollectionPage.COLLECTION_TYPE_INDEX, coinTypeIdx)
+                            .putExtra(CollectionPage.COLLECTION_NAME, collectionName))) {
+                scenario.onActivity(activity -> {
+                    activity.addNewCoin(customCoinName, customCoinMint, -1);
+
+                    // The hand-added coin must be stored as a custom coin
+                    ArrayList<CoinSlot> dbCoinList = activity.mDbAdapter.getCoinList(collectionName, true);
+                    CoinSlot addedCoin = findCoinSlot(dbCoinList, customCoinName, customCoinMint);
+                    assertNotNull(addedCoin);
+                    assertTrue(addedCoin.isCustomCoin());
+
+                    // Coins generated when the collection was created must not be custom coins
+                    for (CoinSlot coinSlot : dbCoinList) {
+                        if (coinSlot != addedCoin) {
+                            assertFalse(coinSlot.isCustomCoin());
+                        }
+                    }
+
+                    // Mark the coin collected so the merge can be checked for data loss
+                    activity.mDbAdapter.toggleInCollection(collectionName, addedCoin);
+                });
+            }
+
+            // Re-save the collection's parameters, as editing the collection does
+            try (ActivityScenario<CoinPageCreator> scenario = ActivityScenario.launch(
+                    new Intent(ApplicationProvider.getApplicationContext(), CoinPageCreator.class)
+                            .putExtra(CoinPageCreator.EXISTING_COLLECTION_EXTRA, info))) {
+                scenario.onActivity(activity -> {
+                    activity.createOrUpdateCoinListForAsyncThread();
+
+                    // The hand-added coin and its collected status must be preserved
+                    CoinSlot mergedCoin = findCoinSlot(activity.mCoinList, customCoinName, customCoinMint);
+                    assertNotNull(mergedCoin);
+                    assertTrue(mergedCoin.isCustomCoin());
+                    assertTrue(mergedCoin.isInCollection());
+                });
+            }
+        }
+    }
+
+    /**
+     * Look up a coin slot by name and mint
+     *
+     * @param coinList   list of coin slots to search
+     * @param identifier coin name to look for
+     * @param mint       coin mint to look for
+     * @return the matching CoinSlot, or null if not present
+     */
+    private static CoinSlot findCoinSlot(ArrayList<CoinSlot> coinList, String identifier, String mint) {
+        for (CoinSlot coinSlot : coinList) {
+            if (identifier.equals(coinSlot.getIdentifier()) && mint.equals(coinSlot.getMint())) {
+                return coinSlot;
+            }
+        }
+        return null;
+    }
+
+    /**
      * Test that all classes listed in COLLECTION_TYPES are included in
      * BASIC_COLLECTIONS and ADVANCED_COLLECTIONS
      */
     @Test
     public void test_collectionTypes() {
+
         assertEquals(COLLECTION_TYPES.length, (BASIC_COLLECTIONS.length + ADVANCED_COLLECTIONS.length + MORE_COLLECTIONS.length));
         for (Class<?> collectionClass : BASIC_COLLECTIONS) {
             // All basic collections should be in the collection types list


### PR DESCRIPTION
## Description

Coins added through the **Add Coin** menu item were stored with `customCoin = 0`, so they were indistinguishable from app-generated slots. The main consequence was silent data loss: `CoinPageCreator.createOrUpdateCoinListForAsyncThread` rebuilds the coin list whenever a collection's parameters are saved and only keeps rows that either match a newly generated coin or are flagged custom. A hand-added coin matches nothing (that is the point of adding it), so it was dropped along with its collected status, grade, quantity, and notes, with no warning. The same flag also gates the `customCoin = 1` exclusion in `DatabaseHelper.removeDuplicateCoinsByIdentifier`, which hand-added coins were missing out on.

`CollectionPage.copyCoinSlot` already got this right via `coinSlot.copy(..., true)`, so the two ways a user can add a coin behaved differently: **Copy Coin** produced a protected row, **Add Coin** did not.

### Approach

`CollectionPage.addNewCoin` was building its slot with the 4-argument `CoinSlot` constructor, which never assigns `mCustomCoin` and leaves it at its field default of `false`. That constructor is used by roughly 50 collection classes to build *generated* coins, where `false` is the correct value, so it is left untouched. Instead this adds a constructor overload that takes an explicit `customCoin` flag, and `addNewCoin` now passes `true`.

### Scope notes

Two things the issue raised are deliberately out of scope:

- **No retroactive migration.** Coins already stored with `customCoin = 0` cannot be reliably distinguished from generated coins after the fact. The regenerate-from-parameters-and-diff heuristic is possible but risks false positives, which would produce duplicate rows on the next parameter edit. `DATABASE_VERSION` stays at 25 and there is no schema change.
- **`updateCoinDetails` is unchanged.** Renaming a generated coin still leaves it non-custom, so it has the same data-loss behavior on the next parameter edit. Whether an edited coin should become custom is a product decision worth deciding separately.

### Testing

New `CollectionPageActivityTests.test_addNewCoinIsCustomAndSurvivesCollectionUpdate` covers the full reported scenario: it adds a coin via `addNewCoin`, asserts the persisted row has `isCustomCoin() == true` while generated coins stay `false`, marks it collected, then relaunches `CoinPageCreator` with `EXISTING_COLLECTION_EXTRA` and runs `createOrUpdateCoinListForAsyncThread()` to assert the coin and its collected status survive.

I verified the test actually catches the bug rather than just passing: reverting only the `addNewCoin` line makes it fail with an `AssertionError`, and restoring it makes it pass. The full `testAndroidDebugUnitTest` suite and `lintAndroidDebug` both pass.

Fixes #436