### PR TITLE
Fix spurious database error when importing into an empty app

### DIFF
--- a/app/src/main/java/com/coincollection/MainActivity.java
+++ b/app/src/main/java/com/coincollection/MainActivity.java
@@ -88,7 +88,7 @@ public class MainActivity extends BaseActivity {
     // App permission requests
     private final static int IMPORT_PERMISSIONS_REQUEST = 0;
     private final static int EXPORT_PERMISSIONS_REQUEST = 1;
-    private final static int PICK_IMPORT_FILE = 2;
+    public final static int PICK_IMPORT_FILE = 2;
     private final static int PICK_EXPORT_FILE = 3;
 
     // Default list item view positions
@@ -428,11 +428,30 @@ public class MainActivity extends BaseActivity {
 
             if (mNumberOfCollections == 0) {
                 // Finish the import using AsyncTaskRunner to do the heavy lifting
-                kickOffAsyncTaskRunner(TASK_IMPORT_COLLECTIONS);
+                startImportTask();
             } else {
                 showImportConfirmation();
             }
         }
+    }
+
+    /**
+     * Starts the import task, flagging that the database is being rewritten so that the
+     * collection list isn't read back mid-import (see onWindowFocusChanged). All import
+     * entry points must go through this method.
+     */
+    private void startImportTask() {
+        mActivityViewModel.mTaskRequest.isImportingCollection = true;
+        kickOffAsyncTaskRunner(TASK_IMPORT_COLLECTIONS);
+    }
+
+    /**
+     * Indicates whether an import task is currently rewriting the database
+     *
+     * @return true while an import is in progress
+     */
+    public boolean isImportInProgress() {
+        return mActivityViewModel.mTaskRequest.isImportingCollection;
     }
 
     /**
@@ -563,7 +582,7 @@ public class MainActivity extends BaseActivity {
                             showImportConfirmation();
                         } else {
                             // Finish the import by kicking off an AsyncTask to do the heavy lifting
-                            kickOffAsyncTaskRunner(TASK_IMPORT_COLLECTIONS);
+                            startImportTask();
                         }
                     }
                     break;
@@ -673,7 +692,7 @@ public class MainActivity extends BaseActivity {
         // We use this function as a convenience for updating the database once the list gets focus
         // after returning from the add/delete/reorder views.
 
-        if (hasFocus && !mActivityViewModel.mTaskRequest.isImportingCollection) {
+        if (hasFocus && !isImportInProgress()) {
             // Only do this if the database has been opened with AsyncTaskRunner first
             // and we aren't modifying the database like crazy (importing)
             // We need this so that new collections that are added/removed get shown
@@ -761,8 +780,7 @@ public class MainActivity extends BaseActivity {
                 .setPositiveButton(mRes.getString(R.string.yes), (dialog, id) -> {
                     // Finish the import using AsyncTaskRunner to do the heavy lifting
                     dialog.dismiss();
-                    mActivityViewModel.mTaskRequest.isImportingCollection = true;
-                    kickOffAsyncTaskRunner(TASK_IMPORT_COLLECTIONS);
+                    startImportTask();
                 })
                 .setNegativeButton(mRes.getString(R.string.no), (dialog, id) -> dialog.cancel()));
     }

--- a/app/src/test/java/com/spencerpages/ImportRaceTests.java
+++ b/app/src/test/java/com/spencerpages/ImportRaceTests.java
@@ -1,0 +1,115 @@
+/*
+ * Coin Collection, an Android app that helps users track the coins that they've collected
+ * Copyright (C) 2010-2016 Andrew Williams
+ *
+ * This file is part of Coin Collection.
+ *
+ * Coin Collection is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Coin Collection is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Coin Collection.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.spencerpages;
+
+import static com.spencerpages.SharedTest.COLLECTION_LIST_INFO_SCENARIOS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.app.Activity;
+import android.content.Intent;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.core.app.ApplicationProvider;
+
+import com.coincollection.BaseActivity;
+import com.coincollection.CollectionListInfo;
+import com.coincollection.MainActivity;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class ImportRaceTests extends BaseTestCase {
+
+    /**
+     * Regression test for the spurious "error reading database" message reported when
+     * importing into an app that has no collections yet.
+     * <p>
+     * The import worker drops the collection_info table before recreating it, so the
+     * collection list must not be re-read while an import is in flight. Every import
+     * entry point has to mark the import as in progress, including the ones that skip
+     * the confirmation dialog because there is nothing to overwrite.
+     */
+    @Test
+    public void test_importWithNoCollectionsSkipsListRefresh() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+                activity.updateCollectionListFromDatabase();
+                assertEquals(0, activity.mNumberOfCollections);
+                assertFalse(activity.isImportInProgress());
+
+                // Use the real (asynchronous) task path so the import is only queued
+                // here. The synchronous unit-test seam would run the import to
+                // completion inline, setting and clearing the flag within this call
+                // and hiding the state the window focus handler has to observe.
+                BaseActivity.isUnitTest = false;
+                try {
+                    // The result intent carries no URI, so the queued task fails fast
+                    // without performing any file I/O
+                    activity.onActivityResult(MainActivity.PICK_IMPORT_FILE,
+                            Activity.RESULT_OK, new Intent());
+                } finally {
+                    BaseActivity.isUnitTest = true;
+                }
+
+                assertTrue(activity.isImportInProgress());
+
+                // Returning from the file picker gives the collection list focus again.
+                // The list must be left alone while the import rewrites the database.
+                CollectionListInfo info = COLLECTION_LIST_INFO_SCENARIOS[0];
+                activity.mDbAdapter.createAndPopulateNewTable(info, 0, null);
+                activity.onWindowFocusChanged(true);
+                assertEquals(0, activity.mNumberOfCollections);
+
+                // Clean up
+                activity.mDbAdapter.dropCollectionTable(info.getName());
+            });
+        }
+    }
+
+    /**
+     * Control for the test above - the collection list is still refreshed when the
+     * window gains focus and no import is running
+     */
+    @Test
+    public void test_windowFocusRefreshesListWhenNotImporting() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+                activity.updateCollectionListFromDatabase();
+                assertEquals(0, activity.mNumberOfCollections);
+
+                CollectionListInfo info = COLLECTION_LIST_INFO_SCENARIOS[0];
+                activity.mDbAdapter.createAndPopulateNewTable(info, 0, null);
+                activity.onWindowFocusChanged(true);
+                assertFalse(activity.isImportInProgress());
+                assertEquals(1, activity.mNumberOfCollections);
+
+                // Clean up
+                activity.mDbAdapter.dropCollectionTable(info.getName());
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fixes #437

Importing a backup into an app that has no collections yet pops up "An error occurred while trying to read the database" and leaves the collection list empty, even though the import actually succeeded. Relaunching the app shows every collection present and correct. It is a false alarm, but it looks like data loss right after the user has been warned that importing wipes everything.

### Root cause

`MainActivity` uses an `isImportingCollection` flag to stop the collection list from being re-read while an import is rewriting the database. That guard matters because `ExportImportHelper.updateDatabaseFromImport()` calls `dropCollectionInfoTable()` before `createCollectionInfoTable()`, so there is a real window where `collection_info` does not exist.

The flag was only ever set by the `showImportConfirmation()` positive button. The two import entry points taken when `mNumberOfCollections == 0` (`onActivityResult()` for `PICK_IMPORT_FILE`, and the legacy-CSV branch of `launchImportTask()`) skip that dialog because there is nothing to overwrite, and neither set the flag. When the file picker closed, `onWindowFocusChanged()` saw the flag as false and read the database concurrently with the import worker, landing in that window:

```
E SQLiteLog: (1) no such table: collection_info in "SELECT ... FROM collection_info ORDER BY displayOrder"
```

The list also went empty because `DatabaseHelper.getAllTables()` calls `collectionListEntries.clear()` before it queries and then throws, so `mNumberOfCollections` was recomputed as 0.

### Fix

Route all three import entry points through a single `startImportTask()` helper that sets the flag before kicking off the task, so the paths cannot drift apart again, and read the flag back through `isImportInProgress()`. The behavioral change is just the two previously unguarded call sites; the rest is consolidation.

`PICK_IMPORT_FILE` was made public so the new test can drive `onActivityResult()`, matching the already-public `IMPORT_COLLECTIONS` / `EXPORT_COLLECTIONS` constants.

### Testing

New `ImportRaceTests` covers the empty-collection import path. It sets `BaseActivity.isUnitTest = false` so the task is only queued on the paused Robolectric looper rather than running inline, which is what makes the flag observable, then asserts a window focus event does not re-read the list. A companion control test proves focus still refreshes the list normally when no import is running.

Reverting just the `onActivityResult` call site makes the regression test fail at the `isImportInProgress()` assertion while the control keeps passing, so the test genuinely pins the bug.

`./gradlew testAndroidDebugUnitTest` and `./gradlew lintAndroidDebug` are both green; lint reports only the 7 pre-existing issues, none in the changed files.

### Notes for reviewers

Deliberately narrow. Two adjacent hardening ideas are left out to avoid overlapping with the planned import-safety work: making `updateCollectionListFromDatabase()` preserve the in-memory list when a read fails, and reordering `updateDatabaseFromImport()` to validate-then-destroy inside a transaction. The second would probably narrow this race incidentally, but it is a much larger change.

No database version bump, no schema change, and no collection class changes.