### PR TITLE
Make collection import atomic and fail cleanly on malformed files

### DIFF
--- a/app/src/main/java/com/coincollection/CoinSlot.java
+++ b/app/src/main/java/com/coincollection/CoinSlot.java
@@ -446,20 +446,45 @@ public class CoinSlot implements Parcelable {
     }
 
     /**
+     * Parses an integer field from an imported string array
+     *
+     * @param in           input String[]
+     * @param index        string position
+     * @param defaultValue value to use if the field isn't present
+     * @return the parsed value
+     * @throws ImportFormatException if the field is present but isn't a valid integer
+     */
+    private int parseIntOrThrow(String[] in, int index, int defaultValue) throws ImportFormatException {
+        if (!isPresentInStringArray(in, index)) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(in[index].trim());
+        } catch (NumberFormatException e) {
+            throw new ImportFormatException("Invalid numeric coin value '" + in[index]
+                    + "' at position " + index, e);
+        }
+    }
+
+    /**
      * Create a CoinSlot from imported string array
      *
      * @param in input String[]
+     * @throws ImportFormatException if the row can't be parsed
      */
-    public CoinSlot(String[] in, int coinIndex) {
+    public CoinSlot(String[] in, int coinIndex) throws ImportFormatException {
+        if (in.length == 0) {
+            throw new ImportFormatException("Coin row is empty");
+        }
         mIdentifier = isPresentInStringArray(in, 0) ? in[0] : "";
         mMint = isPresentInStringArray(in, 1) ? in[1] : "";
-        mInCollection = (isPresentInStringArray(in, 2) && (Integer.parseInt(in[2]) != 0));
-        mAdvancedGrades = isPresentInStringArray(in, 3) ? Integer.parseInt(in[3]) : 0;
-        mAdvancedQuantities = isPresentInStringArray(in, 4) ? Integer.parseInt(in[4]) : 0;
+        mInCollection = (parseIntOrThrow(in, 2, 0) != 0);
+        mAdvancedGrades = parseIntOrThrow(in, 3, 0);
+        mAdvancedQuantities = parseIntOrThrow(in, 4, 0);
         mAdvancedNotes = isPresentInStringArray(in, 5) ? in[5] : "";
-        mSortOrder = isPresentInStringArray(in, 6) ? Integer.parseInt(in[6]) : coinIndex;
-        mCustomCoin = (isPresentInStringArray(in, 7) && (Integer.parseInt(in[7]) != 0));
-        mImageId = isPresentInStringArray(in, 8) ? Integer.parseInt(in[8]) : -1;
+        mSortOrder = parseIntOrThrow(in, 6, coinIndex);
+        mCustomCoin = (parseIntOrThrow(in, 7, 0) != 0);
+        mImageId = parseIntOrThrow(in, 8, -1);
     }
 
     /**

--- a/app/src/main/java/com/coincollection/CollectionListInfo.java
+++ b/app/src/main/java/com/coincollection/CollectionListInfo.java
@@ -338,12 +338,13 @@ public class CollectionListInfo implements Parcelable {
      * Safely parses a mint-mark / checkbox flag string into a long, returning 0
      * for null, empty, or unrecoverable values instead of throwing.
      * <p>
-     * Flag strings are written verbatim from imported files (CSV/JSON) with no
-     * validation, so they can be corrupted by spreadsheets. Excel/Sheets commonly
-     * rewrite large integers as a trailing-decimal ("268435456.0"), with stray
-     * surrounding whitespace, or in scientific notation ("2.68435E+8"). Such a
-     * value would otherwise throw {@link NumberFormatException} during a database
-     * upgrade and crash the app on every startup (issue #406).
+     * Flag strings can be corrupted by spreadsheets: Excel/Sheets commonly rewrite
+     * large integers as a trailing-decimal ("268435456.0"), with stray surrounding
+     * whitespace, or in scientific notation ("2.68435E+8"). Such a value would
+     * otherwise throw {@link NumberFormatException} during a database upgrade and
+     * crash the app on every startup (issue #406). Imports now reject unrecoverable
+     * values up front (see {@link #parseImportedFlagString}), but databases written
+     * before that check still carry them, so reads must stay lenient.
      * <p>
      * To support users who edit the exported CSV in a spreadsheet, this method
      * makes a best effort to recover the integer value from those formats. The
@@ -352,11 +353,49 @@ public class CollectionListInfo implements Parcelable {
      * still parsed to its nearest integer rather than discarded. Anything that
      * still can't be parsed (non-numeric text, values outside the long range)
      * falls back to 0.
+     * <p>
+     * This lenient behavior is required by its callers - the runtime flag getters and
+     * the {@code upgradeDbStructure} migration blocks - which read stored values and
+     * must never throw. Use {@link #parseImportedFlagString} on the import path instead.
      *
      * @param flagStr the flag string to parse
      * @return the parsed flag value, or 0 if the string is null/empty/invalid
      */
     public static long parseFlagString(String flagStr) {
+        Long value = parseFlagStringOrNull(flagStr);
+        return (value != null) ? value : 0L;
+    }
+
+    /**
+     * Parses a flag string on the import path, rejecting values that can't be recovered.
+     * <p>
+     * Unlike {@link #parseFlagString}, an unrecoverable value throws instead of quietly
+     * becoming 0, which would wipe the collection's mint mark / checkbox configuration
+     * without telling the user. Spreadsheet-mangled values still recover; only genuinely
+     * unparseable ones are rejected. A missing or empty value still means 0, which is the
+     * legitimate "no flags set" encoding.
+     *
+     * @param flagStr   the flag string to parse
+     * @param fieldName column name to report if the value is invalid
+     * @return the parsed flag value
+     * @throws ImportFormatException if the value is present but can't be parsed
+     */
+    static long parseImportedFlagString(String flagStr, String fieldName) throws ImportFormatException {
+        Long value = parseFlagStringOrNull(flagStr);
+        if (value == null) {
+            throw new ImportFormatException("Invalid " + fieldName + " value '" + flagStr + "'");
+        }
+        return value;
+    }
+
+    /**
+     * Shared flag-string parsing used by {@link #parseFlagString} and
+     * {@link #parseImportedFlagString}
+     *
+     * @param flagStr the flag string to parse
+     * @return the parsed value, 0 if the string is null/empty, or null if unrecoverable
+     */
+    private static Long parseFlagStringOrNull(String flagStr) {
         if (flagStr == null) {
             return 0L;
         }
@@ -373,7 +412,7 @@ public class CollectionListInfo implements Parcelable {
             // Handles "268435456.0" (exact) and "2.68435E+8" (best-effort, lossy)
             return new java.math.BigDecimal(trimmed).toBigInteger().longValueExact();
         } catch (NumberFormatException | ArithmeticException ignored) {
-            return 0L;
+            return null;
         }
     }
 
@@ -923,9 +962,11 @@ public class CollectionListInfo implements Parcelable {
      *
      * @param reader   JsonReader to read from
      * @param coinList List of coins with collection populated
-     * @throws IOException if an error occurred
+     * @throws IOException           if an error occurred
+     * @throws ImportFormatException if the coin type isn't recognized or a flag value
+     *                               can't be parsed
      */
-    public CollectionListInfo(JsonReader reader, ArrayList<CoinSlot> coinList) throws IOException {
+    public CollectionListInfo(JsonReader reader, ArrayList<CoinSlot> coinList) throws IOException, ImportFormatException {
 
         String collectionName = "";
         int totalCoinsCollected = 0;
@@ -935,7 +976,10 @@ public class CollectionListInfo implements Parcelable {
         int endYear = 0;
         String mintMarkFlags = "";
         String checkboxFlags = "";
-        int collectionTypeIndex = 0;
+        // -1 means "no recognized coin type seen yet"; validated after the read loop below
+        // since JSON member order isn't guaranteed
+        int collectionTypeIndex = -1;
+        String coinTypeName = null;
 
         reader.beginObject();
         while (reader.hasNext()) {
@@ -973,9 +1017,8 @@ public class CollectionListInfo implements Parcelable {
                     checkboxFlags = reader.nextString();
                     break;
                 case COL_COIN_TYPE:
-                    // If the coin type isn't recognized, an error occurred so just choose a safe value
-                    collectionTypeIndex = MainApplication.getIndexFromCollectionNameStr(reader.nextString());
-                    collectionTypeIndex = (collectionTypeIndex != -1) ? collectionTypeIndex : 0;
+                    coinTypeName = reader.nextString();
+                    collectionTypeIndex = MainApplication.getIndexFromCollectionNameStr(coinTypeName);
                     break;
                 case JSON_COIN_LIST:
                     // Since the coin list is stored inside of the same JSON object, we'll populate the
@@ -994,43 +1037,86 @@ public class CollectionListInfo implements Parcelable {
         }
         reader.endObject();
 
+        // An unrecognized coin type can't be imported - failing here is far better than
+        // silently turning the collection into the type at index 0
+        if (collectionTypeIndex == -1) {
+            throw new ImportFormatException("Unrecognized collection type '"
+                    + (coinTypeName != null ? coinTypeName : "") + "' for collection '"
+                    + collectionName + "'");
+        }
+
         mCollectionName = collectionName;
         mTotalCoinsCollected = totalCoinsCollected;
         mTotalCoinsInCollection = totalCoinsInCollection;
         mDisplayType = displayType;
         mStartYear = startYear;
         mEndYear = endYear;
-        mMintMarkFlags = Long.toString(parseFlagString(mintMarkFlags));
-        mCheckboxFlags = Long.toString(parseFlagString(checkboxFlags));
+        mMintMarkFlags = Long.toString(parseImportedFlagString(mintMarkFlags, COL_SHOW_MINT_MARKS));
+        mCheckboxFlags = Long.toString(parseImportedFlagString(checkboxFlags, COL_SHOW_CHECKBOXES));
         mCollectionTypeIndex = collectionTypeIndex;
         mCollectionInfo = MainApplication.COLLECTION_TYPES[mCollectionTypeIndex];
+    }
+
+    /**
+     * Parses an integer field from an imported string array
+     *
+     * @param in           input String[]
+     * @param index        string position
+     * @param defaultValue value to use if the field isn't present
+     * @return the parsed value
+     * @throws ImportFormatException if the field is present but isn't a valid integer
+     */
+    private static int parseIntOrThrow(String[] in, int index, int defaultValue) throws ImportFormatException {
+        if (in.length <= index || in[index].isEmpty()) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(in[index].trim());
+        } catch (NumberFormatException e) {
+            throw new ImportFormatException("Invalid numeric collection value '" + in[index]
+                    + "' at position " + index, e);
+        }
     }
 
     /**
      * Create a collection list info from imported string array
      *
      * @param in input String[]
+     * @throws ImportFormatException if the row can't be parsed
      */
-    public CollectionListInfo(String[] in) {
+    public CollectionListInfo(String[] in) throws ImportFormatException {
+
+        // Indices 0 through 3 are required for every supported export format version
+        if (in.length < 4) {
+            throw new ImportFormatException("Collection row has " + in.length
+                    + " columns, expected at least 4");
+        }
 
         // Strip out all bad characters.  They shouldn't be there anyway ;)
         mCollectionName = in[0].replace('[', ' ').replace(']', ' ');
-        mTotalCoinsCollected = Integer.parseInt(in[2]);
-        mTotalCoinsInCollection = Integer.parseInt(in[3]);
-        mDisplayType = (in.length > 4) ? Integer.parseInt(in[4]) : 0;
+        mTotalCoinsCollected = parseIntOrThrow(in, 2, 0);
+        mTotalCoinsInCollection = parseIntOrThrow(in, 3, 0);
+        mDisplayType = parseIntOrThrow(in, 4, 0);
 
         // If the properties below aren't present, they will be determined
         // using setCreationParametersFromCoinData()
-        mStartYear = (in.length > 5) ? Integer.parseInt(in[5]) : 0;
-        mEndYear = (in.length > 6) ? Integer.parseInt(in[6]) : 0;
-        int mintMarkFlagsLegacy = (in.length > 7) ? Integer.parseInt(in[7]) : 0;
-        int checkboxFlagsLegacy = (in.length > 8) ? Integer.parseInt(in[8]) : 0;
-        mMintMarkFlags = Long.toString(parseFlagString((in.length > 9) ? in[9] : Integer.toString(mintMarkFlagsLegacy)));
-        mCheckboxFlags = Long.toString(parseFlagString((in.length > 10) ? in[10] : Integer.toString(checkboxFlagsLegacy)));
+        mStartYear = parseIntOrThrow(in, 5, 0);
+        mEndYear = parseIntOrThrow(in, 6, 0);
+        int mintMarkFlagsLegacy = parseIntOrThrow(in, 7, 0);
+        int checkboxFlagsLegacy = parseIntOrThrow(in, 8, 0);
+        mMintMarkFlags = Long.toString(parseImportedFlagString(
+                (in.length > 9) ? in[9] : Integer.toString(mintMarkFlagsLegacy), COL_SHOW_MINT_MARKS));
+        mCheckboxFlags = Long.toString(parseImportedFlagString(
+                (in.length > 10) ? in[10] : Integer.toString(checkboxFlagsLegacy), COL_SHOW_CHECKBOXES));
 
-        // If the coin type isn't recognized, an error occurred so just choose a safe value
+        // An unrecognized coin type can't be imported - failing here is far better than
+        // silently turning the collection into the type at index 0
         int collectionTypeIndex = MainApplication.getIndexFromCollectionNameStr(in[1]);
-        mCollectionTypeIndex = (collectionTypeIndex != -1) ? collectionTypeIndex : 0;
+        if (collectionTypeIndex == -1) {
+            throw new ImportFormatException("Unrecognized collection type '" + in[1]
+                    + "' for collection '" + mCollectionName + "'");
+        }
+        mCollectionTypeIndex = collectionTypeIndex;
         mCollectionInfo = MainApplication.COLLECTION_TYPES[mCollectionTypeIndex];
     }
 

--- a/app/src/main/java/com/coincollection/DatabaseAdapter.java
+++ b/app/src/main/java/com/coincollection/DatabaseAdapter.java
@@ -121,6 +121,19 @@ public class DatabaseAdapter {
     }
 
     /**
+     * Runs a block of database work inside a transaction on this adapter's database
+     * <p>
+     * See {@link DatabaseHelper#runInTransaction(SQLiteDatabase, Runnable)} for the
+     * rollback and nesting semantics.
+     *
+     * @param work the work to run
+     * @throws SQLException if the work failed
+     */
+    public void runInTransaction(Runnable work) throws SQLException {
+        DatabaseHelper.runInTransaction(mDb, work);
+    }
+
+    /**
      * Returns whether a coinIdentifier and coinMint has been marked as collected in a given
      * collection.
      *
@@ -253,29 +266,31 @@ public class DatabaseAdapter {
      */
     public void createAndPopulateNewTable(CollectionListInfo collectionListInfo, int displayOrder, ArrayList<CoinSlot> coinData) throws SQLException {
 
-        // Actually make the table
-        String tableName = collectionListInfo.getName();
-        createCollectionTable(tableName);
+        runInTransaction(() -> {
+            // Actually make the table
+            String tableName = collectionListInfo.getName();
+            createCollectionTable(tableName);
 
-        // We have the list of identifiers, now set them correctly
-        if (coinData != null) {
-            for (CoinSlot coinSlot : coinData) {
-                addCoinSlotToCollection(coinSlot, tableName, false, 0);
+            // We have the list of identifiers, now set them correctly
+            if (coinData != null) {
+                for (CoinSlot coinSlot : coinData) {
+                    addCoinSlotToCollection(coinSlot, tableName, false, 0);
+                }
             }
-        }
 
-        // We also need to add the table to the list of tables
-        ContentValues values = new ContentValues();
-        values.put(COL_NAME, collectionListInfo.getName());
-        values.put(COL_COIN_TYPE, collectionListInfo.getType());
-        values.put(COL_TOTAL, collectionListInfo.getMax());
-        values.put(COL_DISPLAY_ORDER, displayOrder);
-        values.put(COL_DISPLAY, collectionListInfo.getDisplayType());
-        values.put(COL_START_YEAR, collectionListInfo.getStartYear());
-        values.put(COL_END_YEAR, collectionListInfo.getEndYear());
-        values.put(COL_SHOW_MINT_MARKS, collectionListInfo.getMintMarkFlags());
-        values.put(COL_SHOW_CHECKBOXES, collectionListInfo.getCheckboxFlags());
-        runSqlInsert(TBL_COLLECTION_INFO, values);
+            // We also need to add the table to the list of tables
+            ContentValues values = new ContentValues();
+            values.put(COL_NAME, collectionListInfo.getName());
+            values.put(COL_COIN_TYPE, collectionListInfo.getType());
+            values.put(COL_TOTAL, collectionListInfo.getMax());
+            values.put(COL_DISPLAY_ORDER, displayOrder);
+            values.put(COL_DISPLAY, collectionListInfo.getDisplayType());
+            values.put(COL_START_YEAR, collectionListInfo.getStartYear());
+            values.put(COL_END_YEAR, collectionListInfo.getEndYear());
+            values.put(COL_SHOW_MINT_MARKS, collectionListInfo.getMintMarkFlags());
+            values.put(COL_SHOW_CHECKBOXES, collectionListInfo.getCheckboxFlags());
+            runSqlInsert(TBL_COLLECTION_INFO, values);
+        });
     }
 
     /**
@@ -310,12 +325,45 @@ public class DatabaseAdapter {
     }
 
     /**
+     * Return the names of all of the defined collections
+     * <p>
+     * Unlike getAllTables(), this doesn't need the stored coin type to be recognized, so it
+     * also returns collections that getAllTables() would skip.
+     *
+     * @return list of collection names
+     */
+    public ArrayList<String> getAllCollectionNameList() {
+        ArrayList<String> names = new ArrayList<>();
+        Cursor cursor = getAllCollectionNames();
+        try {
+            if (cursor.moveToFirst()) {
+                do {
+                    names.add(cursor.getString(cursor.getColumnIndexOrThrow(COL_NAME)));
+                } while (cursor.moveToNext());
+            }
+        } finally {
+            cursor.close();
+        }
+        return names;
+    }
+
+    /**
      * Expose the dbHelper's onUpgrade method so we can call it manually when importing collections
      *
      * @param oldVersion the db version to upgrade from
      */
     void upgradeDbForImport(int oldVersion) {
         DatabaseHelper.upgradeDb(mDb, oldVersion, MainApplication.DATABASE_VERSION, true);
+    }
+
+    /**
+     * Check if a name is reserved for internal database use
+     *
+     * @param tableName The collection name
+     * @return true if the name can't be used for a collection
+     */
+    public boolean isReservedCollectionName(String tableName) {
+        return mReservedDbNames.contains(tableName);
     }
 
     /**
@@ -327,7 +375,7 @@ public class DatabaseAdapter {
     public int checkCollectionName(String tableName) {
 
         // Make sure the name isn't in the reserved list
-        if (mReservedDbNames.contains(tableName)) {
+        if (isReservedCollectionName(tableName)) {
             return R.string.collection_name_reserved;
         }
 
@@ -448,10 +496,23 @@ public class DatabaseAdapter {
     /**
      * Returns a list of all collections in the database
      *
+     * @param collectionListEntries List of CollectionListInfo to populate
      * @throws SQLException if a database error occurs
      */
     public void getAllTables(ArrayList<CollectionListInfo> collectionListEntries) throws SQLException {
-        DatabaseHelper.getAllTables(mDb, collectionListEntries, false);
+        DatabaseHelper.getAllTables(mDb, collectionListEntries, false, null);
+    }
+
+    /**
+     * Returns a list of all collections in the database
+     *
+     * @param collectionListEntries List of CollectionListInfo to populate
+     * @param skippedNames          if non-null, populated with the names of collections that
+     *                              were skipped because their coin type isn't recognized
+     * @throws SQLException if a database error occurs
+     */
+    public void getAllTables(ArrayList<CollectionListInfo> collectionListEntries, ArrayList<String> skippedNames) throws SQLException {
+        DatabaseHelper.getAllTables(mDb, collectionListEntries, false, skippedNames);
     }
 
     /**

--- a/app/src/main/java/com/coincollection/DatabaseHelper.java
+++ b/app/src/main/java/com/coincollection/DatabaseHelper.java
@@ -937,6 +937,21 @@ public class DatabaseHelper extends SQLiteOpenHelper {
      * @throws SQLException if a database error occurs
      */
     public static void getAllTables(SQLiteDatabase db, ArrayList<CollectionListInfo> collectionListEntries, boolean legacyOptions) throws SQLException {
+        getAllTables(db, collectionListEntries, legacyOptions, null);
+    }
+
+    /**
+     * Returns a list of all collections in the database
+     *
+     * @param db                    database
+     * @param collectionListEntries List of CollectionListInfo to populate
+     * @param legacyOptions         if true, uses the legacy mint marks / checkbox columns
+     * @param skippedNames          if non-null, populated with the names of collections that
+     *                              were skipped because their coin type isn't recognized
+     * @throws SQLException if a database error occurs
+     */
+    public static void getAllTables(SQLiteDatabase db, ArrayList<CollectionListInfo> collectionListEntries,
+                                    boolean legacyOptions, ArrayList<String> skippedNames) throws SQLException {
 
         // Get rid of the other items in the list (if any)
         collectionListEntries.clear();
@@ -946,36 +961,42 @@ public class DatabaseHelper extends SQLiteOpenHelper {
                 new String[]{COL_NAME, COL_COIN_TYPE, COL_TOTAL, COL_DISPLAY, COL_START_YEAR,
                         COL_END_YEAR, colShowMintMarks, colShowCheckboxes},
                 null, null, null, null, COL_DISPLAY_ORDER);
-        if (cursor.moveToFirst()) {
-            do {
-                String tableName = cursor.getString(cursor.getColumnIndexOrThrow(COL_NAME));
-                String coinType = cursor.getString(cursor.getColumnIndexOrThrow(COL_COIN_TYPE));
-                // Figure out what collection type maps to this
-                int index = MainApplication.getIndexFromCollectionNameStr(coinType);
-                if (index == -1) {
-                    cursor.close();
-                    throw new SQLException();
-                }
-                // Get the number of coins collected
-                int collected = fetchTotalCollected(db, tableName);
-                if (collected == -1) {
-                    cursor.close();
-                    throw new SQLException();
-                }
-                // Add it to the list of collections
-                collectionListEntries.add(new CollectionListInfo(
-                        tableName,
-                        cursor.getInt(cursor.getColumnIndexOrThrow(COL_TOTAL)),
-                        collected,
-                        index,
-                        cursor.getInt(cursor.getColumnIndexOrThrow(COL_DISPLAY)),
-                        cursor.getInt(cursor.getColumnIndexOrThrow(COL_START_YEAR)),
-                        cursor.getInt(cursor.getColumnIndexOrThrow(COL_END_YEAR)),
-                        cursor.getString(cursor.getColumnIndexOrThrow(colShowMintMarks)),
-                        cursor.getString(cursor.getColumnIndexOrThrow(colShowCheckboxes))));
-            } while (cursor.moveToNext());
+        try {
+            if (cursor.moveToFirst()) {
+                do {
+                    String tableName = cursor.getString(cursor.getColumnIndexOrThrow(COL_NAME));
+                    String coinType = cursor.getString(cursor.getColumnIndexOrThrow(COL_COIN_TYPE));
+                    // Figure out what collection type maps to this
+                    int index = MainApplication.getIndexFromCollectionNameStr(coinType);
+                    if (index == -1) {
+                        // An unrecognized coin type used to throw from here, which crash-looped
+                        // getWritableDatabase() when it happened during onUpgrade. Skip the row
+                        // instead so the rest of the user's collections remain usable.
+                        Log.e(APP_NAME, "Skipping collection '" + tableName
+                                + "' with unrecognized coin type '" + coinType + "'");
+                        if (skippedNames != null) {
+                            skippedNames.add(tableName);
+                        }
+                        continue;
+                    }
+                    // Get the number of coins collected
+                    int collected = fetchTotalCollected(db, tableName);
+                    // Add it to the list of collections
+                    collectionListEntries.add(new CollectionListInfo(
+                            tableName,
+                            cursor.getInt(cursor.getColumnIndexOrThrow(COL_TOTAL)),
+                            collected,
+                            index,
+                            cursor.getInt(cursor.getColumnIndexOrThrow(COL_DISPLAY)),
+                            cursor.getInt(cursor.getColumnIndexOrThrow(COL_START_YEAR)),
+                            cursor.getInt(cursor.getColumnIndexOrThrow(COL_END_YEAR)),
+                            cursor.getString(cursor.getColumnIndexOrThrow(colShowMintMarks)),
+                            cursor.getString(cursor.getColumnIndexOrThrow(colShowCheckboxes))));
+                } while (cursor.moveToNext());
+            }
+        } finally {
+            cursor.close();
         }
-        cursor.close();
     }
 
     /**
@@ -1007,27 +1028,29 @@ public class DatabaseHelper extends SQLiteOpenHelper {
      * @throws SQLException if a database error occurs
      */
     public static void updateCoinList(SQLiteDatabase db, String tableName, ArrayList<CoinSlot> coinData, boolean updateTotal) throws SQLException {
-        runSqlDelete(db, tableName, "1", null);
-        for (CoinSlot coinSlot : coinData) {
-            ContentValues values = new ContentValues();
-            values.put(COL_COIN_IDENTIFIER, coinSlot.getIdentifier());
-            values.put(COL_COIN_MINT, coinSlot.getMint());
-            values.put(COL_IN_COLLECTION, coinSlot.isInCollectionInt());
-            values.put(COL_ADV_GRADE_INDEX, coinSlot.getAdvancedGrades());
-            values.put(COL_ADV_QUANTITY_INDEX, coinSlot.getAdvancedQuantities());
-            values.put(COL_ADV_NOTES, coinSlot.getAdvancedNotes());
-            values.put(COL_SORT_ORDER, coinSlot.getSortOrder());
-            values.put(COL_CUSTOM_COIN, coinSlot.isCustomCoin());
-            values.put(COL_IMAGE_ID, coinSlot.getImageId());
-            coinSlot.setDatabaseId(runSqlInsert(db, tableName, values));
-        }
+        runInTransaction(db, () -> {
+            runSqlDelete(db, tableName, "1", null);
+            for (CoinSlot coinSlot : coinData) {
+                ContentValues values = new ContentValues();
+                values.put(COL_COIN_IDENTIFIER, coinSlot.getIdentifier());
+                values.put(COL_COIN_MINT, coinSlot.getMint());
+                values.put(COL_IN_COLLECTION, coinSlot.isInCollectionInt());
+                values.put(COL_ADV_GRADE_INDEX, coinSlot.getAdvancedGrades());
+                values.put(COL_ADV_QUANTITY_INDEX, coinSlot.getAdvancedQuantities());
+                values.put(COL_ADV_NOTES, coinSlot.getAdvancedNotes());
+                values.put(COL_SORT_ORDER, coinSlot.getSortOrder());
+                values.put(COL_CUSTOM_COIN, coinSlot.isCustomCoin());
+                values.put(COL_IMAGE_ID, coinSlot.getImageId());
+                coinSlot.setDatabaseId(runSqlInsert(db, tableName, values));
+            }
 
-        // Update the collection total if needed
-        if (updateTotal) {
-            ContentValues values = new ContentValues();
-            values.put(COL_TOTAL, coinData.size());
-            runSqlUpdate(db, TBL_COLLECTION_INFO, values, COL_NAME + "=?", new String[]{tableName});
-        }
+            // Update the collection total if needed
+            if (updateTotal) {
+                ContentValues values = new ContentValues();
+                values.put(COL_TOTAL, coinData.size());
+                runSqlUpdate(db, TBL_COLLECTION_INFO, values, COL_NAME + "=?", new String[]{tableName});
+            }
+        });
     }
 
     /**
@@ -1123,6 +1146,30 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     }
 
     /**
+     * Runs a block of database work inside a transaction.
+     * <p>
+     * The transaction is committed only if the work completes normally. If it throws, the
+     * transaction is rolled back and the exception propagates. The transaction is always
+     * ended, so an open transaction can't leak.
+     * <p>
+     * Note: SQLiteDatabase transactions are reference-counted, so it is safe to call this
+     * from work that is already running inside an outer transaction. If an inner
+     * transaction is not marked successful, the entire outer transaction is rolled back.
+     *
+     * @param db   the database
+     * @param work the work to run
+     */
+    public static void runInTransaction(SQLiteDatabase db, Runnable work) {
+        db.beginTransaction();
+        try {
+            work.run();
+            db.setTransactionSuccessful();
+        } finally {
+            db.endTransaction();
+        }
+    }
+
+    /**
      * Remove duplicate coins from a collection table for specific identifiers. For each
      * (coinIdentifier, coinMint) group of non-custom coins whose identifier is in the
      * provided list and that has more than one row, keeps the row with the lowest _id
@@ -1139,61 +1186,63 @@ public class DatabaseHelper extends SQLiteOpenHelper {
                                                        CollectionListInfo collectionListInfo,
                                                        ArrayList<String> identifiers) {
         String safeTable = DatabaseAdapter.removeBrackets(collectionListInfo.getName());
-        int totalRemoved = 0;
+        int[] totalRemoved = new int[]{0};
 
-        for (String identifier : identifiers) {
-            // Find all mint variants with duplicates for this identifier among non-custom coins
-            Cursor dupCursor = db.rawQuery(
-                    "SELECT " + COL_COIN_MINT
-                            + " FROM [" + safeTable + "]"
-                            + " WHERE " + COL_COIN_IDENTIFIER + "=?"
-                            + " AND " + COL_CUSTOM_COIN + " = 0"
-                            + " GROUP BY " + COL_COIN_MINT
-                            + " HAVING COUNT(*) > 1",
-                    new String[]{identifier});
+        runInTransaction(db, () -> {
+            for (String identifier : identifiers) {
+                // Find all mint variants with duplicates for this identifier among non-custom coins
+                Cursor dupCursor = db.rawQuery(
+                        "SELECT " + COL_COIN_MINT
+                                + " FROM [" + safeTable + "]"
+                                + " WHERE " + COL_COIN_IDENTIFIER + "=?"
+                                + " AND " + COL_CUSTOM_COIN + " = 0"
+                                + " GROUP BY " + COL_COIN_MINT
+                                + " HAVING COUNT(*) > 1",
+                        new String[]{identifier});
 
-            if (dupCursor.moveToFirst()) {
-                do {
-                    String mint = dupCursor.getString(0);
+                if (dupCursor.moveToFirst()) {
+                    do {
+                        String mint = dupCursor.getString(0);
 
-                    // Get non-custom rows for this group, ordered by _id so the original is first
-                    Cursor rowCursor = db.rawQuery(
-                            "SELECT " + COL_COIN_ID + ", " + COL_IN_COLLECTION
-                                    + " FROM [" + safeTable + "]"
-                                    + " WHERE " + COL_COIN_IDENTIFIER + "=? AND " + COL_COIN_MINT + "=?"
-                                    + " AND " + COL_CUSTOM_COIN + " = 0"
-                                    + " ORDER BY " + COL_COIN_ID + " ASC",
-                            new String[]{identifier, mint != null ? mint : ""});
+                        // Get non-custom rows for this group, ordered by _id so the original is first
+                        Cursor rowCursor = db.rawQuery(
+                                "SELECT " + COL_COIN_ID + ", " + COL_IN_COLLECTION
+                                        + " FROM [" + safeTable + "]"
+                                        + " WHERE " + COL_COIN_IDENTIFIER + "=? AND " + COL_COIN_MINT + "=?"
+                                        + " AND " + COL_CUSTOM_COIN + " = 0"
+                                        + " ORDER BY " + COL_COIN_ID + " ASC",
+                                new String[]{identifier, mint != null ? mint : ""});
 
-                    if (rowCursor.moveToFirst()) {
-                        int keepId = rowCursor.getInt(0);
-                        boolean anyCollected = rowCursor.getInt(1) == 1;
+                        if (rowCursor.moveToFirst()) {
+                            int keepId = rowCursor.getInt(0);
+                            boolean anyCollected = rowCursor.getInt(1) == 1;
 
-                        // Check remaining rows for collected status and delete them
-                        while (rowCursor.moveToNext()) {
-                            if (rowCursor.getInt(1) == 1) {
-                                anyCollected = true;
+                            // Check remaining rows for collected status and delete them
+                            while (rowCursor.moveToNext()) {
+                                if (rowCursor.getInt(1) == 1) {
+                                    anyCollected = true;
+                                }
+                                int idToDelete = rowCursor.getInt(0);
+                                db.delete("[" + safeTable + "]", COL_COIN_ID + "=?",
+                                        new String[]{String.valueOf(idToDelete)});
+                                totalRemoved[0]++;
                             }
-                            int idToDelete = rowCursor.getInt(0);
-                            db.delete("[" + safeTable + "]", COL_COIN_ID + "=?",
-                                    new String[]{String.valueOf(idToDelete)});
-                            totalRemoved++;
-                        }
 
-                        // If any duplicate was collected, mark the kept row as collected
-                        if (anyCollected) {
-                            ContentValues values = new ContentValues();
-                            values.put(COL_IN_COLLECTION, 1);
-                            db.update("[" + safeTable + "]", values, COL_COIN_ID + "=?",
-                                    new String[]{String.valueOf(keepId)});
+                            // If any duplicate was collected, mark the kept row as collected
+                            if (anyCollected) {
+                                ContentValues values = new ContentValues();
+                                values.put(COL_IN_COLLECTION, 1);
+                                db.update("[" + safeTable + "]", values, COL_COIN_ID + "=?",
+                                        new String[]{String.valueOf(keepId)});
+                            }
                         }
-                    }
-                    rowCursor.close();
-                } while (dupCursor.moveToNext());
+                        rowCursor.close();
+                    } while (dupCursor.moveToNext());
+                }
+                dupCursor.close();
             }
-            dupCursor.close();
-        }
+        });
 
-        return totalRemoved;
+        return totalRemoved[0];
     }
 }

--- a/app/src/main/java/com/coincollection/ExportImportHelper.java
+++ b/app/src/main/java/com/coincollection/ExportImportHelper.java
@@ -36,14 +36,17 @@ import com.spencerpages.MainApplication;
 import com.spencerpages.R;
 
 import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Locale;
 
 public class ExportImportHelper {
 
@@ -136,6 +139,8 @@ public class ExportImportHelper {
             }
         } catch (IOException | CsvValidationException ignored) {
             return mRes.getString(R.string.error_open_file_reading, inputFile.getAbsolutePath());
+        } catch (NumberFormatException ignored) {
+            return mRes.getString(R.string.error_reading_file, inputFile.getAbsolutePath());
         }
 
         // Read the collection_info table
@@ -147,6 +152,8 @@ public class ExportImportHelper {
             }
         } catch (IOException | CsvValidationException ignored) {
             return mRes.getString(R.string.error_open_file_reading, inputFile.getAbsolutePath());
+        } catch (ImportFormatException | NumberFormatException | IndexOutOfBoundsException e) {
+            return mRes.getString(R.string.error_importing, e.getMessage());
         }
 
         // We loaded in the collection "metadata" table, so now load in each collection
@@ -175,6 +182,10 @@ public class ExportImportHelper {
             } catch (IOException | CsvValidationException ignored) {
                 collectionErrorMessages.add(mRes.getString(R.string.error_open_file_reading, inputFile.getAbsolutePath()));
                 continue;
+            } catch (ImportFormatException | NumberFormatException | IndexOutOfBoundsException e) {
+                collectionErrorMessages.add(mRes.getString(R.string.error_reading_file,
+                        inputFile.getAbsolutePath() + " - " + e.getMessage()));
+                continue;
             }
             importedCollectionContents.add(collectionContent);
         }
@@ -185,7 +196,7 @@ public class ExportImportHelper {
             for (String message : collectionErrorMessages) {
                 problems.append("\n").append(message);
             }
-            return mRes.getString(R.string.error_exporting_collections, problems.toString());
+            return mRes.getString(R.string.error_importing_collections, problems.toString());
         }
 
         // All data has been parsed from CSV files so perform the DB steps to import
@@ -321,7 +332,8 @@ public class ExportImportHelper {
             // All data has been parsed from CSV files so perform the DB steps to import
             return updateDatabaseFromImport(importDatabaseVersion, importedCollectionInfoList,
                     importedCollectionContents);
-        } catch (IOException e) {
+        } catch (IOException | ImportFormatException | NumberFormatException
+                 | IndexOutOfBoundsException | IllegalStateException e) {
             return mRes.getString(R.string.error_importing, e.getMessage());
         }
     }
@@ -338,41 +350,92 @@ public class ExportImportHelper {
                                             ArrayList<CollectionListInfo> importedCollectionInfoList,
                                             ArrayList<ArrayList<CoinSlot>> importedCollectionContents) {
 
-        // Drop existing tables
-        ArrayList<CollectionListInfo> existingCollections = new ArrayList<>();
-        mDbAdapter.getAllTables(existingCollections);
-        for (int i = 0; i < existingCollections.size(); i++) {
-            CollectionListInfo info = existingCollections.get(i);
-            mDbAdapter.dropCollectionTable(info.getName());
+        // Pass 1: validate everything before touching the database, so that a bad import
+        // file can't destroy the user's existing collections
+        String validationError = validateImportData(importDatabaseVersion, importedCollectionInfoList,
+                importedCollectionContents);
+        if (!validationError.isEmpty()) {
+            return validationError;
         }
-        mDbAdapter.dropCollectionInfoTable();
 
-        // Take the data we've stored and replace what's in the database with it
+        // Pass 2: replace the database contents inside a single transaction. If anything
+        // fails the transaction is rolled back and the pre-import database is restored.
         try {
-            // Add new collections
-            mDbAdapter.createCollectionInfoTable();
-            for (int i = 0; i < importedCollectionInfoList.size(); i++) {
-                CollectionListInfo collectionListInfo = importedCollectionInfoList.get(i);
-                ArrayList<CoinSlot> collectionContent = importedCollectionContents.get(i);
-
-                // Check for duplicate or illegal names
-                int checkName = mDbAdapter.checkCollectionName(collectionListInfo.getName());
-                if (checkName != -1) {
-                    return mRes.getString(R.string.error_import);
+            mDbAdapter.runInTransaction(() -> {
+                // Drop existing tables. Names come straight from collection_info rather than
+                // getAllTables() so that a collection whose coin type isn't recognized is
+                // still dropped instead of being left behind as an orphan table.
+                for (String existingName : mDbAdapter.getAllCollectionNameList()) {
+                    mDbAdapter.dropCollectionTable(existingName);
                 }
-                mDbAdapter.createAndPopulateNewTable(collectionListInfo, i, collectionContent);
-            }
+                mDbAdapter.dropCollectionInfoTable();
 
-            // Update any imported tables, if necessary
-            if (importDatabaseVersion != MainApplication.DATABASE_VERSION) {
-                mDbAdapter.upgradeDbForImport(importDatabaseVersion);
-            }
+                // Add new collections
+                mDbAdapter.createCollectionInfoTable();
+                for (int i = 0; i < importedCollectionInfoList.size(); i++) {
+                    mDbAdapter.createAndPopulateNewTable(importedCollectionInfoList.get(i), i,
+                            importedCollectionContents.get(i));
+                }
+
+                // Update any imported tables, if necessary. This must run inside the same
+                // transaction, otherwise a failed upgrade would leave a half-imported database.
+                if (importDatabaseVersion != MainApplication.DATABASE_VERSION) {
+                    mDbAdapter.upgradeDbForImport(importDatabaseVersion);
+                }
+            });
         } catch (SQLException e) {
             // Report an import error message to display on the UI thread
             return mRes.getString(R.string.error_import);
         }
 
         // Success!
+        return "";
+    }
+
+    /**
+     * Validates imported data before any database changes are made
+     *
+     * @param importDatabaseVersion      imported database version
+     * @param importedCollectionInfoList imported list of CollectionListInfo
+     * @param importedCollectionContents imported list of coins
+     * @return "" if the data is valid, otherwise an error string
+     */
+    private String validateImportData(int importDatabaseVersion,
+                                      ArrayList<CollectionListInfo> importedCollectionInfoList,
+                                      ArrayList<ArrayList<CoinSlot>> importedCollectionContents) {
+
+        // Every collection must have a matching (possibly empty) coin list
+        if (importedCollectionInfoList.size() != importedCollectionContents.size()) {
+            return mRes.getString(R.string.error_import);
+        }
+
+        // A database version from a newer app release can't be imported, and a missing or
+        // nonsensical version means the file isn't a valid export
+        if (importDatabaseVersion <= 0 || importDatabaseVersion > MainApplication.DATABASE_VERSION) {
+            return mRes.getString(R.string.error_import_db_version,
+                    String.valueOf(importDatabaseVersion),
+                    String.valueOf(MainApplication.DATABASE_VERSION));
+        }
+
+        // Note: names that match existing collections are allowed - importing intentionally
+        // replaces the entire database, so the export/import round trip must keep working
+        Locale defaultLocale = Locale.getDefault();
+        HashSet<String> importedNames = new HashSet<>();
+        for (CollectionListInfo collectionListInfo : importedCollectionInfoList) {
+            String name = collectionListInfo.getName();
+            if (name == null || name.isEmpty()) {
+                return mRes.getString(R.string.error_import_collection_name_empty);
+            }
+            if (name.contains("[") || name.contains("]")) {
+                return mRes.getString(R.string.error_import_collection_name_invalid, name);
+            }
+            if (mDbAdapter.isReservedCollectionName(name)) {
+                return mRes.getString(R.string.error_import_collection_name_reserved, name);
+            }
+            if (!importedNames.add(name.toLowerCase(defaultLocale))) {
+                return mRes.getString(R.string.error_import_collection_name_duplicate, name);
+            }
+        }
         return "";
     }
 
@@ -420,7 +483,8 @@ public class ExportImportHelper {
         // (otherwise, '\' is the escape character, and it can be
         // typed by users!)
         CSVParser parser = new CSVParserBuilder().withEscapeChar('\0').build();
-        CSVReader csvReader = new CSVReaderBuilder(new FileReader(inputFile))
+        CSVReader csvReader = new CSVReaderBuilder(
+                new InputStreamReader(new FileInputStream(inputFile), StandardCharsets.UTF_8))
                 .withCSVParser(parser).build();
 
         ArrayList<String[]> lineList = new ArrayList<>();
@@ -440,7 +504,8 @@ public class ExportImportHelper {
      * @throws IOException if an error occurs
      */
     private void writeToLegacyCsv(File file, ArrayList<String[]> contents) throws IOException {
-        CSVWriter csvWriter = new CSVWriter(new FileWriter(file));
+        CSVWriter csvWriter = new CSVWriter(
+                new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8));
         for (String[] fileLine : contents) {
             csvWriter.writeNext(fileLine);
         }
@@ -468,7 +533,8 @@ public class ExportImportHelper {
         // character to effectively allow no escape characters
         // (otherwise, '\' is the escape character, and it can be
         // typed by users!)
-        try (CSVReader csvReader = new CSVReaderBuilder(new InputStreamReader(inputStream))
+        try (CSVReader csvReader = new CSVReaderBuilder(
+                new InputStreamReader(inputStream, StandardCharsets.UTF_8))
                     .withCSVParser(new CSVParserBuilder().withEscapeChar('\0').build()).build()) {
 
             while (null != (lineValues = csvReader.readNext())) {
@@ -476,19 +542,14 @@ public class ExportImportHelper {
                 if (lineValues.length == 0) {
                     // Ignore empty lines
                     continue;
-                } else if ((lineValues.length >= 2) && lineValues[0].equals(CSV_SEPARATOR)) {
-                    // Look for CSV separators which we're using to put multiple files in a single CSV
-                    // Make sure any cells following '-----', 'section' are blank, to avoid possible data row
-                    boolean foundNonEmptyCell = false;
-                    for (int i = 2; i < lineValues.length; i++) {
-                        if (!lineValues[i].isEmpty()) {
-                            foundNonEmptyCell = true;
-                            break;
-                        }
-                    }
-                    if (foundNonEmptyCell) {
-                        continue;
-                    }
+                }
+
+                // Look for CSV separators which we're using to put multiple files in a single CSV.
+                // A row only counts as a separator when it names a known section and any cells
+                // following '-----', 'section' are blank - otherwise it's a data row.
+                if ((lineValues.length >= 2) && lineValues[0].equals(CSV_SEPARATOR)
+                        && (SectionType.fromLabel(lineValues[1]) != SectionType.UNKNOWN)
+                        && !hasNonEmptyCellFrom(lineValues, 2)) {
                     currSectionType = SectionType.fromLabel(lineValues[1]);
                     coinIndex = 0;
                     if (currSectionType != SectionType.DATABASE_VERSION) {
@@ -500,7 +561,7 @@ public class ExportImportHelper {
 
                 switch (currSectionType) {
                     case DATABASE_VERSION:
-                        importDatabaseVersion = Integer.parseInt(lineValues[0]);
+                        importDatabaseVersion = Integer.parseInt(lineValues[0].trim());
                         break;
                     case COLLECTIONS:
                         importedCollectionInfoList.add(new CollectionListInfo(lineValues));
@@ -508,19 +569,40 @@ public class ExportImportHelper {
                         importedCollectionContents.add(currCoinList);
                         break;
                     case COIN_LIST:
+                        if (importedCollectionInfoList.isEmpty()) {
+                            return mRes.getString(R.string.error_importing,
+                                    mRes.getString(R.string.error_import_coin_without_collection));
+                        }
                         currCoinList.add(new CoinSlot(lineValues, coinIndex++));
                         break;
                     default:
                         break;
                 }
             }
-        } catch (IOException | CsvValidationException e) {
+        } catch (IOException | CsvValidationException | ImportFormatException
+                 | NumberFormatException | IndexOutOfBoundsException e) {
             return mRes.getString(R.string.error_importing, e.getMessage());
         }
 
         // All data has been parsed from the CSV file so perform the DB steps to import
         return updateDatabaseFromImport(importDatabaseVersion, importedCollectionInfoList,
                 importedCollectionContents);
+    }
+
+    /**
+     * Returns true if any cell at or after the given index is non-empty
+     *
+     * @param lineValues CSV row
+     * @param startIndex index to start checking from
+     * @return true if a non-empty cell was found
+     */
+    private static boolean hasNonEmptyCellFrom(String[] lineValues, int startIndex) {
+        for (int i = startIndex; i < lineValues.length; i++) {
+            if (!lineValues[i].isEmpty()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -536,7 +618,8 @@ public class ExportImportHelper {
         ArrayList<CollectionListInfo> collectionListEntries = new ArrayList<>();
         mDbAdapter.getAllTables(collectionListEntries);
 
-        try (CSVWriter csvWriter = new CSVWriter(new OutputStreamWriter(outputStream))) {
+        try (CSVWriter csvWriter = new CSVWriter(
+                new OutputStreamWriter(outputStream, StandardCharsets.UTF_8))) {
 
             // Write database version
             csvWriter.writeNext(new String[]{CSV_SEPARATOR, SectionType.DATABASE_VERSION.label});

--- a/app/src/main/java/com/coincollection/ImportFormatException.java
+++ b/app/src/main/java/com/coincollection/ImportFormatException.java
@@ -1,0 +1,39 @@
+/*
+ * Coin Collection, an Android app that helps users track the coins that they've collected
+ * Copyright (C) 2010-2016 Andrew Williams
+ *
+ * This file is part of Coin Collection.
+ *
+ * Coin Collection is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Coin Collection is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Coin Collection.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.coincollection;
+
+/**
+ * Thrown when an import file can't be parsed into valid collection data.
+ * <p>
+ * This is a checked exception on purpose: the import entry points must handle it
+ * and turn it into a user-facing error string rather than letting a malformed
+ * file crash the app or, worse, silently import mangled data.
+ */
+public class ImportFormatException extends Exception {
+
+    public ImportFormatException(String message) {
+        super(message);
+    }
+
+    public ImportFormatException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/app/src/main/java/com/coincollection/MainActivity.java
+++ b/app/src/main/java/com/coincollection/MainActivity.java
@@ -28,6 +28,7 @@ import static com.spencerpages.MainApplication.APP_NAME;
 import android.Manifest;
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -81,6 +82,10 @@ public class MainActivity extends BaseActivity {
 
     // The number of actual collections in mCollectionListEntries
     public int mNumberOfCollections = 0;
+
+    // Tracks whether the "unknown collection type" warning has already been shown, so that
+    // it appears at most once per activity instance instead of on every list refresh
+    private boolean mShownUnknownTypeWarning = false;
 
     // Import/export task inputs live in mActivityViewModel.mTaskRequest (not in
     // activity fields) so they survive configuration changes while a task runs
@@ -293,6 +298,10 @@ public class MainActivity extends BaseActivity {
                         return mRes.getString(R.string.error_importing,
                                 mRes.getString(R.string.error_no_file_selected));
                     }
+                    if (!isSafeDocumentUri(fileUri)) {
+                        return mRes.getString(R.string.error_importing,
+                                mRes.getString(R.string.error_unsupported_file_location));
+                    }
                     try (InputStream inputStream = getContentResolver().openInputStream(fileUri)) {
                         String fileName = getFileNameFromUri(fileUri);
                         if (fileName.endsWith(".csv")) {
@@ -314,6 +323,10 @@ public class MainActivity extends BaseActivity {
                     if (fileUri == null) {
                         return mRes.getString(R.string.error_exporting,
                                 mRes.getString(R.string.error_no_file_selected));
+                    }
+                    if (!isSafeDocumentUri(fileUri)) {
+                        return mRes.getString(R.string.error_exporting,
+                                mRes.getString(R.string.error_unsupported_file_location));
                     }
                     try (OutputStream outputStream = getContentResolver().openOutputStream(fileUri)) {
                         String fileName = getFileNameFromUri(fileUri);
@@ -708,10 +721,22 @@ public class MainActivity extends BaseActivity {
     public void updateCollectionListFromDatabase() {
 
         //Get a list of all the database tables
+        ArrayList<String> skippedCollections = new ArrayList<>();
         try {
-            mDbAdapter.getAllTables(mCollectionListEntries);
+            mDbAdapter.getAllTables(mCollectionListEntries, skippedCollections);
         } catch (SQLException e) {
             showCancelableAlert(mRes.getString(R.string.error_reading_database));
+        }
+
+        // Let the user know once if any collections couldn't be loaded, instead of
+        // silently dropping them from the list
+        if (!skippedCollections.isEmpty() && !mShownUnknownTypeWarning) {
+            mShownUnknownTypeWarning = true;
+            StringBuilder names = new StringBuilder();
+            for (String name : skippedCollections) {
+                names.append("\n").append(name);
+            }
+            showCancelableAlert(mRes.getString(R.string.warning_unknown_collection_types, names.toString()));
         }
 
         // Record the actual number of collections before spacers are added
@@ -945,6 +970,28 @@ public class MainActivity extends BaseActivity {
     public String getLegacyExportFolderName() {
         File sdCard = Environment.getExternalStorageDirectory();
         return sdCard.getAbsolutePath() + LEGACY_EXPORT_FOLDER_NAME;
+    }
+
+    /**
+     * Checks that a URI handed back by the system file picker is one we're willing to
+     * resolve. The SAF picker only ever returns content:// URIs, so anything else (in
+     * particular file:// URIs, or content URIs served by this app's own provider) is
+     * rejected rather than being read from or written to the app's private storage.
+     *
+     * @param uri uri to check
+     * @return true if the uri is safe to resolve
+     */
+    private boolean isSafeDocumentUri(Uri uri) {
+        if (!ContentResolver.SCHEME_CONTENT.equals(uri.getScheme())) {
+            return false;
+        }
+        String authority = uri.getAuthority();
+        if (authority == null || authority.isEmpty()) {
+            return false;
+        }
+        // Reject content providers exported by this app, which would resolve into our
+        // own private storage rather than a user-chosen document
+        return !authority.equals(getPackageName()) && !authority.startsWith(getPackageName() + ".");
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -312,11 +312,19 @@
     <string name="export_canceled">Export canceled - storage write permission request denied</string>
     <string name="collection_name_reserved">Collection name is reserved, please choose a different name</string>
     <string name="collection_name_exists">A collection with this name already exists, please choose a different name</string>
-    <string name="error_exporting_collections">The following collections could not be exported due to errors:%1$s</string>
     <string name="error_exporting">Could not export collections (%1$s)</string>
     <string name="error_importing">Could not import collections (%1$s)</string>
     <string name="error_no_file_selected">no file was selected</string>
     <string name="error_no_file_manager">No app found to open files. Please install a file manager to import collections</string>
+    <string name="error_importing_collections">The following collections could not be imported due to errors:%1$s</string>
+    <string name="error_import_db_version">The import file\'s database version (%1$s) isn\'t supported by this app, which supports up to version %2$s. The file may have been created by a newer version of the app.</string>
+    <string name="error_import_collection_name_empty">The import file contains a collection with no name</string>
+    <string name="error_import_collection_name_invalid">The import file contains an invalid collection name: \'%1$s\'</string>
+    <string name="error_import_collection_name_reserved">The import file uses a reserved collection name: \'%1$s\'</string>
+    <string name="error_import_collection_name_duplicate">The import file contains more than one collection named \'%1$s\'</string>
+    <string name="error_import_coin_without_collection">a coin was listed before any collection</string>
+    <string name="error_unsupported_file_location">the selected file location isn\'t supported</string>
+    <string name="warning_unknown_collection_types">The following collections use an unknown coin type and can\'t be shown. They may have been created by a newer version of the app:%1$s</string>
 
     <!-- Reorder Collections Page -->
     <string name="changes_saved">Saved changes successfully</string>

--- a/app/src/test/java/com/coincollection/CollectionListInfoFlagParsingTests.java
+++ b/app/src/test/java/com/coincollection/CollectionListInfoFlagParsingTests.java
@@ -100,10 +100,10 @@ public class CollectionListInfoFlagParsingTests {
      * database and the user's configuration is preserved where possible.
      */
     @Test
-    public void stringArrayConstructor_recoversMangledFlags() {
+    public void stringArrayConstructor_recoversMangledFlags() throws ImportFormatException {
         String[] in = new String[]{
                 "Test Collection", // 0 name
-                "Lincoln Cents",   // 1 coin type
+                "Pennies",         // 1 coin type
                 "0",               // 2 collected
                 "0",               // 3 total
                 "0",               // 4 display

--- a/app/src/test/java/com/spencerpages/ExportImportErrorTests.java
+++ b/app/src/test/java/com/spencerpages/ExportImportErrorTests.java
@@ -1,0 +1,766 @@
+/*
+ * Coin Collection, an Android app that helps users track the coins that they've collected
+ * Copyright (C) 2010-2016 Andrew Williams
+ *
+ * This file is part of Coin Collection.
+ *
+ * Coin Collection is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Coin Collection is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Coin Collection.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.spencerpages;
+
+import static com.coincollection.CollectionListInfo.COL_COIN_TYPE;
+import static com.coincollection.CollectionListInfo.COL_DISPLAY;
+import static com.coincollection.CollectionListInfo.COL_END_YEAR;
+import static com.coincollection.CollectionListInfo.COL_NAME;
+import static com.coincollection.CollectionListInfo.COL_SHOW_CHECKBOXES;
+import static com.coincollection.CollectionListInfo.COL_SHOW_MINT_MARKS;
+import static com.coincollection.CollectionListInfo.COL_START_YEAR;
+import static com.coincollection.CollectionListInfo.COL_TOTAL;
+import static com.coincollection.CollectionListInfo.TBL_COLLECTION_INFO;
+import static com.coincollection.ExportImportHelper.CSV_SEPARATOR;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.content.ContentValues;
+import android.content.Intent;
+import android.database.sqlite.SQLiteDatabase;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.core.app.ApplicationProvider;
+
+import com.coincollection.CoinSlot;
+import com.coincollection.CollectionListInfo;
+import com.coincollection.DatabaseAdapter;
+import com.coincollection.DatabaseHelper;
+import com.coincollection.ExportImportHelper;
+import com.coincollection.MainActivity;
+import com.spencerpages.collections.LincolnCents;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+/**
+ * Negative-path tests for import. Every case must return a non-empty error string
+ * and leave the pre-existing database completely untouched.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class ExportImportErrorTests extends BaseTestCase {
+
+    private static final String COLLECTION_A = "Collection A";
+    private static final String COLLECTION_B = "Collection B";
+
+    /**
+     * Snapshot of the database contents, used to prove that a failed import changed nothing
+     */
+    private static class DbSnapshot {
+        final ArrayList<String> names;
+        final ArrayList<ArrayList<CoinSlot>> coinLists;
+
+        DbSnapshot(ArrayList<String> names, ArrayList<ArrayList<CoinSlot>> coinLists) {
+            this.names = names;
+            this.coinLists = coinLists;
+        }
+    }
+
+    /**
+     * Populate the database with two known collections
+     *
+     * @param activity test activity
+     */
+    private void setupTwoCollections(MainActivity activity) {
+        ArrayList<String> names = new ArrayList<>(Arrays.asList(COLLECTION_A, COLLECTION_B));
+        assertTrue(setupCollectionsWithNames(activity, names));
+    }
+
+    /**
+     * Take a snapshot of every collection and its coins
+     *
+     * @param activity test activity
+     * @return snapshot of the database contents
+     */
+    private DbSnapshot snapshotDb(MainActivity activity) {
+        ArrayList<String> names = getCollectionNames(activity);
+        return new DbSnapshot(names, getCoinSlotListsFromCollectionNames(activity.mDbAdapter, names));
+    }
+
+    /**
+     * Assert that the database still matches a previously taken snapshot
+     *
+     * @param activity test activity
+     * @param before   snapshot taken before the failed import
+     */
+    private void assertDbUnchanged(MainActivity activity, DbSnapshot before) {
+        DbSnapshot after = snapshotDb(activity);
+        assertEquals(before.names, after.names);
+        compareListOfCoinSlotLists(before.coinLists, after.coinLists, true);
+    }
+
+    /**
+     * Run a single-file CSV import from an in-memory string
+     *
+     * @param activity test activity
+     * @param contents CSV file contents
+     * @return the import result string
+     */
+    private String importCsv(MainActivity activity, String contents) {
+        ExportImportHelper helper = new ExportImportHelper(activity.mRes, activity.mDbAdapter);
+        InputStream inputStream = new ByteArrayInputStream(contents.getBytes(StandardCharsets.UTF_8));
+        String result = helper.importCollectionsFromSingleCSV(inputStream);
+        closeStream(inputStream);
+        return result;
+    }
+
+    /**
+     * Run a JSON import from an in-memory string
+     *
+     * @param activity test activity
+     * @param contents JSON file contents
+     * @return the import result string
+     */
+    private String importJson(MainActivity activity, String contents) {
+        ExportImportHelper helper = new ExportImportHelper(activity.mRes, activity.mDbAdapter);
+        InputStream inputStream = new ByteArrayInputStream(contents.getBytes(StandardCharsets.UTF_8));
+        String result = helper.importCollectionsFromJson(inputStream);
+        closeStream(inputStream);
+        return result;
+    }
+
+    /**
+     * Build the header rows shared by every valid CSV import file
+     *
+     * @param databaseVersion database version to declare in the file
+     * @return the start of a CSV import file
+     */
+    private String csvHeader(int databaseVersion) {
+        return CSV_SEPARATOR + "," + ExportImportHelper.JSON_DB_VERSION + "\n"
+                + databaseVersion + "\n";
+    }
+
+    /**
+     * Build a collection section for a CSV import file
+     *
+     * @param name     collection name
+     * @param coinType collection type string
+     * @param total    total coin count cell
+     * @return CSV collection section
+     */
+    private String csvCollectionSection(String name, String coinType, String total) {
+        return CSV_SEPARATOR + "," + ExportImportHelper.JSON_COLLECTIONS + "\n"
+                + String.join(",", CollectionListInfo.getCsvExportHeader()) + "\n"
+                + name + "," + coinType + ",0," + total + ",0,1909,2020,0,0,15,1\n";
+    }
+
+    /**
+     * Build a coin list section for a CSV import file
+     *
+     * @param coinRows raw coin rows to include
+     * @return CSV coin list section
+     */
+    private String csvCoinSection(String... coinRows) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(CSV_SEPARATOR).append(",").append(ExportImportHelper.JSON_COIN_LIST).append("\n");
+        builder.append(String.join(",", CoinSlot.getCsvExportHeader())).append("\n");
+        for (String coinRow : coinRows) {
+            builder.append(coinRow).append("\n");
+        }
+        return builder.toString();
+    }
+
+    /**
+     * Rewrite a collection's stored coin type to a value this app doesn't recognize
+     *
+     * @param activity       test activity
+     * @param collectionName collection to corrupt
+     */
+    private void makeCollectionTypeUnknown(MainActivity activity, String collectionName) {
+        SQLiteDatabase db = new DatabaseHelper(activity).getWritableDatabase();
+        ContentValues values = new ContentValues();
+        values.put(COL_COIN_TYPE, "Martian Doubloons");
+        assertEquals(1, DatabaseHelper.runSqlUpdate(db, TBL_COLLECTION_INFO, values,
+                COL_NAME + "=?", new String[]{collectionName}));
+        db.close();
+    }
+
+    /**
+     * A completely empty import file has no database version, so it must be rejected
+     */
+    @Test
+    public void test_csvImportEmptyStream() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+                setupTwoCollections(activity);
+                DbSnapshot before = snapshotDb(activity);
+
+                assertFalse(importCsv(activity, "").isEmpty());
+                assertDbUnchanged(activity, before);
+            });
+        }
+    }
+
+    /**
+     * A collection row that's missing required columns must be rejected
+     */
+    @Test
+    public void test_csvImportTooFewColumns() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+                setupTwoCollections(activity);
+                DbSnapshot before = snapshotDb(activity);
+
+                String contents = csvHeader(MainApplication.DATABASE_VERSION)
+                        + CSV_SEPARATOR + "," + ExportImportHelper.JSON_COLLECTIONS + "\n"
+                        + String.join(",", CollectionListInfo.getCsvExportHeader()) + "\n"
+                        + "Imported," + LincolnCents.COLLECTION_TYPE + "\n";
+
+                assertFalse(importCsv(activity, contents).isEmpty());
+                assertDbUnchanged(activity, before);
+            });
+        }
+    }
+
+    /**
+     * A non-numeric total cell must be rejected rather than crashing with NumberFormatException
+     */
+    @Test
+    public void test_csvImportNonNumericTotal() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+                setupTwoCollections(activity);
+                DbSnapshot before = snapshotDb(activity);
+
+                String contents = csvHeader(MainApplication.DATABASE_VERSION)
+                        + csvCollectionSection("Imported", LincolnCents.COLLECTION_TYPE, "not-a-number");
+
+                assertFalse(importCsv(activity, contents).isEmpty());
+                assertDbUnchanged(activity, before);
+            });
+        }
+    }
+
+    /**
+     * An unknown coin type must abort the import instead of silently becoming the
+     * collection type at index 0
+     */
+    @Test
+    public void test_csvImportUnknownCoinType() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+                setupTwoCollections(activity);
+                DbSnapshot before = snapshotDb(activity);
+
+                String contents = csvHeader(MainApplication.DATABASE_VERSION)
+                        + csvCollectionSection("Imported", "Martian Doubloons", "1")
+                        + csvCoinSection("2019,P,1,0,0,,0,0,-1");
+
+                assertFalse(importCsv(activity, contents).isEmpty());
+                assertDbUnchanged(activity, before);
+
+                // The bogus collection must not have been imported as Lincoln Cents
+                assertFalse(getCollectionNames(activity).contains("Imported"));
+            });
+        }
+    }
+
+    /**
+     * A coin row that appears before any collection header has nowhere to go
+     */
+    @Test
+    public void test_csvImportCoinWithoutCollection() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+                setupTwoCollections(activity);
+                DbSnapshot before = snapshotDb(activity);
+
+                String contents = csvHeader(MainApplication.DATABASE_VERSION)
+                        + csvCoinSection("2019,P,1,0,0,,0,0,-1");
+
+                assertFalse(importCsv(activity, contents).isEmpty());
+                assertDbUnchanged(activity, before);
+            });
+        }
+    }
+
+    /**
+     * Two collections with the same name can't both be created, so this must be caught
+     * during validation - before anything is dropped
+     */
+    @Test
+    public void test_csvImportDuplicateNamesWithinFile() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+                setupTwoCollections(activity);
+                DbSnapshot before = snapshotDb(activity);
+
+                String contents = csvHeader(MainApplication.DATABASE_VERSION)
+                        + csvCollectionSection("Imported", LincolnCents.COLLECTION_TYPE, "1")
+                        + csvCoinSection("2019,P,1,0,0,,0,0,-1")
+                        + csvCollectionSection("imported", LincolnCents.COLLECTION_TYPE, "1")
+                        + csvCoinSection("2020,P,1,0,0,,0,0,-1");
+
+                assertFalse(importCsv(activity, contents).isEmpty());
+                assertDbUnchanged(activity, before);
+            });
+        }
+    }
+
+    /**
+     * A collection using an internal table name must be rejected
+     */
+    @Test
+    public void test_csvImportReservedName() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+                setupTwoCollections(activity);
+                DbSnapshot before = snapshotDb(activity);
+
+                String contents = csvHeader(MainApplication.DATABASE_VERSION)
+                        + csvCollectionSection(TBL_COLLECTION_INFO, LincolnCents.COLLECTION_TYPE, "1")
+                        + csvCoinSection("2019,P,1,0,0,,0,0,-1");
+
+                assertFalse(importCsv(activity, contents).isEmpty());
+                assertDbUnchanged(activity, before);
+            });
+        }
+    }
+
+    /**
+     * Atomicity proof: the first collection in the file is perfectly valid and the second
+     * is not. The whole import must be rejected, leaving the original database intact.
+     */
+    @Test
+    public void test_csvImportSecondCollectionInvalidIsAtomic() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+                setupTwoCollections(activity);
+                DbSnapshot before = snapshotDb(activity);
+                assertEquals(2, before.names.size());
+
+                String contents = csvHeader(MainApplication.DATABASE_VERSION)
+                        + csvCollectionSection("Good Collection", LincolnCents.COLLECTION_TYPE, "1")
+                        + csvCoinSection("2019,P,1,0,0,,0,0,-1")
+                        + csvCollectionSection("Bad Collection", "Martian Doubloons", "1")
+                        + csvCoinSection("2020,P,1,0,0,,0,0,-1");
+
+                assertFalse(importCsv(activity, contents).isEmpty());
+
+                // Neither the valid nor the invalid collection may have landed
+                assertDbUnchanged(activity, before);
+                assertFalse(getCollectionNames(activity).contains("Good Collection"));
+                assertFalse(getCollectionNames(activity).contains("Bad Collection"));
+            });
+        }
+    }
+
+    /**
+     * A truncated JSON document must produce an error rather than a crash
+     */
+    @Test
+    public void test_jsonImportTruncated() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+                setupTwoCollections(activity);
+                DbSnapshot before = snapshotDb(activity);
+
+                String contents = "{\"" + ExportImportHelper.JSON_DB_VERSION + "\":"
+                        + MainApplication.DATABASE_VERSION + ",\""
+                        + ExportImportHelper.JSON_COLLECTIONS + "\":[{\"" + COL_NAME + "\":\"Imp";
+
+                assertFalse(importJson(activity, contents).isEmpty());
+                assertDbUnchanged(activity, before);
+            });
+        }
+    }
+
+    /**
+     * A file written by a newer version of the app can't be imported safely
+     */
+    @Test
+    public void test_jsonImportFutureDatabaseVersion() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+                setupTwoCollections(activity);
+                DbSnapshot before = snapshotDb(activity);
+
+                String contents = "{\"" + ExportImportHelper.JSON_DB_VERSION + "\":"
+                        + (MainApplication.DATABASE_VERSION + 1) + ",\""
+                        + ExportImportHelper.JSON_COLLECTIONS + "\":[]}";
+
+                assertFalse(importJson(activity, contents).isEmpty());
+                assertDbUnchanged(activity, before);
+            });
+        }
+    }
+
+    /**
+     * An unknown coin type in a JSON file must abort the import
+     */
+    @Test
+    public void test_jsonImportUnknownCoinType() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+                setupTwoCollections(activity);
+                DbSnapshot before = snapshotDb(activity);
+
+                String contents = "{\"" + ExportImportHelper.JSON_DB_VERSION + "\":"
+                        + MainApplication.DATABASE_VERSION + ",\""
+                        + ExportImportHelper.JSON_COLLECTIONS + "\":[{"
+                        + "\"" + COL_NAME + "\":\"Imported\","
+                        + "\"" + COL_COIN_TYPE + "\":\"Martian Doubloons\","
+                        + "\"" + COL_TOTAL + "\":0,"
+                        + "\"" + COL_DISPLAY + "\":0,"
+                        + "\"" + COL_START_YEAR + "\":0,"
+                        + "\"" + COL_END_YEAR + "\":0,"
+                        + "\"" + COL_SHOW_MINT_MARKS + "\":\"0\","
+                        + "\"" + COL_SHOW_CHECKBOXES + "\":\"0\","
+                        + "\"" + ExportImportHelper.JSON_COIN_LIST + "\":[]}]}";
+
+                assertFalse(importJson(activity, contents).isEmpty());
+                assertDbUnchanged(activity, before);
+                assertFalse(getCollectionNames(activity).contains("Imported"));
+            });
+        }
+    }
+
+    /**
+     * A JSON collection with no coinType at all must be rejected too
+     */
+    @Test
+    public void test_jsonImportMissingCoinType() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+                setupTwoCollections(activity);
+                DbSnapshot before = snapshotDb(activity);
+
+                String contents = "{\"" + ExportImportHelper.JSON_DB_VERSION + "\":"
+                        + MainApplication.DATABASE_VERSION + ",\""
+                        + ExportImportHelper.JSON_COLLECTIONS + "\":[{"
+                        + "\"" + COL_NAME + "\":\"Imported\","
+                        + "\"" + COL_TOTAL + "\":0,"
+                        + "\"" + ExportImportHelper.JSON_COIN_LIST + "\":[]}]}";
+
+                assertFalse(importJson(activity, contents).isEmpty());
+                assertDbUnchanged(activity, before);
+            });
+        }
+    }
+
+    /**
+     * A valid import file that replaces collections with the same names must still work -
+     * this is the normal export/import round trip and must not be broken by validation
+     */
+    @Test
+    public void test_csvImportOverExistingNamesSucceeds() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+                setupTwoCollections(activity);
+
+                String contents = csvHeader(MainApplication.DATABASE_VERSION)
+                        + csvCollectionSection(COLLECTION_A, LincolnCents.COLLECTION_TYPE, "1")
+                        + csvCoinSection("2019,P,1,0,0,,0,0,-1");
+
+                assertEquals("", importCsv(activity, contents));
+
+                ArrayList<String> names = getCollectionNames(activity);
+                assertEquals(1, names.size());
+                assertEquals(COLLECTION_A, names.get(0));
+                assertEquals(1, activity.mDbAdapter.getCoinList(COLLECTION_A, true).size());
+            });
+        }
+    }
+
+    /**
+     * Importing a file from an older database version must run the upgrade inside the same
+     * transaction and still succeed
+     */
+    @Test
+    public void test_csvImportOlderDatabaseVersionSucceeds() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+                setupTwoCollections(activity);
+
+                String contents = csvHeader(MainApplication.DATABASE_VERSION - 1)
+                        + csvCollectionSection("Old Version Collection", LincolnCents.COLLECTION_TYPE, "1")
+                        + csvCoinSection("2019,P,1,0,0,,0,0,-1");
+
+                assertEquals("", importCsv(activity, contents));
+
+                ArrayList<String> names = getCollectionNames(activity);
+                assertEquals(1, names.size());
+                assertEquals("Old Version Collection", names.get(0));
+            });
+        }
+    }
+
+    /**
+     * A collection stored with an unrecognized coin type must be skipped and reported
+     * rather than throwing, which used to crash-loop getWritableDatabase()
+     */
+    @Test
+    public void test_getAllTablesSkipsUnknownCoinType() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+                setupTwoCollections(activity);
+
+                // Insert a collection_info row referencing a coin type this app doesn't know
+                DatabaseAdapter dbAdapter = new DatabaseAdapter(activity);
+                dbAdapter.open();
+                CollectionListInfo bogusInfo = new CollectionListInfo("Future Collection", 0, 0,
+                        MainApplication.getIndexFromCollectionNameStr(LincolnCents.COLLECTION_TYPE),
+                        0, 0, 0, "0", "0");
+                dbAdapter.createAndPopulateNewTable(bogusInfo, 2, new ArrayList<>());
+                dbAdapter.close();
+
+                makeCollectionTypeUnknown(activity, "Future Collection");
+
+                // The other collections must still load, and the bad one must be reported
+                ArrayList<CollectionListInfo> entries = new ArrayList<>();
+                ArrayList<String> skipped = new ArrayList<>();
+                activity.mDbAdapter.getAllTables(entries, skipped);
+
+                assertEquals(2, entries.size());
+                assertEquals(COLLECTION_A, entries.get(0).getName());
+                assertEquals(COLLECTION_B, entries.get(1).getName());
+                assertEquals(1, skipped.size());
+                assertEquals("Future Collection", skipped.get(0));
+            });
+        }
+    }
+
+    /**
+     * Rollback proof: force a failure inside the import transaction itself (rather than
+     * during parsing) by leaving an orphan table behind that isn't listed in
+     * collection_info, so the CREATE TABLE for the imported collection fails after the
+     * existing tables have already been dropped. The original database must come back.
+     */
+    @Test
+    public void test_csvImportRollsBackFailureInsideTransaction() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+                setupTwoCollections(activity);
+
+                // Create a table that collection_info doesn't know about, so it survives the
+                // drop loop and collides with the imported collection's CREATE TABLE
+                SQLiteDatabase db = new DatabaseHelper(activity).getWritableDatabase();
+                db.execSQL("CREATE TABLE [Orphan Table] (_id integer primary key);");
+                db.close();
+
+                DbSnapshot before = snapshotDb(activity);
+                assertEquals(2, before.names.size());
+
+                String contents = csvHeader(MainApplication.DATABASE_VERSION)
+                        + csvCollectionSection("Orphan Table", LincolnCents.COLLECTION_TYPE, "1")
+                        + csvCoinSection("2019,P,1,0,0,,0,0,-1");
+
+                assertFalse(importCsv(activity, contents).isEmpty());
+
+                // Both original collections and all of their coins must still be there
+                assertDbUnchanged(activity, before);
+            });
+        }
+    }
+
+    /**
+     * A successful import must drop every collection listed in collection_info, including
+     * one whose coin type this app doesn't recognize - otherwise its table would be
+     * orphaned when the collection_info row goes away
+     */
+    @Test
+    public void test_csvImportDropsCollectionWithUnknownCoinType() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+                setupTwoCollections(activity);
+                makeCollectionTypeUnknown(activity, COLLECTION_B);
+
+                // Import a collection reusing the unrecognized collection's name. This only
+                // works if the old table was dropped despite its unknown type.
+                String contents = csvHeader(MainApplication.DATABASE_VERSION)
+                        + csvCollectionSection(COLLECTION_B, LincolnCents.COLLECTION_TYPE, "1")
+                        + csvCoinSection("2019,P,1,0,0,,0,0,-1");
+
+                assertEquals("", importCsv(activity, contents));
+
+                ArrayList<String> names = getCollectionNames(activity);
+                assertEquals(1, names.size());
+                assertEquals(COLLECTION_B, names.get(0));
+                assertEquals(1, activity.mDbAdapter.getCoinList(COLLECTION_B, true).size());
+            });
+        }
+    }
+
+    /**
+     * A flag value that can't be recovered must abort the import rather than silently
+     * becoming 0, which would wipe the collection's mint mark configuration
+     */
+    @Test
+    public void test_csvImportUnrecoverableFlagValue() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+                setupTwoCollections(activity);
+                DbSnapshot before = snapshotDb(activity);
+
+                // Trailing cell 9 is showMintMarks - "not a number" is unrecoverable
+                String contents = csvHeader(MainApplication.DATABASE_VERSION)
+                        + CSV_SEPARATOR + "," + ExportImportHelper.JSON_COLLECTIONS + "\n"
+                        + String.join(",", CollectionListInfo.getCsvExportHeader()) + "\n"
+                        + "Imported," + LincolnCents.COLLECTION_TYPE
+                        + ",0,1,0,1909,2020,0,0,not a number,1\n"
+                        + csvCoinSection("2019,P,1,0,0,,0,0,-1");
+
+                assertFalse(importCsv(activity, contents).isEmpty());
+                assertDbUnchanged(activity, before);
+            });
+        }
+    }
+
+    /**
+     * The same check must apply to JSON imports
+     */
+    @Test
+    public void test_jsonImportUnrecoverableFlagValue() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+                setupTwoCollections(activity);
+                DbSnapshot before = snapshotDb(activity);
+
+                String contents = "{\"" + ExportImportHelper.JSON_DB_VERSION + "\":"
+                        + MainApplication.DATABASE_VERSION + ",\""
+                        + ExportImportHelper.JSON_COLLECTIONS + "\":[{"
+                        + "\"" + COL_NAME + "\":\"Imported\","
+                        + "\"" + COL_COIN_TYPE + "\":\"" + LincolnCents.COLLECTION_TYPE + "\","
+                        + "\"" + COL_TOTAL + "\":0,"
+                        + "\"" + COL_DISPLAY + "\":0,"
+                        + "\"" + COL_START_YEAR + "\":0,"
+                        + "\"" + COL_END_YEAR + "\":0,"
+                        + "\"" + COL_SHOW_MINT_MARKS + "\":\"not a number\","
+                        + "\"" + COL_SHOW_CHECKBOXES + "\":\"0\","
+                        + "\"" + ExportImportHelper.JSON_COIN_LIST + "\":[]}]}";
+
+                assertFalse(importJson(activity, contents).isEmpty());
+                assertDbUnchanged(activity, before);
+            });
+        }
+    }
+
+    /**
+     * Spreadsheet-mangled flag values must still be recovered rather than rejected -
+     * tightening the import check must not break the issue #406 recovery path
+     */
+    @Test
+    public void test_csvImportRecoversSpreadsheetMangledFlags() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+                setupTwoCollections(activity);
+
+                // Cell 9 uses scientific notation, cell 10 a trailing decimal
+                String contents = csvHeader(MainApplication.DATABASE_VERSION)
+                        + CSV_SEPARATOR + "," + ExportImportHelper.JSON_COLLECTIONS + "\n"
+                        + String.join(",", CollectionListInfo.getCsvExportHeader()) + "\n"
+                        + "Imported," + LincolnCents.COLLECTION_TYPE
+                        + ",0,1,0,1909,2020,0,0,2.68435E+8,268435456.0\n"
+                        + csvCoinSection("2019,P,1,0,0,,0,0,-1");
+
+                assertEquals("", importCsv(activity, contents));
+
+                ArrayList<CollectionListInfo> entries = new ArrayList<>();
+                activity.mDbAdapter.getAllTables(entries);
+                assertEquals(1, entries.size());
+                assertEquals(268435000L, entries.get(0).getMintMarkFlagsAsLong());
+                assertEquals(268435456L, entries.get(0).getCheckboxFlagsAsLong());
+            });
+        }
+    }
+
+    /**
+     * An empty flag cell is the legitimate "no flags set" encoding and must still import
+     */
+    @Test
+    public void test_csvImportEmptyFlagValueIsZero() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+                setupTwoCollections(activity);
+
+                String contents = csvHeader(MainApplication.DATABASE_VERSION)
+                        + CSV_SEPARATOR + "," + ExportImportHelper.JSON_COLLECTIONS + "\n"
+                        + String.join(",", CollectionListInfo.getCsvExportHeader()) + "\n"
+                        + "Imported," + LincolnCents.COLLECTION_TYPE + ",0,1,0,1909,2020,0,0,,\n"
+                        + csvCoinSection("2019,P,1,0,0,,0,0,-1");
+
+                assertEquals("", importCsv(activity, contents));
+
+                ArrayList<CollectionListInfo> entries = new ArrayList<>();
+                activity.mDbAdapter.getAllTables(entries);
+                assertEquals(1, entries.size());
+                assertEquals(0L, entries.get(0).getMintMarkFlagsAsLong());
+                assertEquals(0L, entries.get(0).getCheckboxFlagsAsLong());
+            });
+        }
+    }
+
+    /**
+     * A data row starting with the separator token must be treated as data, not silently
+     * dropped as a malformed section header
+     */
+    @Test
+    public void test_csvImportSeparatorLookalikeRowIsData() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+                setupTwoCollections(activity);
+
+                // A coin whose identifier happens to be the separator token
+                String contents = csvHeader(MainApplication.DATABASE_VERSION)
+                        + csvCollectionSection("Separator Test", LincolnCents.COLLECTION_TYPE, "2")
+                        + csvCoinSection(CSV_SEPARATOR + ",P,1,0,0,,0,1,-1",
+                        "2019,P,1,0,0,,1,0,-1");
+
+                assertEquals("", importCsv(activity, contents));
+
+                ArrayList<CoinSlot> coinList = activity.mDbAdapter.getCoinList("Separator Test", true);
+                assertEquals(2, coinList.size());
+                assertEquals(CSV_SEPARATOR, coinList.get(0).getIdentifier());
+                assertEquals("2019", coinList.get(1).getIdentifier());
+            });
+        }
+    }
+}

--- a/app/src/test/java/com/spencerpages/ExportImportTests.java
+++ b/app/src/test/java/com/spencerpages/ExportImportTests.java
@@ -49,6 +49,7 @@ import com.coincollection.CollectionInfo;
 import com.coincollection.CollectionListInfo;
 import com.coincollection.DatabaseAdapter;
 import com.coincollection.ExportImportHelper;
+import com.coincollection.ImportFormatException;
 import com.coincollection.MainActivity;
 import com.spencerpages.collections.AmericanInnovationDollars;
 import com.spencerpages.collections.NativeAmericanDollars;
@@ -337,7 +338,7 @@ public class ExportImportTests extends BaseTestCase {
      * Test that running the collection list info export -> import work
      */
     @Test
-    public void test_csvExportImportMethods() {
+    public void test_csvExportImportMethods() throws ImportFormatException {
         for (CollectionListInfo info : COLLECTION_LIST_INFO_SCENARIOS) {
             DatabaseAdapter fakeDbAdapter = mock(DatabaseAdapter.class);
             when(fakeDbAdapter.fetchTableDisplay(anyString())).thenReturn(info.getDisplayType());


### PR DESCRIPTION

## The bug

`updateDatabaseFromImport()` dropped every collection table and `collection_info` **before** validating any of the imported data, with no transaction to fall back on. A malformed or partially-invalid import file destroyed the user's entire database — the drop had already happened by the time the first bad row was noticed, and the only `catch` was for `SQLException`.

Supporting problems: an unrecognized coin type silently became index 0 (Lincoln Cents), the CSV/JSON parsers threw uncaught runtime exceptions, and `getAllTables()` threw a bare `SQLException` from inside `onUpgrade`, crash-looping `getWritableDatabase()` on every launch.

## Validate, then destroy

Pass 1 makes no writes. It rejects a mismatched collection/coin-list pairing, an out-of-range database version, and empty, bracketed, reserved, or duplicated collection names.

Names that collide with **existing** collections are deliberately still allowed — import intentionally replaces the whole database, so rejecting them would break the ordinary export → import round trip.

Pass 2 runs inside a single transaction covering drop → create → populate → `upgradeDbForImport`, so any failure restores the pre-import database. Table names for the drop loop now come from `collection_info` directly rather than `getAllTables()`, so a collection whose coin type isn't recognized is still dropped instead of orphaned.

## Parsers fail loudly

- Both `CollectionListInfo` import constructors throw a new checked `ImportFormatException` on an unrecognized coin type instead of falling back to index 0. The JSON constructor validates *after* its read loop, since member order isn't guaranteed.
- `CoinSlot(String[], int)` and `CollectionListInfo(String[])` validate row length and route every numeric field through a parse helper that names the offending cell.
- An unrecoverable mint-mark/checkbox flag string silently became `0`, wiping the collection's configuration. Imports now reject it. **`parseFlagString` itself stays lenient** — the runtime getters and the `upgradeDbStructure` blocks read *stored* values and must never throw (#406), and spreadsheet-mangled values like `2.68435E+8` still recover.
- The three import entry points catch `ImportFormatException | NumberFormatException | IndexOutOfBoundsException` and return a localized error string.

## No more crash-loop

`getAllTables()` logs and skips an unrecognized row, optionally collecting skipped names so `MainActivity` can warn once, and closes its cursor in a `finally`. The dead `collected == -1` branch is gone (`fetchTotalCollected()` throws rather than returning `-1`).

## Also included

Bulk write loops (`updateCoinList`, `createAndPopulateNewTable`, `removeDuplicateCoinsByIdentifier`) wrapped in the transaction helper; an importing-specific error string on the import path; UTF-8 pinned on the four CSV streams; a row is only treated as a section separator when it names a known section, so a data row starting with `-----` is no longer silently discarded; and the import/export URI is checked to be a `content://` URI that doesn't resolve into the app's own private storage (CodeQL `java/android/unsafe-content-uri-resolution`, deferred from #407).

## Testing

New `ExportImportErrorTests` (22 tests): empty stream, too few columns, non-numeric total, unknown coin type, coin row before any collection header, truncated JSON, future `databaseVersion`, missing coin type, duplicate names within one file, reserved name, unrecoverable and spreadsheet-mangled flag values, and `getAllTables` with a bogus `collection_info` row. Every negative case asserts both a non-empty error string **and** an unchanged database.

`test_csvImportRollsBackFailureInsideTransaction` is the atomicity proof: it forces a failure *inside* the transaction (via an orphan table that collides with the imported `CREATE TABLE`) and asserts the original collections and their coins survive. I verified it genuinely bites by temporarily stubbing out `runInTransaction` — it fails without the transaction and passes with it. Same falsification check was run for the two strict flag-value tests.

Full suite green (727 test cases, 0 failures) and `lintAndroidDebug` clean.

## Notes for review

- **`"Lincoln Cents"` was never a valid collection type string** (it's `"Pennies"`). The existing `stringArrayConstructor_recoversMangledFlags` passed only because of the index-0 fallback this PR removes — i.e. it was quietly exercising the bug. Fixed the test's type string.
- **Whitespace-only collection names are legitimate** (`SharedTest` includes `" "` and `"  "`), so the empty-name rule lives in the import validation pass and rejects only *truly* empty names, not blank ones.
- **Behavior change, intentional:** files that previously "imported" by mangling an unknown coin type or a corrupt flag value now return an error. That silent mangling is the bug being fixed.
- No `DATABASE_VERSION` bump — nothing here is a schema change. No migration blocks, `COLLECTION_TYPES[]`, or `COIN_IMG_IDS[]` touched.