### PR TITLE
Single-source app version in version.properties

### DIFF
--- a/.github/prompts/release-checklist.prompt.md
+++ b/.github/prompts/release-checklist.prompt.md
@@ -30,10 +30,10 @@ No new errors should be introduced. Warnings are acceptable if pre-existing.
 
 ### 3. Version is bumped
 
-Read `app/src/main/AndroidManifest.xml` and check:
+Read `version.properties` at the repo root and check:
 
-- `android:versionCode` — must be incremented from the last release
-- `android:versionName` — must reflect the new version string
+- `versionCode` — must be incremented from the last release
+- `versionName` — must reflect the new version string
 
 Compare with the latest git tag to confirm the version has changed:
 

--- a/.github/skills/release-checklist/SKILL.md
+++ b/.github/skills/release-checklist/SKILL.md
@@ -3,7 +3,7 @@ name: release-checklist
 description: >
   Run the pre-release verification checklist before triggering the GitHub
   Actions release workflow. Verifies unit tests, lint, version bump in
-  AndroidManifest.xml, DATABASE_VERSION, store metadata, screenshots, and
+  version.properties, DATABASE_VERSION, store metadata, screenshots, and
   git state, then reports a summary table. Use when asked to run the release
   checklist, verify release readiness, or check that everything is ready
   before a release.
@@ -35,10 +35,10 @@ No new errors should be introduced. Warnings are acceptable if pre-existing.
 
 ### 3. Version is bumped
 
-Read `app/src/main/AndroidManifest.xml` and check:
+Read `version.properties` at the repo root and check:
 
-- `android:versionCode` — must be incremented from the last release
-- `android:versionName` — must reflect the new version string
+- `versionCode` — must be incremented from the last release
+- `versionName` — must reflect the new version string
 
 Compare with the latest git tag to confirm the version has changed:
 

--- a/.github/skills/ui-regression-test/SKILL.md
+++ b/.github/skills/ui-regression-test/SKILL.md
@@ -102,7 +102,7 @@ A first-time tutorial dialog ("Thanks for downloading...") will appear — dismi
 7. Tap the "Sanity Test" collection — verify the `CollectionPage` opens (look for `standard_collection_page` GridView; no tutorial dialog this time since it was dismissed in step 6)
 8. Take a screenshot
 9. Navigate back to main activity
-10. Tap "App Info" — verify a dialog appears containing "Coin Collection" and a version string matching the `versionName` in `app/src/main/AndroidManifest.xml` — press BACK to dismiss
+10. Tap "App Info" — verify a dialog appears containing "Coin Collection" and a version string matching the `versionName` in `version.properties` — press BACK to dismiss
 11. Tap "Reorder Collections" — a tutorial dialog appears on first use — dismiss it with "OKAY!" — verify the reorder screen loads (look for `reorder_collections_recycler_view` with the collection name and up/down arrows) — press BACK
 
 **Pass criteria:** App launches; CoinPageCreator, CollectionPage, App Info, and Reorder screens all render without crashes.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ on:
           - production  # Public production track
         default: 'internal'
       release_tag:
-        description: "Optional. GitHub Release tag to deploy (e.g. v3.2.0). Leave blank to use the version currently in main's AndroidManifest.xml."
+        description: "Optional. GitHub Release tag to deploy (e.g. v3.2.0). Leave blank to use the version currently in main's version.properties."
         required: false
         type: string
         default: ''
@@ -54,7 +54,7 @@ jobs:
       - name: Checkout main branch
         uses: actions/checkout@v7
         with:
-          ref: 'main' # main carries the latest manifest; used as default version source.
+          ref: 'main' # main carries the latest version.properties; used as default version source.
 
       - name: Resolve target version and tag
         id: resolve_version
@@ -69,27 +69,27 @@ jobs:
             VERSION_NAME="${TAG#v}"
             echo "Using operator-supplied tag: $TAG (versionName=$VERSION_NAME)"
           else
-            MANIFEST_PATH="app/src/main/AndroidManifest.xml"
-            if [ ! -f "$MANIFEST_PATH" ]; then
-              echo "AndroidManifest.xml not found at $MANIFEST_PATH"
+            VERSION_PROPS_PATH="version.properties"
+            if [ ! -f "$VERSION_PROPS_PATH" ]; then
+              echo "version.properties not found at $VERSION_PROPS_PATH"
               exit 1
             fi
-            VERSION_NAME=$(grep 'android:versionName=' "$MANIFEST_PATH" | sed -n 's/.*android:versionName="\([^"]*\)".*/\1/p')
+            VERSION_NAME=$(grep -E '^versionName=' "$VERSION_PROPS_PATH" | cut -d= -f2- | tr -d '[:space:]')
             if [ -z "$VERSION_NAME" ]; then
-              echo "Could not extract versionName from $MANIFEST_PATH"
+              echo "Could not extract versionName from $VERSION_PROPS_PATH"
               exit 1
             fi
             TAG="v$VERSION_NAME"
-            echo "Derived tag from main's manifest: $TAG"
+            echo "Derived tag from main's version.properties: $TAG"
           fi
 
           # versionCode is only used to name the Amazon changelog file. When an
-          # explicit tag is supplied, we cannot trust main's manifest (the tag
-          # may predate it), so use 0 as a sentinel and the Fastfile will skip
-          # writing the Amazon changelog file. Fastlane's `supply` derives the
+          # explicit tag is supplied, we cannot trust main's version.properties
+          # (the tag may predate it), so use 0 as a sentinel and the Fastfile will
+          # skip writing the Amazon changelog file. Fastlane's `supply` derives the
           # Play versionCode from the APK directly.
           if [ -z "$INPUT_RELEASE_TAG" ]; then
-            VERSION_CODE=$(grep 'android:versionCode=' "app/src/main/AndroidManifest.xml" | sed -n 's/.*android:versionCode="\([0-9]*\)".*/\1/p')
+            VERSION_CODE=$(grep -E '^versionCode=' version.properties | cut -d= -f2- | tr -d '[:space:]')
           else
             VERSION_CODE="0"
           fi

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -45,10 +45,14 @@ jobs:
         run: |
           set -euo pipefail
           COMMIT_SHA="$(git rev-parse HEAD)"
-          MANIFEST_PATH="app/src/main/AndroidManifest.xml"
-          VERSION_CODE=$(grep 'android:versionCode=' "$MANIFEST_PATH" | sed -n 's/.*android:versionCode="\([0-9]*\)".*/\1/p')
+          VERSION_PROPS_PATH="version.properties"
+          if [ ! -f "$VERSION_PROPS_PATH" ]; then
+            echo "$VERSION_PROPS_PATH not found at ${{ steps.parse.outputs.rc_tag }}. Pre-release tags cut before the version moved out of AndroidManifest.xml cannot be promoted by this workflow."
+            exit 1
+          fi
+          VERSION_CODE=$(grep -E '^versionCode=' "$VERSION_PROPS_PATH" | cut -d= -f2- | tr -d '[:space:]')
           if [ -z "$VERSION_CODE" ]; then
-            echo "Could not extract versionCode from $MANIFEST_PATH at ${{ steps.parse.outputs.rc_tag }}"
+            echo "Could not extract versionCode from $VERSION_PROPS_PATH at ${{ steps.parse.outputs.rc_tag }}"
             exit 1
           fi
           echo "commit_sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,27 +21,27 @@ jobs:
         with:
           fetch-depth: 0 # Needed for changelog generation between tags
 
-      - name: Extract versionName and versionCode from Manifest
+      - name: Extract versionName and versionCode from version.properties
         id: extract_versions
         run: |
-          MANIFEST_PATH="app/src/main/AndroidManifest.xml"
-          if [ ! -f "$MANIFEST_PATH" ]; then
-            echo "AndroidManifest.xml not found"
+          VERSION_PROPS_PATH="version.properties"
+          if [ ! -f "$VERSION_PROPS_PATH" ]; then
+            echo "version.properties not found"
             exit 1
           fi
           
-          VERSION_NAME=$(grep 'android:versionName=' "$MANIFEST_PATH" | sed -n 's/.*android:versionName="\([^"]*\)".*/\1/p')
-          VERSION_CODE=$(grep 'android:versionCode=' "$MANIFEST_PATH" | sed -n 's/.*android:versionCode="\([0-9]*\)".*/\1/p')
+          VERSION_NAME=$(grep -E '^versionName=' "$VERSION_PROPS_PATH" | cut -d= -f2- | tr -d '[:space:]')
+          VERSION_CODE=$(grep -E '^versionCode=' "$VERSION_PROPS_PATH" | cut -d= -f2- | tr -d '[:space:]')
           
           if [ -z "$VERSION_NAME" ] || [ -z "$VERSION_CODE" ]; then
-            echo "Could not extract versionName or versionCode from $MANIFEST_PATH"
+            echo "Could not extract versionName or versionCode from $VERSION_PROPS_PATH"
             exit 1
           fi
           
           echo "Extracted versionName: $VERSION_NAME"
           echo "Extracted versionCode: $VERSION_CODE"
-          echo "manifest_version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
-          echo "manifest_version_code=$VERSION_CODE" >> $GITHUB_OUTPUT
+          echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
+          echo "version_code=$VERSION_CODE" >> $GITHUB_OUTPUT
 
       - name: Verify checked-in release notes exist
         # Release notes are checked into the repo at
@@ -51,7 +51,7 @@ jobs:
         id: release_notes
         run: |
           set -euo pipefail
-          VC="${{ steps.extract_versions.outputs.manifest_version_code }}"
+          VC="${{ steps.extract_versions.outputs.version_code }}"
           NOTES_FILE="fastlane/metadata/android/en-US/changelogs/${VC}.txt"
           if [ ! -s "$NOTES_FILE" ]; then
             echo "::error::Release notes file $NOTES_FILE is missing or empty. Add it (checked in) before running this workflow."
@@ -75,7 +75,7 @@ jobs:
           INPUT_RC_NUMBER: ${{ github.event.inputs.rc_number }}
         run: |
           set -euo pipefail
-          VERSION_NAME="${{ steps.extract_versions.outputs.manifest_version_name }}"
+          VERSION_NAME="${{ steps.extract_versions.outputs.version_name }}"
           # Sanitize the RC number to digits only, then strip leading zeros so
           # e.g. "007" -> "7" (and "0" / "000" -> ""). This rejects 0, which would
           # otherwise produce a meaningless "-rc.0" tag.
@@ -91,7 +91,7 @@ jobs:
           # Fetch all tags from remote so local git is authoritative.
           git fetch --tags --force
           if git rev-parse "$FINAL_TAG" >/dev/null 2>&1; then
-            echo "Error: Final tag $FINAL_TAG already exists; this version was already released. Bump android:versionName before pre-releasing."
+            echo "Error: Final tag $FINAL_TAG already exists; this version was already released. Bump versionName in version.properties before pre-releasing."
             exit 1
           fi
           if git rev-parse "$RC_TAG" >/dev/null 2>&1; then
@@ -136,12 +136,12 @@ jobs:
           SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
         run: |
           chmod +x ./gradlew
-          # Gradle uses versionName and versionCode from the manifest directly
+          # Gradle reads versionName and versionCode from version.properties
           ./gradlew :app:assembleAndroidRelease :app:assembleAmazonRelease 
 
       - name: Verify Versioned APKs Exist
         run: |
-          MVN="${{ steps.extract_versions.outputs.manifest_version_name }}" # Manifest Version Name
+          MVN="${{ steps.extract_versions.outputs.version_name }}" # Version Name
           echo "Checking for app/build/outputs/apk/android/release/app-android-release-v${MVN}.apk"
           test -f "app/build/outputs/apk/android/release/app-android-release-v${MVN}.apk"
           echo "Checking for app/build/outputs/apk/amazon/release/app-amazon-release-v${MVN}.apk"
@@ -154,7 +154,7 @@ jobs:
         # an unsigned/debug-signed APK could be uploaded to a GitHub Release and only
         # rejected later by the Play/Amazon stores.
         run: |
-          MVN="${{ steps.extract_versions.outputs.manifest_version_name }}"
+          MVN="${{ steps.extract_versions.outputs.version_name }}"
           APKSIGNER=$(find "$ANDROID_HOME/build-tools" -name apksigner -type f | sort -V | tail -n 1)
           if [ -z "$APKSIGNER" ]; then
             echo "apksigner not found in \$ANDROID_HOME/build-tools"
@@ -198,7 +198,7 @@ jobs:
         env:
           RC_TAG: ${{ steps.check_tag.outputs.rc_tag }}
         run: |
-          MVN="${{ steps.extract_versions.outputs.manifest_version_name }}"
+          MVN="${{ steps.extract_versions.outputs.version_name }}"
           # Prepend a pre-release notice to the checked-in release notes so
           # internal testers can tell this is a release candidate, not the final
           # build. The Fastfile prepends this to the ephemeral CI copy of
@@ -207,7 +207,7 @@ jobs:
           bundle exec fastlane deploy_playstore_test \
             apk_path:"${{ github.workspace }}/app/build/outputs/apk/android/release/app-android-release-v${MVN}.apk" \
             version_name:"${MVN}" \
-            version_code:"${{ steps.extract_versions.outputs.manifest_version_code }}" \
+            version_code:"${{ steps.extract_versions.outputs.version_code }}" \
             track:"internal" \
             prerelease_notice:"$PRERELEASE_NOTICE"
 
@@ -217,8 +217,8 @@ jobs:
           tag_name: ${{ steps.check_tag.outputs.rc_tag }}
           name: Pre-release ${{ steps.check_tag.outputs.rc_tag }}
           files: |
-            app/build/outputs/apk/android/release/app-android-release-v${{ steps.extract_versions.outputs.manifest_version_name }}.apk
-            app/build/outputs/apk/amazon/release/app-amazon-release-v${{ steps.extract_versions.outputs.manifest_version_name }}.apk
+            app/build/outputs/apk/android/release/app-android-release-v${{ steps.extract_versions.outputs.version_name }}.apk
+            app/build/outputs/apk/amazon/release/app-amazon-release-v${{ steps.extract_versions.outputs.version_name }}.apk
           fail_on_unmatched_files: true
           draft: false
           prerelease: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,10 +44,11 @@ generation.
 - `DATABASE_VERSION` and `DATABASE_NAME` live in
   `app/src/main/java/com/spencerpages/MainApplication.java` — **not** in
   `DatabaseHelper`. Never hardcode the current version number; check the file.
-- `versionCode`/`versionName` live in `app/src/main/AndroidManifest.xml` —
-  atypical for Android projects (NOT in `build.gradle`). Three release
-  workflows (`release.yml`, `promote.yml`, `deploy.yml`) grep them from there,
-  so keep them in the manifest.
+- `versionCode`/`versionName` live in the repo-root `version.properties` — NOT
+  in `AndroidManifest.xml` and NOT literal values in `build.gradle`.
+  `app/build.gradle` reads that file into `defaultConfig`, and three release
+  workflows (`release.yml`, `promote.yml`, `deploy.yml`) grep it, so keep it as
+  the single source of truth.
 - Every Java file needs the GPL-3.0 license header block — copy it from any
   existing Java file in the repo.
 - `compileSdk 37` / `minSdk 21`. The `amazon` flavor pins `targetSdk 35`

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -58,7 +58,7 @@ The pipeline has two operator-driven stages.
 
 ```text
   bump version in          release.yml                    promote.yml
-  AndroidManifest.xml ─►   (Stage 1, Step 1.1)       ─►   (Stage 2, Step 1.3)
+  version.properties  ─►   (Stage 1, Step 1.1)       ─►   (Stage 2, Step 1.3)
   + merge to main          tag vX.Y.Z-rc.N                tag vX.Y.Z
                            GitHub pre-release             final GitHub Release
                            + Play internal                + Play production + Amazon
@@ -71,8 +71,8 @@ The pipeline has two operator-driven stages.
 
 ### 1.1 Build and publish the pre-release
 
-1. Bump `android:versionName` **and** `android:versionCode` in
-   [`app/src/main/AndroidManifest.xml`](app/src/main/AndroidManifest.xml).
+1. Bump `versionName` **and** `versionCode` in
+   [`version.properties`](version.properties) at the repo root.
    `versionCode` must strictly increase from the last published value on
    every store. Because the app has been published for years, the current
    value is already well into the dozens — just `+1` from whatever's on
@@ -187,8 +187,9 @@ checked-in file.
   - Uploads to the Amazon Appstore via `fastlane-plugin-amazon_appstore`.
     Used by the promote workflow.
   - Inputs: `apk_path`, `version_code`, optional `release_notes`. The promote
-    workflow passes the real `version_code` (read from the manifest at the RC
-    tag), so the Amazon changelog is read from `changelogs/<versionCode>.txt`. A
+    workflow passes the real `version_code` (read from `version.properties` at
+    the RC tag), so the Amazon changelog is read from
+    `changelogs/<versionCode>.txt`. A
     `version_code` of `0` (the sentinel used by the optional `deploy.yml`
     fallback) skips the file lookup and reuses existing metadata.
 
@@ -199,8 +200,7 @@ checked-in file.
 **Pre-release workflow fails with `Tag vX.Y.Z already exists` (or
 `vX.Y.Z-rc.N already exists`).**
 The final tag exists because this version was already released — bump
-`android:versionName` in
-[`app/src/main/AndroidManifest.xml`](app/src/main/AndroidManifest.xml) and
+`versionName` in [`version.properties`](version.properties) and
 merge to `main`. If only the RC tag exists, just pick a higher `rc_number`
 and re-run.
 
@@ -236,7 +236,8 @@ version and start a new pre-release.
 
 **Deploy fails: `Google Api Error: ... versionCode N has already been used`.**
 The `versionCode` in the APK has been uploaded to Play before. You cannot
-re-use a versionCode on Google Play. Bump `android:versionCode` and run the
+re-use a versionCode on Google Play. Bump `versionCode` in
+[`version.properties`](version.properties) and run the
 pre-release workflow again.
 
 **Deploy fails: `... GOOGLE_PLAY_JSON_KEY_DATA did not parse as JSON`.**

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,17 @@ plugins {
     id 'com.android.application'
 }
 
+// The app version is single-sourced from the repo-root version.properties,
+// shared with the three release workflows. Read it through providers.fileContents
+// so the file is a tracked configuration input (the configuration cache is
+// enabled in gradle.properties).
+def versionProps = new Properties()
+versionProps.load(new StringReader(
+        providers.fileContents(rootProject.layout.projectDirectory.file('version.properties'))
+                .asText.get()))
+def appVersionCode = versionProps.getProperty('versionCode').trim().toInteger()
+def appVersionName = versionProps.getProperty('versionName').trim()
+
 android {
     signingConfigs {
         Android {
@@ -44,6 +55,8 @@ android {
         applicationId = "com.spencerpages"
         minSdk = 21
         targetSdk = 37
+        versionCode = appVersionCode
+        versionName = appVersionName
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
@@ -57,11 +70,6 @@ android {
             // produces an unsigned release APK (CI always provides the keystore).
             if (signingConfigs.Android.storeFile != null) {
                 signingConfig = signingConfigs.Android
-            }
-            android.applicationVariants.all { variant ->
-                variant.outputs.all {
-                    outputFileName = "app-${variant.flavorName}-${variant.buildType.name}-v${variant.versionName}.apk"
-                }
             }
         }
         debug {
@@ -122,6 +130,18 @@ android {
     packagingOptions {
         resources {
             merges += ['META-INF/LICENSE.md', 'META-INF/LICENSE-notice.md']
+        }
+    }
+}
+
+// Name every APK app-<flavor>-<buildType>-v<versionName>.apk. This applies to
+// debug as well as release: fastlane/Fastfile and release.yml both look up APKs
+// by that exact name.
+androidComponents {
+    onVariants(selector().all()) { variant ->
+        variant.outputs.each { output ->
+            output.outputFileName.set(
+                    "app-${variant.flavorName}-${variant.buildType}-v${appVersionName}.apk")
         }
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:versionCode="41"
-    android:versionName="3.8.4">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Reorder view, long press menu, and menu options require a touchscreen -->
     <uses-feature android:name="android.hardware.touchscreen"

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,6 @@ android.r8.strictFullModeForKeepRules=false
 android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
 android.uniquePackageNames=false
 android.useAndroidX=true
-android.usesSdkInManifest.disallowed=false
 org.gradle.configuration-cache=true
 org.gradle.jvmargs=-Xmx3g
 android.generateSyncIssueWhenLibraryConstraintsAreEnabled=false

--- a/version.properties
+++ b/version.properties
@@ -1,0 +1,10 @@
+# Single source of truth for the app version.
+#
+# Read by app/build.gradle (defaultConfig) and by the three release workflows
+# (.github/workflows/release.yml, promote.yml, deploy.yml). Bump both values
+# together before cutting a release; see DEPLOYMENT.md.
+#
+# versionCode must strictly increase and must exceed the latest versionCode
+# published on Google Play and the Amazon Appstore.
+versionCode=41
+versionName=3.8.4


### PR DESCRIPTION
## Summary

`versionCode`/`versionName` lived in `app/src/main/AndroidManifest.xml` and were scraped by three release workflows with `grep | sed`. This moves them to a repo-root `version.properties` read by `app/build.gradle`'s `defaultConfig`, so the version is defined exactly once.

Also migrates the APK output-rename off the legacy variant API and drops one AGP-9 opt-out flag.

## Changes

- **New `version.properties`** at the repo root (`versionCode=41`, `versionName=3.8.4` — same values as before).
- **`app/build.gradle`** reads it via `providers.fileContents(...)` so the file is a tracked configuration-cache input, and sets `versionCode`/`versionName` in `defaultConfig`.
- **`AndroidManifest.xml`**: `android:versionCode` / `android:versionName` removed.
- **Output rename migrated** from `android.applicationVariants.all { ... }` — which was confusingly nested inside `buildTypes.release {}` even though it renamed *every* variant — to a top-level `androidComponents { onVariants { ... } }` block. Naming is unchanged (`app-<flavor>-<buildType>-v<versionName>.apk`) and still applies to debug, which `fastlane/Fastfile:112` depends on. This clears AGP's obsolete-API warning.
- **`gradle.properties`**: dropped `android.usesSdkInManifest.disallowed=false`.
- **`release.yml` / `promote.yml` / `deploy.yml`** all read `version.properties` with an identical `grep -E` + `cut` + `tr` snippet. Stale comments, error messages, and the `deploy.yml` input description updated; `release.yml`'s `manifest_version_*` step outputs renamed to `version_*`.
- **Docs updated in the same PR**: `CLAUDE.md`, `DEPLOYMENT.md`, `.github/skills/release-checklist/SKILL.md`, `.github/prompts/release-checklist.prompt.md`, `.github/skills/ui-regression-test/SKILL.md`.

## Note on the AGP-9 flag

Despite its name, `android.usesSdkInManifest.disallowed` is `BooleanOption.DISALLOW_USES_SDK_IN_MANIFEST` and governs `<uses-sdk>` handling in `ProcessApplicationManifest`/`ProcessTestManifest` — **not** manifest versioning. Its real consumer here is `app/src/androidTest/AndroidManifest.xml`'s `<uses-sdk tools:overrideLibrary="...ub_uiautomator, ...screengrab"/>`. I confirmed via `assembleAndroidDebugAndroidTest` that the androidTest manifest still merges without the flag, so removing it is safe.

## Behavior change to be aware of

`promote.yml` now fails loudly if `version.properties` is absent at the checked-out RC tag (no manifest fallback, by choice). Practical effect: **pre-release tags cut before this PR can no longer be promoted by the workflow.** The next release must be cut from a commit that already has `version.properties`.

Separately, F-Droid builds from the `vX.Y.Z` tag using a recipe in upstream `fdroiddata` (not in this repo). If that recipe scrapes the manifest for a version, it may need an upstream update — flagging it rather than treating it as a blocker.

## Verification

- `assembleDebug` + `assembleRelease` produce all four expected names: `app-{android,amazon}-{debug,release}-v3.8.4.apk`
- Merged manifest still carries `versionCode="41"` / `versionName="3.8.4"`; `BuildConfig.VERSION_CODE`/`VERSION_NAME` unchanged (used by `MainActivity:215`)
- Temporarily set the file to `9.9.9`/`99` and rebuilt: the configuration cache invalidated and the new values flowed through to the merged manifest and APK names — then reverted
- `testAndroidDebugUnitTest`, `lintAndroidDebug`, `assembleAndroidDebugAndroidTest` all green
- No obsolete `applicationVariants` warning remains
- markdownlint-cli2: 0 issues across 41 files; all three workflow YAMLs parse; all three extractors yield `3.8.4` / `41`
- `fastlane/Fastfile:112`'s `app-android-debug-v*.apk` glob resolves (fastlane itself isn't installed in this environment, so the Fastfile was verified by checking its actual dependency rather than by running `fastlane lanes`)

## Follow-up

Tracking issue #442 opened for retiring the remaining AGP-9 opt-out flags one at a time.