### PR TITLE
Fix collection data bugs and migrate to database version 27

### DIFF
--- a/app/src/main/java/com/spencerpages/MainApplication.java
+++ b/app/src/main/java/com/spencerpages/MainApplication.java
@@ -243,8 +243,13 @@ public class MainApplication extends Application {
      * Version 24 - Used in Version 3.8.0 of the app
      * Version 25 - Adds the 2018 Roosevelt "S Reverse Silver Proof" dime (#362)
      * Version 26 - Fixes Philadelphia penny mint marks, including the 2017 "P" (#366)
+     * Version 27 - Fixes collection data bugs, migrated per collection in each class's
+     *              onCollectionDatabaseUpgrade: the "1776-1796" bicentennial identifier
+     *              (KennedyHalfDollars, SilverHalfDollars), duplicated 1932-1964 coins
+     *              (WashingtonQuarters), and the "ProofType II" (Cartwheels) and
+     *              "Kennedy Halve" (WestPoint) typos
      */
-    public static final int DATABASE_VERSION = 26;
+    public static final int DATABASE_VERSION = 27;
 
     /**
      * Get the collection index from collection type name

--- a/app/src/main/java/com/spencerpages/collections/BasicQuarters.java
+++ b/app/src/main/java/com/spencerpages/collections/BasicQuarters.java
@@ -67,7 +67,7 @@ public class BasicQuarters extends CollectionInfo {
     };
 
     private static final Integer START_YEAR = 1932;
-    private static final Integer STOP_YEAR = 2026;
+    private static final Integer STOP_YEAR = CoinPageCreator.OPTVAL_STILL_IN_PRODUCTION;
 
     private static final int OBVERSE_IMAGE_COLLECTED = R.drawable.quarter_front_92px;
 

--- a/app/src/main/java/com/spencerpages/collections/Cartwheels.java
+++ b/app/src/main/java/com/spencerpages/collections/Cartwheels.java
@@ -21,6 +21,11 @@
 
 package com.spencerpages.collections;
 
+import static com.coincollection.CoinSlot.COL_COIN_MINT;
+import static com.coincollection.CoinSlot.COL_CUSTOM_COIN;
+import static com.coincollection.DatabaseHelper.runSqlUpdate;
+
+import android.content.ContentValues;
 import android.database.sqlite.SQLiteDatabase;
 
 import com.coincollection.CoinPageCreator;
@@ -214,7 +219,7 @@ public class Cartwheels extends CollectionInfo {
                         coinList.add(new CoinSlot("1776-1976", String.format("D%nType II"), coinIndex++, getImgId("Eisenhower")));}
                     if (showS) {
                         coinList.add(new CoinSlot("1776-1976", String.format("S%nProof Type I"), coinIndex++, getImgId("Eisenhower")));
-                        coinList.add(new CoinSlot("1776-1976", String.format("S%nProofType II"), coinIndex++, getImgId("Eisenhower")));
+                        coinList.add(new CoinSlot("1776-1976", String.format("S%nProof Type II"), coinIndex++, getImgId("Eisenhower")));
                         coinList.add(new CoinSlot("1776-1976", String.format("S%n40%% Silver"), coinIndex++, getImgId("Eisenhower")));
                         coinList.add(new CoinSlot("1776-1976", String.format("S%nSilver Proof"), coinIndex++, getImgId("Eisenhower")));}
                 }
@@ -269,7 +274,7 @@ public class Cartwheels extends CollectionInfo {
                        if (i==2020){coinList.add(new CoinSlot(year, "W Proof Privy Mark", coinIndex++, getImgId("Eagle")));}
                        if (i==2021){
                             coinList.add(new CoinSlot(year, "W Proof Type I", coinIndex++, getImgId("Eagle")));
-                            coinList.add(new CoinSlot(year, "W ProofType II", coinIndex++, getImgId("Eagle")));
+                            coinList.add(new CoinSlot(year, "W Proof Type II", coinIndex++, getImgId("Eagle")));
                             coinList.add(new CoinSlot(year, "W Reverse Proof", coinIndex++, getImgId("Eagle")));}
                     }
                 }
@@ -310,6 +315,24 @@ public class Cartwheels extends CollectionInfo {
                         "2026", mintVariants, getImgId("1776-2026 Eagle"));
             }
         }
+
+        if (oldVersion <= 26) {
+            // Fix the "ProofType II" typos. These live in the mint column, not the
+            // identifier. The old values are deliberately written out here rather than
+            // shared with the generator, so this block can never track a later edit.
+            ContentValues values = new ContentValues();
+            values.put(COL_COIN_MINT, String.format("S%nProof Type II"));
+            runSqlUpdate(db, collectionListInfo.getName(), values,
+                    COL_COIN_MINT + "=? AND " + COL_CUSTOM_COIN + "=0",
+                    new String[]{String.format("S%nProofType II")});
+
+            values.clear();
+            values.put(COL_COIN_MINT, "W Proof Type II");
+            runSqlUpdate(db, collectionListInfo.getName(), values,
+                    COL_COIN_MINT + "=? AND " + COL_CUSTOM_COIN + "=0",
+                    new String[]{"W ProofType II"});
+        }
+
         return total;
     }
 }

--- a/app/src/main/java/com/spencerpages/collections/EarlyDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/EarlyDollars.java
@@ -159,7 +159,7 @@ public class EarlyDollars extends CollectionInfo {
 
     @Override
     public int getAttributionResId() {
-        return R.string.attr_early_halfs;
+        return R.string.attr_early_dollars;
     }
 
     @Override

--- a/app/src/main/java/com/spencerpages/collections/KennedyHalfDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/KennedyHalfDollars.java
@@ -20,6 +20,11 @@
 
 package com.spencerpages.collections;
 
+import static com.coincollection.CoinSlot.COL_COIN_IDENTIFIER;
+import static com.coincollection.CoinSlot.COL_CUSTOM_COIN;
+import static com.coincollection.DatabaseHelper.runSqlUpdate;
+
+import android.content.ContentValues;
 import android.database.sqlite.SQLiteDatabase;
 
 import com.coincollection.CoinPageCreator;
@@ -63,9 +68,9 @@ public class KennedyHalfDollars extends CollectionInfo {
             {"Franklin Reverse", R.drawable.rev_franklin_half},                     // 12
             {"Walking Liberty Reverse", R.drawable.rev_walking_liberty_half},       // 13
             {"Barber Reverse", R.drawable.rev_barber_half},                         // 14
-            {"Flowing Hair", R.drawable.ha1795o},                                   // 15
-            {"Draped Bust", R.drawable.ha1796o},                                    // 16
-            {"Capped Bust", R.drawable.ha1837o},                                    // 17
+            {"Flowing Hair Alt", R.drawable.ha1795o},                               // 15
+            {"Draped Bust Alt", R.drawable.ha1796o},                                // 16
+            {"Capped Bust Alt", R.drawable.ha1837o},                                // 17
             {"Seated Liberty", R.drawable.ha1853o},                                 // 18
             {"Enduring Liberty", R.drawable.semiq_2026_half_obv_unc},               // 19
     };
@@ -204,7 +209,8 @@ public class KennedyHalfDollars extends CollectionInfo {
                     if (showD) {coinList.add(new CoinSlot(year, String.format("D%n40%% Silver"), coinIndex++, kennedyImg));}
                     if (showSilverProofs) {coinList.add(new CoinSlot(year, String.format("S Proof%n40%% Silver"), coinIndex++, kennedyProofImg));}
                 }
-                if (i == 1976) {{coinList.add(new CoinSlot("1776-1796", String.format("S BU%n40%% Silver"), coinIndex++, kennedyImg));}
+                if (i == 1976) {
+                    coinList.add(new CoinSlot("1776-1976", String.format("S BU%n40%% Silver"), coinIndex++, kennedyImg));
                     if (showSilverProofs) {coinList.add(new CoinSlot("1776-1976", String.format("S %n40%% Proof"), coinIndex++, kennedyProofImg));}
                 }
                 if (showSilverProofs && i > 1991) {coinList.add(new CoinSlot(year, String.format("S%nSilver Proof"), coinIndex++, kennedyProofImg));
@@ -251,6 +257,18 @@ public class KennedyHalfDollars extends CollectionInfo {
                 total += DatabaseHelper.addFromYear(db, collectionListInfo, 2025, 2026,
                         "2026", mintVariants, getImgId("Enduring Liberty"));
             }
+        }
+
+        if (oldVersion <= 26) {
+            // Fix the typo'd bicentennial identifier on the 40% silver BU half dollar.
+            // The old value is deliberately a literal: it must never track a constant
+            // that could change later. Custom coins are skipped because their
+            // identifiers are user-entered and aren't ours to rewrite.
+            ContentValues values = new ContentValues();
+            values.put(COL_COIN_IDENTIFIER, "1776-1976");
+            runSqlUpdate(db, collectionListInfo.getName(), values,
+                    COL_COIN_IDENTIFIER + "=? AND " + COL_CUSTOM_COIN + "=0",
+                    new String[]{"1776-1796"});
         }
 
         return total;

--- a/app/src/main/java/com/spencerpages/collections/SilverHalfDollars.java
+++ b/app/src/main/java/com/spencerpages/collections/SilverHalfDollars.java
@@ -20,6 +20,11 @@
 
 package com.spencerpages.collections;
 
+import static com.coincollection.CoinSlot.COL_COIN_IDENTIFIER;
+import static com.coincollection.CoinSlot.COL_CUSTOM_COIN;
+import static com.coincollection.DatabaseHelper.runSqlUpdate;
+
+import android.content.ContentValues;
 import android.database.sqlite.SQLiteDatabase;
 
 import com.coincollection.CoinPageCreator;
@@ -214,7 +219,7 @@ public class SilverHalfDollars extends CollectionInfo {
                     if (showSilver) {coinList.add(new CoinSlot(year, String.format("S Proof%n40%% Silver"), coinIndex++, kennedyProofImg));}
                 }
                 if (i == 1976) {
-                    if (showS) {coinList.add(new CoinSlot("1776-1796", String.format("S BU%n40%% Silver"), coinIndex++, kennedyImg));}
+                    if (showS) {coinList.add(new CoinSlot("1776-1976", String.format("S BU%n40%% Silver"), coinIndex++, kennedyImg));}
                     if (showSilver) {coinList.add(new CoinSlot("1776-1976", String.format("S%n40%% Proof"), coinIndex++, kennedyProofImg));}
                 }
                 if (showSilver && i > 1991) {coinList.add(new CoinSlot(year, "S Proof", coinIndex++, kennedyProofImg));
@@ -257,6 +262,19 @@ public class SilverHalfDollars extends CollectionInfo {
                         "2026", mintVariants, getImgId("Enduring Liberty"));
             }
         }
+
+        if (oldVersion <= 26) {
+            // Fix the typo'd bicentennial identifier on the 40% silver BU half dollar.
+            // The old value is deliberately a literal: it must never track a constant
+            // that could change later. Custom coins are skipped because their
+            // identifiers are user-entered and aren't ours to rewrite.
+            ContentValues values = new ContentValues();
+            values.put(COL_COIN_IDENTIFIER, "1776-1976");
+            runSqlUpdate(db, collectionListInfo.getName(), values,
+                    COL_COIN_IDENTIFIER + "=? AND " + COL_CUSTOM_COIN + "=0",
+                    new String[]{"1776-1796"});
+        }
+
         return total;
     }
 }

--- a/app/src/main/java/com/spencerpages/collections/WashingtonQuarters.java
+++ b/app/src/main/java/com/spencerpages/collections/WashingtonQuarters.java
@@ -20,12 +20,17 @@
 
 package com.spencerpages.collections;
 
+import static com.coincollection.CoinSlot.COL_COIN_IDENTIFIER;
+import static com.coincollection.CoinSlot.COL_CUSTOM_COIN;
+import static com.coincollection.DatabaseHelper.runSqlDelete;
+
 import android.database.sqlite.SQLiteDatabase;
 
 import com.coincollection.CoinPageCreator;
 import com.coincollection.CoinSlot;
 import com.coincollection.CollectionInfo;
 import com.coincollection.CollectionListInfo;
+import com.coincollection.DatabaseHelper;
 import com.spencerpages.R;
 
 import java.util.ArrayList;
@@ -110,7 +115,10 @@ public class WashingtonQuarters extends CollectionInfo {
             if (i == 1933 || (i == 1975))
                 continue;
 
-           if (showClad){
+           // Clad quarters start in 1965 — before that the coins are 90% silver and
+           // belong to the showSilver branch below. Without this floor the two
+           // branches generated the same 1932-1964 coins twice.
+           if (showClad && i >= 1965){
                if (showP) {
                    if (i >= 1980) {coinList.add(new CoinSlot(year, "P", coinIndex++));}
                    if (i < 1980){coinList.add(new CoinSlot(year, "", coinIndex++));}
@@ -118,9 +126,6 @@ public class WashingtonQuarters extends CollectionInfo {
                }
                if (showD) {
                    if (i != 1938 && (i < 1965 || i > 1967)) {coinList.add(new CoinSlot(year, "D", coinIndex++));}
-               }
-               if (showS) {
-                   if (i < 1955 && i != 1934 && i != 1949) {coinList.add(new CoinSlot(year, "S", coinIndex++));}
                }
                if (showProofs){
                    if (i > 1967){coinList.add(new CoinSlot(year, "S Proof", coinIndex++));}
@@ -161,6 +166,44 @@ public class WashingtonQuarters extends CollectionInfo {
 
     @Override
     public int onCollectionDatabaseUpgrade(SQLiteDatabase db, CollectionListInfo collectionListInfo,
-                                           int oldVersion, int newVersion) {return 0;}
+                                           int oldVersion, int newVersion) {
+        int total = 0;
+
+        if (oldVersion <= 26) {
+            // Before V27 the clad branch had no year floor, so it generated the
+            // 1932-1964 coins that belong to the silver branch. The years are
+            // deliberately literals rather than START_YEAR: an old migration must never
+            // pick up a constant's new value. 1933 simply matches nothing, since the
+            // generator has always skipped it.
+            final int firstCladYear = 1965;
+            final int firstQuarterYear = 1932;
+
+            if (collectionListInfo.hasCladCoins()) {
+                ArrayList<String> preCladIdentifiers = new ArrayList<>();
+                for (int year = firstQuarterYear; year < firstCladYear; year++) {
+                    preCladIdentifiers.add(Integer.toString(year));
+                }
+
+                if (collectionListInfo.hasSilverCoins()) {
+                    // Both branches ran, so every pre-1965 coin exists twice. Keep the
+                    // original row (lowest _id, the clad-branch one) so the remaining
+                    // coins stay in the same order a freshly created collection uses.
+                    total -= DatabaseHelper.removeDuplicateCoinsByIdentifier(db, collectionListInfo,
+                            preCladIdentifiers);
+                } else {
+                    // Clad-only: the pre-1965 coins exist exactly once and are wrong
+                    // outright — those quarters are silver, not clad — so remove them.
+                    // Custom coins are user-added and are always left alone.
+                    for (String identifier : preCladIdentifiers) {
+                        total -= runSqlDelete(db, collectionListInfo.getName(),
+                                COL_COIN_IDENTIFIER + "=? AND " + COL_CUSTOM_COIN + "=0",
+                                new String[]{identifier});
+                    }
+                }
+            }
+        }
+
+        return total;
+    }
 }
 

--- a/app/src/main/java/com/spencerpages/collections/WestPoint.java
+++ b/app/src/main/java/com/spencerpages/collections/WestPoint.java
@@ -20,6 +20,11 @@
 
 package com.spencerpages.collections;
 
+import static com.coincollection.CoinSlot.COL_COIN_IDENTIFIER;
+import static com.coincollection.CoinSlot.COL_CUSTOM_COIN;
+import static com.coincollection.DatabaseHelper.runSqlUpdate;
+
+import android.content.ContentValues;
 import android.database.sqlite.SQLiteDatabase;
 
 import com.coincollection.CoinSlot;
@@ -51,7 +56,7 @@ public class WestPoint extends CollectionInfo {
             {"2020 W Salt River Bay Quarter", R.drawable.parks_2020_salt_river_bay_unc},
             {"2020 W Marsh-Billings Quarter", R.drawable.parks_2020_marsh_billings_rockefeller_unc},
             {"2020 W Tallgrass Prairie Quarter", R.drawable.parks_2020_tallgrass_prairie_unc},
-            {"2014 W Reverse Proof Kennedy Halve", R.drawable.ha2018srevproof},
+            {"2014 W Reverse Proof Kennedy Half", R.drawable.ha2018srevproof},
             {"2006 W Burnished Silver Eagle", R.drawable.obv_american_eagle_unc},
             {"2007 W Burnished Silver Eagle", R.drawable.obv_american_eagle_unc},
             {"2008 W Burnished Silver Eagle", R.drawable.obv_american_eagle_unc},
@@ -111,5 +116,18 @@ public class WestPoint extends CollectionInfo {
 
     @Override
     public int onCollectionDatabaseUpgrade(SQLiteDatabase db, CollectionListInfo collectionListInfo,
-                                           int oldVersion, int newVersion) {return 0;}
+                                           int oldVersion, int newVersion) {
+        if (oldVersion <= 26) {
+            // Fix the "Kennedy Halve" typo. This string is both the persisted identifier
+            // and the COIN_MAP image-lookup key, so without this rename existing rows
+            // would fall back to the default image. The old value is deliberately a
+            // literal so this block can never track a later edit.
+            ContentValues values = new ContentValues();
+            values.put(COL_COIN_IDENTIFIER, "2014 W Reverse Proof Kennedy Half");
+            runSqlUpdate(db, collectionListInfo.getName(), values,
+                    COL_COIN_IDENTIFIER + "=? AND " + COL_CUSTOM_COIN + "=0",
+                    new String[]{"2014 W Reverse Proof Kennedy Halve"});
+        }
+        return 0;
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -361,6 +361,7 @@
     <string name="attr_two_cents">Two Cent coin images from Heritage Auctions via Wikimedia Commons</string>
     <string name="attr_half_cents">Half Cent images courtesy of the National Numismatic Collection, National Museum of American History via Wikimedia</string>
     <string name="attr_early_halfs">Flowing Hair, Draped Bust, Capped Bust, and Liberty Seated half Dollar images courtesy of Lost Dutchman Rare Coins and Wikimedia Commons</string>
+    <string name="attr_early_dollars">Flowing Hair, Draped Bust, Liberty Seated, and Trade dollar images courtesy of Lost Dutchman Rare Coins and Wikimedia Commons</string>
     <string name="attr_quarters">Eagle reverse quarter image by 636Buster via wikimedia other Washington quarter images by the US Mint</string>
 
 

--- a/app/src/test/java/com/spencerpages/CollectionCreationTests.java
+++ b/app/src/test/java/com/spencerpages/CollectionCreationTests.java
@@ -1851,14 +1851,14 @@ public class CollectionCreationTests extends BaseTestCase {
 
         // Show Mint Marks, P, D, S, Expected Result
         Object[][] tests = {
-                {true, true, false, false, false, false, true, true, 100},
-                {true, false, true, false, false, false, true, true, 92},
-                {true, false, false, true, false, false, true, true, 40},
+                {true, true, false, false, false, false, true, true, 68},
+                {true, false, true, false, false, false, true, true, 61},
+                {true, false, false, true, false, false, true, true, 20},
                 {true, false, false, false, true, false, true, true, 30},
                 {true, false, false, false, false, true, true, true, 9},
                 {true, true, true, true, true, true, true, false, 92},
-                {true, true, true, true, true, true, false, true, 179},
-                {true, true, true, true, true, true, true, true, 271},
+                {true, true, true, true, true, true, false, true, 96},
+                {true, true, true, true, true, true, true, true, 188},
         };
 
         for (Object[] test : tests) {

--- a/app/src/test/java/com/spencerpages/CollectionUpgradeTests.java
+++ b/app/src/test/java/com/spencerpages/CollectionUpgradeTests.java
@@ -2018,4 +2018,343 @@ public class CollectionUpgradeTests extends BaseTestCase {
         }
         return false;
     }
+
+    /**
+     * Builds a V23 collection whose coins are generated from the current (fixed) source,
+     * then rewrites a single value back to its pre-V27 buggy form so the V27 migration
+     * has something to repair. The default upgrade helpers cannot do this: they populate
+     * the "old" database from the current generator, so the bug is never present.
+     *
+     * @param collection          the collection type
+     * @param coinType            the coin type string
+     * @param collectionName      name for the test collection
+     * @param identifierToExclude if non-null, exclude coins whose identifier contains this
+     * @param parameters          creation parameters to use
+     * @param legacyValues        one or more corruptions to apply; each row is
+     *                            {column, currentValue, oldValue, matchColumn, matchValue}
+     *                            where matchColumn/matchValue may be null
+     */
+    private void assertLegacyValuesAreMigrated(CollectionInfo collection, String coinType,
+                                               String collectionName, String identifierToExclude,
+                                               ParcelableHashMap parameters,
+                                               String[][] legacyValues) {
+        TestDatabaseHelperV23 testDbHelper = new TestDatabaseHelperV23(ApplicationProvider.getApplicationContext());
+        SQLiteDatabase db = testDbHelper.getWritableDatabase();
+        createV23FromPopulateWithParams(db, collection, coinType, collectionName,
+                identifierToExclude, parameters);
+
+        for (String[] legacyValue : legacyValues) {
+            String column = legacyValue[0];
+            String currentValue = legacyValue[1];
+            String oldValue = legacyValue[2];
+            String matchColumn = legacyValue[3];
+            String matchValue = legacyValue[4];
+
+            ContentValues values = new ContentValues();
+            values.put(column, oldValue);
+            String where = column + "=?";
+            String[] whereArgs = new String[]{currentValue};
+            if (matchColumn != null) {
+                where = where + " AND " + matchColumn + "=?";
+                whereArgs = new String[]{currentValue, matchValue};
+            }
+            int updated = db.update("[" + collectionName + "]", values, where, whereArgs);
+            assertEquals("Expected exactly one coin to carry the pre-V27 value " + oldValue,
+                    1, updated);
+        }
+
+        db.close();
+        testDbHelper.close();
+
+        // Opening the database runs the upgrade, which must restore every corrected value
+        validateUpdatedDbWithParams(collection, collectionName, parameters);
+    }
+
+    /**
+     * The "1776-1796" bicentennial typo on the 40% silver BU half dollar must be
+     * migrated to "1776-1976" for Kennedy half dollar collections.
+     */
+    @Test
+    public void test_KennedyHalfDollarsBicentennialTypoMigration() {
+        CollectionInfo collection = new KennedyHalfDollars();
+        ParcelableHashMap parameters = new ParcelableHashMap();
+        collection.getCreationParameters(parameters);
+
+        assertLegacyValuesAreMigrated(collection, "Kennedy Half Dollars",
+                "Kennedy Bicentennial Typo", "2026", parameters,
+                new String[][]{{CoinSlot.COL_COIN_IDENTIFIER, "1776-1976", "1776-1796",
+                        CoinSlot.COL_COIN_MINT, String.format("S BU%n40%% Silver")}});
+    }
+
+    /**
+     * The same bicentennial typo must be migrated for silver half dollar collections.
+     */
+    @Test
+    public void test_SilverHalfDollarsBicentennialTypoMigration() {
+        CollectionInfo collection = new SilverHalfDollars();
+        ParcelableHashMap parameters = new ParcelableHashMap();
+        collection.getCreationParameters(parameters);
+
+        assertLegacyValuesAreMigrated(collection, "Silver Half Dollars",
+                "Silver Bicentennial Typo", "2026", parameters,
+                new String[][]{{CoinSlot.COL_COIN_IDENTIFIER, "1776-1976", "1776-1796",
+                        CoinSlot.COL_COIN_MINT, String.format("S BU%n40%% Silver")}});
+    }
+
+    /**
+     * Both "ProofType II" mint typos must be migrated for Cartwheels collections: the
+     * 1976 Eisenhower "S Proof Type II" and the 2021 Silver Eagle "W Proof Type II".
+     * These live in the mint column rather than the identifier column.
+     */
+    @Test
+    public void test_CartwheelsProofTypeTypoMigration() {
+        CollectionInfo collection = new Cartwheels();
+        ParcelableHashMap parameters = new ParcelableHashMap();
+        collection.getCreationParameters(parameters);
+
+        assertLegacyValuesAreMigrated(collection, "Cartwheels",
+                "Cartwheels ProofType Typo", "2026", parameters,
+                new String[][]{
+                        {CoinSlot.COL_COIN_MINT, String.format("S%nProof Type II"),
+                                String.format("S%nProofType II"), null, null},
+                        {CoinSlot.COL_COIN_MINT, "W Proof Type II", "W ProofType II", null, null},
+                });
+    }
+
+    /**
+     * The "Kennedy Halve" identifier typo must be migrated for West Point collections.
+     * This identifier doubles as the image-lookup key, so a missed rename would silently
+     * fall back to the default image.
+     */
+    @Test
+    public void test_WestPointKennedyHalveTypoMigration() {
+        CollectionInfo collection = new WestPoint();
+        ParcelableHashMap parameters = new ParcelableHashMap();
+        collection.getCreationParameters(parameters);
+
+        assertLegacyValuesAreMigrated(collection, "West Point Mint",
+                "West Point Halve Typo", null, parameters,
+                new String[][]{{CoinSlot.COL_COIN_IDENTIFIER,
+                        "2014 W Reverse Proof Kennedy Half",
+                        "2014 W Reverse Proof Kennedy Halve", null, null}});
+    }
+
+    /**
+     * Builds Washington quarter creation parameters with the given silver/clad checkboxes
+     * and every mint mark enabled.
+     */
+    private ParcelableHashMap getWashingtonParams(CollectionInfo collection,
+                                                  boolean showSilver, boolean showClad) {
+        ParcelableHashMap parameters = new ParcelableHashMap();
+        collection.getCreationParameters(parameters);
+        parameters.put(CoinPageCreator.OPT_SHOW_MINT_MARKS, Boolean.TRUE);
+        parameters.put(CoinPageCreator.OPT_SHOW_MINT_MARK_1, Boolean.TRUE);
+        parameters.put(CoinPageCreator.OPT_SHOW_MINT_MARK_2, Boolean.TRUE);
+        parameters.put(CoinPageCreator.OPT_SHOW_MINT_MARK_3, Boolean.TRUE);
+        parameters.put(CoinPageCreator.OPT_SHOW_MINT_MARK_4, Boolean.TRUE);
+        parameters.put(CoinPageCreator.OPT_SHOW_MINT_MARK_5, Boolean.TRUE);
+        parameters.put(CoinPageCreator.OPT_CHECKBOX_1, showSilver);
+        parameters.put(CoinPageCreator.OPT_CHECKBOX_2, showClad);
+        return parameters;
+    }
+
+    /**
+     * A pre-V27 Washington quarter collection with both Silver and Clad enabled has every
+     * 1932-1964 coin twice, because the clad branch had no year floor. The migration must
+     * deduplicate it while preserving collected status and leaving custom coins alone.
+     */
+    @Test
+    public void test_WashingtonQuartersCladSilverDeduplication() {
+
+        CollectionInfo collection = new WashingtonQuarters();
+        String coinType = "Washington Quarters";
+        String collectionName = "Washington Clad Silver Dup";
+
+        TestDatabaseHelperV23 testDbHelper = new TestDatabaseHelperV23(ApplicationProvider.getApplicationContext());
+        SQLiteDatabase db = testDbHelper.getWritableDatabase();
+
+        ParcelableHashMap parameters = getWashingtonParams(collection, true, true);
+        createV23FromPopulateWithParams(db, collection, coinType, collectionName, null, parameters);
+
+        // Re-create the pre-V27 duplication: every 1932-1964 coin was emitted by both the
+        // clad and the silver branch. Mark one duplicate collected to prove the status
+        // survives onto the kept row.
+        ArrayList<CoinSlot> generated = new ArrayList<>();
+        collection.populateCollectionLists(parameters, generated);
+        int duplicated = 0;
+        for (CoinSlot coin : generated) {
+            int year;
+            try {
+                year = Integer.parseInt(coin.getIdentifier());
+            } catch (NumberFormatException ignored) {
+                continue;
+            }
+            if (year >= 1965) {
+                continue;
+            }
+            ContentValues values = new ContentValues();
+            values.put(CoinSlot.COL_COIN_IDENTIFIER, coin.getIdentifier());
+            values.put(CoinSlot.COL_COIN_MINT, coin.getMint());
+            values.put(CoinSlot.COL_IN_COLLECTION, "1940".equals(coin.getIdentifier()) ? 1 : 0);
+            values.put(CoinSlot.COL_SORT_ORDER, 9000 + duplicated);
+            db.insert("[" + collectionName + "]", null, values);
+            duplicated++;
+        }
+        assertTrue("Expected pre-1965 coins to duplicate", duplicated > 0);
+
+        // A user-added coin that collides with a generated identifier must survive
+        ContentValues customCoin = new ContentValues();
+        customCoin.put(CoinSlot.COL_COIN_IDENTIFIER, "1950");
+        customCoin.put(CoinSlot.COL_COIN_MINT, "");
+        customCoin.put(CoinSlot.COL_IN_COLLECTION, 1);
+        customCoin.put(CoinSlot.COL_SORT_ORDER, 9999);
+        customCoin.put(CoinSlot.COL_CUSTOM_COIN, 1);
+        db.insert("[" + collectionName + "]", null, customCoin);
+
+        ContentValues totalUpdate = new ContentValues();
+        totalUpdate.put(CollectionListInfo.COL_TOTAL, generated.size() + duplicated + 1);
+        db.update(CollectionListInfo.TBL_COLLECTION_INFO, totalUpdate,
+                CollectionListInfo.COL_NAME + "=?", new String[]{collectionName});
+
+        db.close();
+        testDbHelper.close();
+
+        assertUpgradedMatchesGenerated(collection, collectionName, parameters, "1950", true);
+    }
+
+    /**
+     * A pre-V27 clad-only Washington quarter collection has 1932-1964 coins that the clad
+     * branch should never have produced — those quarters are silver. They exist exactly
+     * once, so deduplication cannot help; the migration must delete them outright while
+     * leaving custom coins alone.
+     */
+    @Test
+    public void test_WashingtonQuartersCladOnlyPre1965Removal() {
+
+        CollectionInfo collection = new WashingtonQuarters();
+        String coinType = "Washington Quarters";
+        String collectionName = "Washington Clad Only";
+
+        TestDatabaseHelperV23 testDbHelper = new TestDatabaseHelperV23(ApplicationProvider.getApplicationContext());
+        SQLiteDatabase db = testDbHelper.getWritableDatabase();
+
+        ParcelableHashMap parameters = getWashingtonParams(collection, false, true);
+        createV23FromPopulateWithParams(db, collection, coinType, collectionName, null, parameters);
+
+        // Re-create the pre-V27 clad branch, which ran with no year floor. Mark them
+        // collected to prove the removal is unconditional, as intended.
+        int added = 0;
+        for (int year = 1932; year < 1965; year++) {
+            if (year == 1933) {
+                continue;
+            }
+            String identifier = Integer.toString(year);
+            for (String mint : new String[]{"", "D", "S"}) {
+                ContentValues values = new ContentValues();
+                values.put(CoinSlot.COL_COIN_IDENTIFIER, identifier);
+                values.put(CoinSlot.COL_COIN_MINT, mint);
+                values.put(CoinSlot.COL_IN_COLLECTION, 1);
+                values.put(CoinSlot.COL_SORT_ORDER, 9000 + added);
+                db.insert("[" + collectionName + "]", null, values);
+                added++;
+            }
+        }
+        assertTrue("Expected legacy pre-1965 clad coins", added > 0);
+
+        // A user-added pre-1965 coin must survive even though the generated ones don't
+        ContentValues customCoin = new ContentValues();
+        customCoin.put(CoinSlot.COL_COIN_IDENTIFIER, "1940");
+        customCoin.put(CoinSlot.COL_COIN_MINT, "Custom");
+        customCoin.put(CoinSlot.COL_IN_COLLECTION, 1);
+        customCoin.put(CoinSlot.COL_SORT_ORDER, 9999);
+        customCoin.put(CoinSlot.COL_CUSTOM_COIN, 1);
+        db.insert("[" + collectionName + "]", null, customCoin);
+
+        ArrayList<CoinSlot> generated = new ArrayList<>();
+        collection.populateCollectionLists(parameters, generated);
+        ContentValues totalUpdate = new ContentValues();
+        totalUpdate.put(CollectionListInfo.COL_TOTAL, generated.size() + added + 1);
+        db.update(CollectionListInfo.TBL_COLLECTION_INFO, totalUpdate,
+                CollectionListInfo.COL_NAME + "=?", new String[]{collectionName});
+
+        db.close();
+        testDbHelper.close();
+
+        assertUpgradedMatchesGenerated(collection, collectionName, parameters, "1940", false);
+    }
+
+    /**
+     * Launches the app to run the pending upgrade, then asserts that the non-custom coins
+     * exactly match a freshly generated collection and that the single custom coin
+     * survived.
+     *
+     * @param collection        the collection type
+     * @param collectionName    name of the upgraded collection
+     * @param parameters        creation parameters used to build the reference list
+     * @param customIdentifier  identifier of the custom coin that must survive
+     * @param expectCollectedAt whether a pre-1965 "1940" coin should end up collected
+     */
+    private void assertUpgradedMatchesGenerated(final CollectionInfo collection,
+                                                final String collectionName,
+                                                final ParcelableHashMap parameters,
+                                                final String customIdentifier,
+                                                final boolean expectCollectedAt) {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(
+                new Intent(ApplicationProvider.getApplicationContext(), MainActivity.class))) {
+            scenario.onActivity(activity -> {
+
+                ArrayList<CoinSlot> expectedCoins = new ArrayList<>();
+                collection.populateCollectionLists(parameters, expectedCoins);
+
+                ArrayList<CoinSlot> dbCoins = activity.mDbAdapter.getCoinList(collectionName, true);
+                assertNotNull(dbCoins);
+
+                ArrayList<CoinSlot> dbNonCustom = new ArrayList<>();
+                ArrayList<CoinSlot> dbCustom = new ArrayList<>();
+                for (CoinSlot coin : dbCoins) {
+                    if (coin.isCustomCoin()) {
+                        dbCustom.add(coin);
+                    } else {
+                        dbNonCustom.add(coin);
+                    }
+                }
+
+                assertEquals("Non-custom coins should match a freshly created collection",
+                        expectedCoins.size(), dbNonCustom.size());
+                for (int i = 0; i < expectedCoins.size(); i++) {
+                    assertEquals(expectedCoins.get(i).getIdentifier(), dbNonCustom.get(i).getIdentifier());
+                    assertEquals(expectedCoins.get(i).getMint(), dbNonCustom.get(i).getMint());
+                    assertEquals(expectedCoins.get(i).getImageId(), dbNonCustom.get(i).getImageId());
+                }
+
+                assertEquals("Custom coin should be preserved", 1, dbCustom.size());
+                assertEquals(customIdentifier, dbCustom.get(0).getIdentifier());
+
+                if (expectCollectedAt) {
+                    // The collected status of a removed duplicate moves onto the kept row
+                    boolean foundCollected = false;
+                    for (CoinSlot coin : dbNonCustom) {
+                        if ("1940".equals(coin.getIdentifier()) && coin.isInCollection()) {
+                            foundCollected = true;
+                            break;
+                        }
+                    }
+                    assertTrue("Collected status should survive deduplication", foundCollected);
+                }
+
+                ArrayList<CollectionListInfo> collectionListEntries = new ArrayList<>();
+                activity.mDbAdapter.getAllTables(collectionListEntries);
+                boolean foundTable = false;
+                for (CollectionListInfo info : collectionListEntries) {
+                    if (collectionName.equals(info.getName())) {
+                        foundTable = true;
+                        assertEquals("Total should include the custom coin",
+                                expectedCoins.size() + 1, info.getMax());
+                        break;
+                    }
+                }
+                assertTrue(foundTable);
+            });
+        }
+    }
 }

--- a/shared-test/src/main/java/com/spencerpages/SharedTest.java
+++ b/shared-test/src/main/java/com/spencerpages/SharedTest.java
@@ -140,7 +140,7 @@ public class SharedTest {
                     new CollectionListInfo("Coin Sets", 182, 0, getIndexFromCollectionClass(CoinSets.class), 0, 1947, 2023, "0", "492581209243649"),
                     new CollectionListInfo("Kennedy Half Dollars", 231, 0, getIndexFromCollectionClass(KennedyHalfDollars.class), 0, 1964, 2023, "2439", "598134325510185"),
                     new CollectionListInfo("Roosevelt Dimes", 288, 0, getIndexFromCollectionClass(RooseveltDimes.class), 0, 1946, 2023, "2511", "598134325510185"),
-                    new CollectionListInfo("Washington Quarters", 271, 0, getIndexFromCollectionClass(WashingtonQuarters.class), 0, 1932, 1998, "399", "35184372088841"),
+                    new CollectionListInfo("Washington Quarters", 188, 0, getIndexFromCollectionClass(WashingtonQuarters.class), 0, 1932, 1998, "399", "35184372088841"),
                     new CollectionListInfo("Innovation Dollars", 132, 0, getIndexFromCollectionClass(AmericanInnovationDollars.class), 0, 0, 0, "647", "0"),
                     new CollectionListInfo("SemiQ 2026", 18, 0, getIndexFromCollectionClass(Semiquincentennials.class), 0, 0, 0, "7", "0"),
             };


### PR DESCRIPTION
## Description

Several collection classes carried data bugs that were persisted into user databases. This fixes the generators *and* migrates existing collections in one `DATABASE_VERSION` bump (26 → 27), with every new block gated on `oldVersion <= 26`.

### Bugs fixed

| Class | Bug |
| --- | --- |
| `KennedyHalfDollars`, `SilverHalfDollars` | The 40% silver BU bicentennial half dollar used the identifier `"1776-1796"` instead of `"1776-1976"` |
| `WashingtonQuarters` | The clad branch had no year floor, so it generated the 1932–1964 coins that belong to the silver branch |
| `Cartwheels` | `"S\nProofType II"` and `"W ProofType II"` mint marks were missing a space |
| `WestPoint` | `"2014 W Reverse Proof Kennedy Halve"` should be `"Kennedy Half"` |
| `KennedyHalfDollars` | `COIN_IMG_IDS` repeated three name keys at indices 15–17 |
| `EarlyDollars` | Returned the *half dollar* attribution string |
| `BasicQuarters` | `STOP_YEAR` was a hardcoded `2026` |

### Notes on the trickier ones

**Washington quarters.** With both Silver and Clad checked, every pre-1965 coin was created twice. With only Clad checked, the collection got silver quarters it should never have contained. The clad branch is now bound to 1965 (matching `CladQuarters`' 1965 and `RooseveltDimes`' `i > 1964`), and the now-dead pre-1955 `S` sub-branch is dropped. The migration deduplicates when both boxes are set and removes the stray pre-1965 coins when only Clad is set.

⚠️ The clad-only path deletes rows that may be marked collected. Custom coins are left alone, but generated pre-1965 slots and their collected status are removed — those quarters are silver, so the "Clad" checkbox should never have produced them.

**West Point.** That string is both the persisted identifier *and* the `COIN_MAP` image-lookup key, so renaming it in source without a migration would make existing rows fall back to the default image.

**Kennedy image keys.** `getImgId` returns the first match, so indices 15–17 were unreachable and showed up as duplicate entries in the image picker. Renamed in place — indices and drawables are unchanged, so no persisted `imageId` changes meaning.

**BasicQuarters.** `OPTVAL_STILL_IN_PRODUCTION` is `2026` today, so this is future-proofing with no behavior change.

### Migration safety

- Every block uses `oldVersion <= 26`, never `==`.
- Old values are written as literals rather than referencing constants, so the blocks can't silently track a later edit.
- Custom coins (`customCoin = 1`) are excluded from every update and delete — their values are user-entered.
- No `!fromImport` guard: these are data-value migrations, not schema changes, and imported databases carry the same bad values.
- `COLLECTION_TYPE` strings, `COLLECTION_TYPES[]` order, and all `COIN_IMG_IDS` ordering are untouched.

## Testing

`./gradlew testAndroidDebugUnitTest lintAndroidDebug` — 733 tests, 0 failures, lint clean.

- **Six new `CollectionUpgradeTests` cases** that inject the old buggy values directly. This was necessary because the existing helpers build their "old" database from the *current* generator, so they can't reproduce these bugs at all. Verified non-vacuous: with the migrations disabled, all six fail.
- **The checked-in v23 fixtures already contain every one of these bugs** — including a Washington collection with exactly 83 duplicate pairs (`P 32 + D 31 + S 20` for 1932–1964) and a clad-only collection with 32 stray pre-1965 rows. `CollectionUpgradeAllParamsTests` compares upgraded fixtures element-by-element against fresh generation, so it gates these migrations against real data. All four fail without the migrations. **The fixtures are deliberately left unmodified** — regenerating them would erase the bugs and destroy that coverage.
- Updated the Washington expected counts in `CollectionCreationTests` (100→68, 92→61, 40→20, 179→96, 271→188) and the `SharedTest` scenario total 271→188. Only configurations with Clad enabled change; silver-only rows are unaffected.

## Out of scope

- `EarlyQuarters` indices 0–2 still map to half-dollar drawables. The repo has never contained Draped Bust / Capped Bust / Seated *quarter* obverses, so fixing this needs sourced, licensed images rather than a code change.
- Multi-source attributions for the composite collections that embed images from several Wikimedia sources.